### PR TITLE
Fix issue error in minimal privileged account in AliCloud

### DIFF
--- a/pkg/controller/provider/alicloud/handler.go
+++ b/pkg/controller/provider/alicloud/handler.go
@@ -18,6 +18,7 @@ package alicloud
 
 import (
 	"fmt"
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/alidns"
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/external-dns-management/pkg/dns"
@@ -88,6 +89,11 @@ func (this *Handler) GetZones() (provider.DNSHostedZones, error) {
 			}
 			err := this.access.ListRecords(z.DomainName, f)
 			if err != nil {
+				if checkAccessForbiddern(err) {
+					// It is reasonable for some RAM user, it is only allowed to access certain domain's records detail
+					// As a result, this domain should not appended to the host zones
+					continue
+				}
 				return nil, err
 			}
 			hostedZone := provider.NewDNSHostedZone(
@@ -127,4 +133,18 @@ func (this *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNS
 		return nil
 	}
 	return exec.submitChanges()
+}
+
+func checkAccessForbiddern(err error) bool {
+	if err != nil {
+		switch err.(type) {
+		case *errors.ServerError:
+			serverErr := err.(*errors.ServerError)
+			if serverErr.ErrorCode() == "Forbidden.RAM" {
+				return true
+			}
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
In AliCloud, we provide access to list all domains. But for security reason, we do not provide an account with  DescribeDomainRecords for all domains. So we do not need to list all zones.