### PR TITLE
Upgrade golang to 1.12.7

### DIFF
--- a/.ci/check
+++ b/.ci/check
@@ -41,7 +41,7 @@ ignore=(
 )
 
 # Install Golint (linting tool).
-go get -u github.com/golang/lint/golint
+go get -u golang.org/x/lint/golint
 
 ###############################################################################
 

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -8,15 +8,15 @@ external-dns-management:
       component_descriptor: ~ 
     steps:
       check:
-        image: 'golang:1.12.4'
+        image: 'golang:1.12.7'
       test:
-        image: 'golang:1.12.4'
+        image: 'golang:1.12.7'
       integrationtest:
-        image: 'golang:1.12.4'
+        image: 'golang:1.12.7'
       #functionaltest:
-      #  image: 'golang:1.12.4'
+      #  image: 'golang:1.12.7'
       build:
-        image: 'golang:1.12.4'
+        image: 'golang:1.12.7'
   jobs:
     release:
       traits:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.8
+FROM golang:1.12.7
 WORKDIR /go/src/github.com/gardener/external-dns-management/
 RUN go get -u github.com/golang/dep/cmd/dep
 COPY . .


### PR DESCRIPTION
**What this PR does / why we need it**:
- Upgrade golang to 1.12.7 (prerequisite for go modules)
- `github.com/golang/lint/golint` is replaced by `golang.org/x/lint/golint`. See golang/lint#45

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Golang version is upgraded to 1.12.7.
```
