### PR TITLE
Adding private zone flag to DNSHostedZone.

### DIFF
--- a/pkg/controller/provider/alicloud/handler.go
+++ b/pkg/controller/provider/alicloud/handler.go
@@ -108,9 +108,7 @@ func (h *Handler) getZones(cache provider.ZoneCache) (provider.DNSHostedZones, e
 				}
 				return nil, err
 			}
-			hostedZone := provider.NewDNSHostedZone(
-				h.ProviderType(), z.DomainId,
-				z.DomainName, z.DomainName, forwarded)
+			hostedZone := provider.NewDNSHostedZone(h.ProviderType(), z.DomainId, z.DomainName, z.DomainName, forwarded, false)
 			zones = append(zones, hostedZone)
 		}
 	}

--- a/pkg/controller/provider/aws/handler.go
+++ b/pkg/controller/provider/aws/handler.go
@@ -132,8 +132,11 @@ func (h *Handler) getZones(cache provider.ZoneCache) (provider.DNSHostedZones, e
 		domain := aws.StringValue(z.Name)
 		comp := strings.Split(aws.StringValue(z.Id), "/")
 		id := comp[len(comp)-1]
-		hostedZone := provider.NewDNSHostedZone(h.ProviderType(),
-			id, dns.NormalizeHostname(domain), aws.StringValue(z.Id), []string{})
+		var isPrivateZone bool
+		if z.Config.PrivateZone != nil && *z.Config.PrivateZone {
+			isPrivateZone = true
+		}
+		hostedZone := provider.NewDNSHostedZone(h.ProviderType(), id, dns.NormalizeHostname(domain), aws.StringValue(z.Id), []string{}, isPrivateZone)
 
 		// call GetZoneState for side effect to calculate forwarded domains
 		_, err := cache.GetZoneState(hostedZone)

--- a/pkg/controller/provider/azure/handler.go
+++ b/pkg/controller/provider/azure/handler.go
@@ -129,13 +129,7 @@ func (h *Handler) getZones(cache provider.ZoneCache) (provider.DNSHostedZones, e
 		forwarded := h.collectForwardedSubzones(resourceGroup, *item.Name)
 
 		// ResourceGroup needed for requests to Azure. Remember by adding to Id. Split by calling splitZoneid().
-		hostedZone := provider.NewDNSHostedZone(
-			h.ProviderType(),
-			resourceGroup+"/"+*item.Name,
-			dns.NormalizeHostname(*item.Name),
-			"",
-			forwarded,
-		)
+		hostedZone := provider.NewDNSHostedZone(h.ProviderType(), resourceGroup+"/"+*item.Name, dns.NormalizeHostname(*item.Name), "", forwarded, false)
 
 		zones = append(zones, hostedZone)
 	}

--- a/pkg/controller/provider/google/handler.go
+++ b/pkg/controller/provider/google/handler.go
@@ -115,8 +115,7 @@ func (h *Handler) getZones(cache provider.ZoneCache) (provider.DNSHostedZones, e
 
 	zones := provider.DNSHostedZones{}
 	for _, z := range raw {
-		hostedZone := provider.NewDNSHostedZone(h.ProviderType(),
-			z.Name, dns.NormalizeHostname(z.DnsName), "", []string{})
+		hostedZone := provider.NewDNSHostedZone(h.ProviderType(), z.Name, dns.NormalizeHostname(z.DnsName), "", []string{}, false)
 
 		// call GetZoneState for side effect to calculate forwarded domains
 		_, err := cache.GetZoneState(hostedZone)

--- a/pkg/controller/provider/mock/handler.go
+++ b/pkg/controller/provider/mock/handler.go
@@ -57,13 +57,7 @@ func NewHandler(config *provider.DNSHandlerConfig) (provider.DNSHandler, error) 
 	for _, dnsName := range mockConfig.Zones {
 		if dnsName != "" {
 			logger.Infof("Providing mock DNSZone %s", dnsName)
-			hostedZone := provider.NewDNSHostedZone(
-				h.ProviderType(),
-				dnsName,
-				dnsName,
-				"",
-				[]string{},
-			)
+			hostedZone := provider.NewDNSHostedZone(h.ProviderType(), dnsName, dnsName, "", []string{}, false)
 			mock.AddZone(hostedZone)
 		}
 	}

--- a/pkg/controller/provider/openstack/handler.go
+++ b/pkg/controller/provider/openstack/handler.go
@@ -108,13 +108,7 @@ func (h *Handler) getZones(cache provider.ZoneCache) (provider.DNSHostedZones, e
 	zoneHandler := func(zone *zones.Zone) error {
 		forwarded := h.collectForwardedSubzones(zone)
 
-		hostedZone := provider.NewDNSHostedZone(
-			h.ProviderType(),
-			zone.ID,
-			dns.NormalizeHostname(zone.Name),
-			"",
-			forwarded,
-		)
+		hostedZone := provider.NewDNSHostedZone(h.ProviderType(), zone.ID, dns.NormalizeHostname(zone.Name), "", forwarded, false)
 		hostedZones = append(hostedZones, hostedZone)
 		return nil
 	}

--- a/pkg/controller/provider/openstack/handler_test.go
+++ b/pkg/controller/provider/openstack/handler_test.go
@@ -67,6 +67,10 @@ func (tz *testzone) ForwardedDomains() []string {
 	return []string{} // not implemented
 }
 
+func (tz *testzone) IsPrivate() bool {
+	return false
+}
+
 type designateMockClient struct {
 	tzmap map[string]*testzone
 }

--- a/pkg/dns/provider/default.go
+++ b/pkg/dns/provider/default.go
@@ -44,6 +44,7 @@ type DefaultDNSHostedZone struct {
 	domain       string   // base domain for zone
 	forwarded    []string // forwarded sub domains
 	key          string   // internal key used by provider (not used by this lib)
+	isPrivate    bool     // indicates a private zone
 }
 
 func (this *DefaultDNSHostedZone) Key() string {
@@ -69,11 +70,15 @@ func (this *DefaultDNSHostedZone) ForwardedDomains() []string {
 	return this.forwarded
 }
 
-func NewDNSHostedZone(ptype string, id, domain, key string, forwarded []string) DNSHostedZone {
-	return &DefaultDNSHostedZone{providerType: ptype, id: id, key: key, domain: domain, forwarded: forwarded}
+func (this *DefaultDNSHostedZone) IsPrivate() bool {
+	return this.isPrivate
+}
+
+func NewDNSHostedZone(ptype string, id, domain, key string, forwarded []string, isPrivate bool) DNSHostedZone {
+	return &DefaultDNSHostedZone{providerType: ptype, id: id, key: key, domain: domain, forwarded: forwarded, isPrivate: isPrivate}
 }
 
 func CopyDNSHostedZone(zone DNSHostedZone, forwardedDomains []string) DNSHostedZone {
 	return &DefaultDNSHostedZone{providerType: zone.ProviderType(), id: zone.Id(), key: zone.Key(),
-		domain: zone.Domain(), forwarded: forwardedDomains}
+		domain: zone.Domain(), forwarded: forwardedDomains, isPrivate: zone.IsPrivate()}
 }

--- a/pkg/dns/provider/interface.go
+++ b/pkg/dns/provider/interface.go
@@ -110,6 +110,7 @@ type DNSHostedZone interface {
 	Id() string
 	Domain() string
 	ForwardedDomains() []string
+	IsPrivate() bool
 }
 
 type DNSHostedZones []DNSHostedZone

--- a/pkg/dns/provider/zonecache.go
+++ b/pkg/dns/provider/zonecache.go
@@ -317,10 +317,11 @@ type PersistentZone struct {
 	Id               string   `json:"id"`
 	Domain           string   `json:"domain"`
 	ForwardedDomains []string `json:"forwardedDomains"`
+	IsPrivate        bool     `json:"isPrivate"`
 }
 
 func (z *PersistentZone) ToDNSHostedZone() DNSHostedZone {
-	return NewDNSHostedZone(z.ProviderType, z.Id, z.Domain, z.Key, z.ForwardedDomains)
+	return NewDNSHostedZone(z.ProviderType, z.Id, z.Domain, z.Key, z.ForwardedDomains, z.IsPrivate)
 }
 
 func NewPersistentZone(zone DNSHostedZone) *PersistentZone {
@@ -330,6 +331,7 @@ func NewPersistentZone(zone DNSHostedZone) *PersistentZone {
 		Key:              zone.Key(),
 		Domain:           zone.Domain(),
 		ForwardedDomains: zone.ForwardedDomains(),
+		IsPrivate:        zone.IsPrivate(),
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

AWS Route53 supports private zones. Consumers of this project as a library then can use that information from the DNSHostedZone.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
