### PR TITLE
Source controller for DNS entries

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -189,7 +189,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b6ec5ecb0c53b8a5b66298628c5af4b7e4a2e8996bb440917825959db33a8a8f"
+  digest = "1:8717a4d1cd443d0381fddabffd099bb5ef689ce5ff7fbd0386d61f310a5b60f8"
   name = "github.com/gardener/controller-manager-library"
   packages = [
     "pkg/controllermanager",
@@ -213,7 +213,7 @@
     "pkg/utils",
   ]
   pruneopts = "NUT"
-  revision = "5a6c39478157eacf96a3f3d87fbe7ff33990629c"
+  revision = "549d47540c70756a9f0cfd93e4a625c64e4d03ef"
 
 [[projects]]
   digest = "1:260f7ebefc63024c8dfe2c9f1a2935a89fa4213637a1f522f592f80c001cc441"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -189,7 +189,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:8717a4d1cd443d0381fddabffd099bb5ef689ce5ff7fbd0386d61f310a5b60f8"
+  digest = "1:68724d60ca91e56564b7a12a57baffd253c2e64fd56cd2ed21fc28d327207c82"
   name = "github.com/gardener/controller-manager-library"
   packages = [
     "pkg/controllermanager",
@@ -213,7 +213,7 @@
     "pkg/utils",
   ]
   pruneopts = "NUT"
-  revision = "549d47540c70756a9f0cfd93e4a625c64e4d03ef"
+  revision = "b2516476e46a4c1ae55a35250320611f5ca4084b"
 
 [[projects]]
   digest = "1:260f7ebefc63024c8dfe2c9f1a2935a89fa4213637a1f522f592f80c001cc441"

--- a/cmd/dns/main.go
+++ b/cmd/dns/main.go
@@ -34,6 +34,7 @@ import (
 	_ "github.com/gardener/external-dns-management/pkg/controller/provider/google/controller"
 	_ "github.com/gardener/external-dns-management/pkg/controller/provider/openstack/controller"
 
+	_ "github.com/gardener/external-dns-management/pkg/controller/source/dnsentry"
 	_ "github.com/gardener/external-dns-management/pkg/controller/source/ingress"
 	_ "github.com/gardener/external-dns-management/pkg/controller/source/service"
 

--- a/examples/owner.yaml
+++ b/examples/owner.yaml
@@ -1,0 +1,8 @@
+apiVersion: dns.gardener.cloud/v1alpha1
+kind: DNSOwner
+metadata:
+  name: second-owner
+  namespace: default
+spec:
+  ownerId: second-owner-id
+  active: true

--- a/pkg/controller/source/dnsentry/controller.go
+++ b/pkg/controller/source/dnsentry/controller.go
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *
+ */
+
+package dnsentry
+
+import (
+	"github.com/gardener/controller-manager-library/pkg/resources"
+	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/gardener/external-dns-management/pkg/dns/source"
+)
+
+var _MAIN_RESOURCE = resources.NewGroupKind(api.GroupName, api.DNSEntryKind)
+
+func init() {
+	source.DNSSourceController(source.NewDNSSouceTypeForCreator("dnsentry-source", _MAIN_RESOURCE, NewDNSEntrySource), nil).
+		FinalizerDomain("dns.gardener.cloud").
+		MustRegister(source.CONTROLLER_GROUP_DNS_SOURCES)
+}

--- a/pkg/controller/source/dnsentry/handler.go
+++ b/pkg/controller/source/dnsentry/handler.go
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *
+ */
+
+package dnsentry
+
+import (
+	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
+	"github.com/gardener/controller-manager-library/pkg/logger"
+	"github.com/gardener/controller-manager-library/pkg/resources"
+	"github.com/gardener/controller-manager-library/pkg/utils"
+	"github.com/gardener/external-dns-management/pkg/dns/source"
+
+	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+)
+
+type DNSEntrySource struct {
+	source.DefaultDNSSource
+	resources resources.Resources
+}
+
+type updateOriginalFeedback struct {
+	logger     logger.LogContext
+	resources  resources.Resources
+	objectName resources.ObjectName
+}
+
+func NewDNSEntrySource(c controller.Interface) (source.DNSSource, error) {
+	return &DNSEntrySource{resources: c.GetMainCluster().Resources()}, nil
+}
+
+var sourceProviderType = "source"
+
+func (this *DNSEntrySource) GetDNSInfo(logger logger.LogContext, obj resources.Object, current *source.DNSCurrentState) (*source.DNSInfo, error) {
+	data := obj.Data().(*api.DNSEntry)
+
+	info := &source.DNSInfo{
+		Names:    utils.NewStringSet(data.Spec.DNSName),
+		Targets:  utils.NewStringSetByArray(data.Spec.Targets),
+		TTL:      data.Spec.TTL,
+		Interval: data.Spec.CNameLookupInterval,
+		Feedback: &updateOriginalFeedback{logger: logger, resources: this.resources, objectName: obj.ClusterKey().ObjectName()},
+	}
+	return info, nil
+}
+
+func (f *updateOriginalFeedback) Succeeded() {
+}
+
+func (f *updateOriginalFeedback) Pending(dnsname string, msg string) {
+	f.setStatus("Pending", msg)
+
+}
+
+func (f *updateOriginalFeedback) Ready(dnsname string, msg string) {
+	f.setStatus("Ready", msg)
+}
+
+func (f *updateOriginalFeedback) Invalid(dnsname string, err error) {
+	f.setStatus("Invalid", err.Error())
+}
+
+func (f *updateOriginalFeedback) Failed(dnsname string, err error) {
+	f.setStatus("Failed", err.Error())
+}
+
+func (f *updateOriginalFeedback) setStatus(state string, msg string) {
+	obj, err := f.resources.GetObjectInto(f.objectName, &api.DNSEntry{})
+	if err != nil {
+		logger.Warn("Cannot get object %v: %s", f.objectName, err)
+		return
+	}
+	data := obj.Data().(*api.DNSEntry)
+	if msg != "" {
+		data.Status.Message = &msg
+	} else {
+		data.Status.Message = nil
+	}
+	data.Status.State = state
+	data.Status.ProviderType = &sourceProviderType
+	err = obj.UpdateStatus()
+	if err != nil {
+		logger.Warn("Cannot update status for object %v: %s", f.objectName, err)
+	}
+}

--- a/pkg/controller/source/service/handler.go
+++ b/pkg/controller/source/service/handler.go
@@ -29,10 +29,10 @@ import (
 // FakeTargetIP provides target for testing without load balancer
 var FakeTargetIP *string
 
-func GetTargets(logger logger.LogContext, obj resources.Object, current *source.DNSCurrentState) (utils.StringSet, error) {
+func GetTargets(logger logger.LogContext, obj resources.Object, current *source.DNSCurrentState) (utils.StringSet, utils.StringSet, error) {
 	svc := obj.Data().(*api.Service)
 	if svc.Spec.Type != api.ServiceTypeLoadBalancer {
-		return nil, fmt.Errorf("service is not of type LoadBalancer")
+		return nil, nil, fmt.Errorf("service is not of type LoadBalancer")
 	}
 	set := utils.StringSet{}
 	for _, i := range svc.Status.LoadBalancer.Ingress {
@@ -47,5 +47,5 @@ func GetTargets(logger logger.LogContext, obj resources.Object, current *source.
 	if FakeTargetIP != nil {
 		set.Add(*FakeTargetIP)
 	}
-	return set, nil
+	return set, nil, nil
 }

--- a/pkg/dns/provider/state.go
+++ b/pkg/dns/provider/state.go
@@ -18,6 +18,7 @@ package provider
 
 import (
 	"fmt"
+	"github.com/gardener/controller-manager-library/pkg/resources/access"
 	"strings"
 	"sync"
 	"time"
@@ -267,7 +268,7 @@ func (this *state) lookupProvider(e *dnsutils.DNSEntryObject) (DNSProvider, erro
 			n := p.Match(e.GetDNSName())
 			if n > 0 {
 				if match < n {
-					err = CheckAccess(e, p.Object())
+					err = access.CheckAccess(e, p.Object())
 					if err == nil {
 						found = p
 						match = n

--- a/pkg/dns/provider/utils.go
+++ b/pkg/dns/provider/utils.go
@@ -19,8 +19,6 @@ package provider
 import (
 	"fmt"
 
-	"github.com/gardener/controller-manager-library/pkg/resources"
-	"github.com/gardener/controller-manager-library/pkg/resources/access"
 	dnsutils "github.com/gardener/external-dns-management/pkg/dns/utils"
 
 	"github.com/gardener/controller-manager-library/pkg/utils"
@@ -61,35 +59,6 @@ func copyZones(src map[string]*dnsHostedZone) dnsHostedZones {
 		dst[k] = v
 	}
 	return dst
-}
-
-func CheckAccess(object resources.Object, used resources.Object) error {
-	var err error
-
-	owners := object.GetOwners()
-	if len(owners) > 0 {
-		for o := range owners {
-			ok, msg, aerr := access.Allowed(o, "use", used.ClusterKey())
-			if !ok {
-				if aerr != nil {
-					err = fmt.Errorf("%s: %s: %s", o, msg, err)
-				} else {
-					err = fmt.Errorf("%s: %s", o, msg)
-				}
-			}
-		}
-	} else {
-		o := object.ClusterKey()
-		ok, msg, aerr := access.Allowed(o, "use", used.ClusterKey())
-		if !ok {
-			if aerr != nil {
-				err = fmt.Errorf("%s: %s: %s", used.ClusterKey(), msg, err)
-			} else {
-				err = fmt.Errorf("%s: %s", used.ClusterKey(), msg)
-			}
-		}
-	}
-	return err
 }
 
 func errorValue(format string, err error) string {

--- a/pkg/dns/source/controller.go
+++ b/pkg/dns/source/controller.go
@@ -38,11 +38,15 @@ const PERIOD_ANNOTATION = "dns.gardener.cloud/cname-lookup-interval"
 const CLASS_ANNOTATION = utils.CLASS_ANNOTATION
 
 const OPT_CLASS = "dns-class"
-const OPT_TARGETCLASS = "dns-target-class"
+const OPT_TARGET_CLASS = "dns-target-class"
 const OPT_EXCLUDE = "exclude-domains"
 const OPT_KEY = "key"
 const OPT_NAMESPACE = "target-namespace"
 const OPT_NAMEPREFIX = "target-name-prefix"
+const OPT_TARGET_CREATOR_LABEL_NAME = "target-creator-label-name"
+const OPT_TARGET_CREATOR_LABEL_VALUE = "target-creator-label-value"
+const OPT_TARGET_OWNER_ID = "target-owner-id"
+const OPT_TARGET_SET_IGNORE_OWNERS = "target-set-ignore-owners"
 
 var ENTRY = resources.NewGroupKind(api.GroupName, api.DNSEntryKind)
 
@@ -53,12 +57,16 @@ func init() {
 func DNSSourceController(source DNSSourceType, reconcilerType controller.ReconcilerType) controller.Configuration {
 	gk := source.GroupKind()
 	return controller.Configure(source.Name()).
-		DefaultedStringOption(OPT_CLASS, utils.DEFAULT_CLASS, "Identifier used to differentiate responsible controllers for entries").
-		StringOption(OPT_TARGETCLASS, "Identifier used to differentiate responsible dns controllers for target entries").
+		DefaultedStringOption(OPT_CLASS, utils.DEFAULT_CLASS, "identifier used to differentiate responsible controllers for entries").
+		StringOption(OPT_TARGET_CLASS, "identifier used to differentiate responsible dns controllers for target entries").
 		StringArrayOption(OPT_EXCLUDE, "excluded domains").
 		StringOption(OPT_KEY, "selecting key for annotation").
 		DefaultedStringOption(OPT_NAMESPACE, "", "target namespace for cross cluster generation").
 		DefaultedStringOption(OPT_NAMEPREFIX, "", "name prefix in target namespace for cross cluster generation").
+		DefaultedStringOption(OPT_TARGET_CREATOR_LABEL_NAME, "creator", "label name to store the creator for generated DNS entries").
+		StringOption(OPT_TARGET_CREATOR_LABEL_VALUE, "label value for creator label").
+		StringOption(OPT_TARGET_OWNER_ID, "owner id to use for generated DNS entries").
+		BoolOption(OPT_TARGET_SET_IGNORE_OWNERS, "mark generated DNS entries to omit owner based access control").
 		FinalizerDomain(api.GroupName).
 		Reconciler(SourceReconciler(source, reconcilerType)).
 		Cluster(cluster.DEFAULT). // first one used as MAIN cluster

--- a/pkg/dns/source/defaults.go
+++ b/pkg/dns/source/defaults.go
@@ -43,28 +43,28 @@ func NewEventFeedback(logger logger.LogContext, obj resources.Object, events map
 	return &EventFeedback{logger, obj, events}
 }
 
-func (this *EventFeedback) Ready(dnsname, msg string) {
+func (this *EventFeedback) Ready(dnsname, msg string, state *DNSState) {
 	if msg == "" {
 		msg = fmt.Sprintf("dns entry is ready")
 	}
 	this.event(dnsname, msg)
 }
 
-func (this *EventFeedback) Pending(dnsname, msg string) {
+func (this *EventFeedback) Pending(dnsname, msg string, state *DNSState) {
 	if msg == "" {
 		msg = fmt.Sprintf("dns entry is pending")
 	}
 	this.event(dnsname, msg)
 }
 
-func (this *EventFeedback) Failed(dnsname string, err error) {
+func (this *EventFeedback) Failed(dnsname string, err error, state *DNSState) {
 	if err == nil {
 		err = fmt.Errorf("dns entry is errornous")
 	}
 	this.event(dnsname, err.Error())
 }
 
-func (this *EventFeedback) Invalid(dnsname string, msg error) {
+func (this *EventFeedback) Invalid(dnsname string, msg error, state *DNSState) {
 	if msg == nil {
 		msg = fmt.Errorf("dns entry is invalid")
 	}
@@ -143,8 +143,9 @@ func (this *DefaultDNSSource) GetDNSInfo(logger logger.LogContext, obj resources
 	events := this.GetEvents(obj.ClusterKey())
 	info := &DNSInfo{Feedback: NewEventFeedback(logger, obj, events)}
 	info.Names = current.AnnotatedNames
-	tgts, err := this.handler(logger, obj, current)
+	tgts, txts, err := this.handler(logger, obj, current)
 	info.Targets = tgts
+	info.Text = txts
 	return info, err
 }
 

--- a/pkg/dns/source/dnsinfo.go
+++ b/pkg/dns/source/dnsinfo.go
@@ -67,6 +67,9 @@ func (this *sourceReconciler) getDNSInfo(logger logger.LogContext, obj resources
 	if err != nil {
 		return info, err
 	}
+	if info == nil {
+		return nil, nil
+	}
 	if info.TTL == nil {
 		a := obj.GetAnnotations()[TTL_ANNOTATION]
 		if a != "" {

--- a/vendor/github.com/gardener/controller-manager-library/pkg/resources/utils.go
+++ b/vendor/github.com/gardener/controller-manager-library/pkg/resources/utils.go
@@ -47,6 +47,15 @@ func RemoveAnnotation(o ObjectData, key string) bool {
 	return false
 }
 
+func GetAnnotation(o ObjectData, key string) (string, bool) {
+	annos := o.GetAnnotations()
+	if annos == nil {
+		return "", false
+	}
+	value, ok := annos[key]
+	return value, ok
+}
+
 func SetOwnerReference(o ObjectData, ref *metav1.OwnerReference) bool {
 	refs := o.GetOwnerReferences()
 	for _, r := range refs {
@@ -76,15 +85,15 @@ func FilterKeysByGroupKinds(keys ClusterObjectKeySet, kinds ...schema.GroupKind)
 	if len(kinds) == 0 {
 		return keys.Copy()
 	}
-	new := ClusterObjectKeySet{}
+	set := ClusterObjectKeySet{}
 outer:
 	for k := range keys {
 		for _, g := range kinds {
 			if k.GroupKind() == g {
-				new.Add(k)
+				set.Add(k)
 				continue outer
 			}
 		}
 	}
-	return new
+	return set
 }

--- a/vendor/github.com/gardener/controller-manager-library/pkg/resources/utils.go
+++ b/vendor/github.com/gardener/controller-manager-library/pkg/resources/utils.go
@@ -56,6 +56,45 @@ func GetAnnotation(o ObjectData, key string) (string, bool) {
 	return value, ok
 }
 
+///////////////
+
+func SetLabel(o ObjectData, key, value string) bool {
+	labels := o.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	old, ok := labels[key]
+	if !ok || old != value {
+		labels[key] = value
+		o.SetLabels(labels)
+		return true
+	}
+	return false
+}
+
+func RemoveLabel(o ObjectData, key string) bool {
+	labels := o.GetLabels()
+	if labels != nil {
+		if _, ok := labels[key]; ok {
+			delete(labels, key)
+			o.SetLabels(labels)
+			return true
+		}
+	}
+	return false
+}
+
+func GetLabel(o ObjectData, key string) (string, bool) {
+	labels := o.GetLabels()
+	if labels == nil {
+		return "", false
+	}
+	value, ok := labels[key]
+	return value, ok
+}
+
+//////////////
+
 func SetOwnerReference(o ObjectData, ref *metav1.OwnerReference) bool {
 	refs := o.GetOwnerReferences()
 	for _, r := range refs {


### PR DESCRIPTION
**What this PR does / why we need it**:
source controller for DNS entries

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
Source controller for DNS entries has been added to forward DNS entries to a target cluster.
This allows to delegate management of the DNS backend to another cluster.
```

```improvement operator
New flags --target-creator-label-name, --target-creator-label-value, --target-owner-id, --target-set-ignore-owners to annotate/label multiple source clusters
```
