### PR TITLE
dealing with owner conflict caused by stale cache from external changes

### DIFF
--- a/pkg/controller/provider/alicloud/handler.go
+++ b/pkg/controller/provider/alicloud/handler.go
@@ -135,6 +135,10 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, cache provider.ZoneC
 	return state, nil
 }
 
+func (h *Handler) ReportZoneStateConflict(zone provider.DNSHostedZone, err error) bool {
+	return h.cache.ReportZoneStateConflict(zone, err)
+}
+
 func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
 	err := h.executeRequests(logger, zone, state, reqs)
 	h.cache.ApplyRequests(err, zone, reqs)

--- a/pkg/controller/provider/aws/handler.go
+++ b/pkg/controller/provider/aws/handler.go
@@ -223,6 +223,10 @@ func (h *Handler) handleRecordSets(zone provider.DNSHostedZone, f func(rs *route
 	return forwarded, err
 }
 
+func (h *Handler) ReportZoneStateConflict(zone provider.DNSHostedZone, err error) bool {
+	return h.cache.ReportZoneStateConflict(zone, err)
+}
+
 func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
 	err := h.executeRequests(logger, zone, state, reqs)
 	h.cache.ApplyRequests(err, zone, reqs)

--- a/pkg/controller/provider/azure/handler.go
+++ b/pkg/controller/provider/azure/handler.go
@@ -215,6 +215,10 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, cache provider.ZoneC
 	return provider.NewDNSZoneState(dnssets), nil
 }
 
+func (h *Handler) ReportZoneStateConflict(zone provider.DNSHostedZone, err error) bool {
+	return h.cache.ReportZoneStateConflict(zone, err)
+}
+
 func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
 	err := h.executeRequests(logger, zone, state, reqs)
 	h.cache.ApplyRequests(err, zone, reqs)

--- a/pkg/controller/provider/google/handler.go
+++ b/pkg/controller/provider/google/handler.go
@@ -179,6 +179,10 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, cache provider.ZoneC
 	return provider.NewDNSZoneState(dnssets), nil
 }
 
+func (h *Handler) ReportZoneStateConflict(zone provider.DNSHostedZone, err error) bool {
+	return h.cache.ReportZoneStateConflict(zone, err)
+}
+
 func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
 	err := h.executeRequests(logger, zone, state, reqs)
 	h.cache.ApplyRequests(err, zone, reqs)

--- a/pkg/controller/provider/mock/handler.go
+++ b/pkg/controller/provider/mock/handler.go
@@ -91,6 +91,10 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, cache provider.ZoneC
 	return h.mock.CloneZoneState(zone)
 }
 
+func (h *Handler) ReportZoneStateConflict(zone provider.DNSHostedZone, err error) bool {
+	return h.cache.ReportZoneStateConflict(zone, err)
+}
+
 func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
 	err := h.executeRequests(logger, zone, state, reqs)
 	h.cache.ApplyRequests(err, zone, reqs)

--- a/pkg/controller/provider/openstack/handler.go
+++ b/pkg/controller/provider/openstack/handler.go
@@ -188,6 +188,10 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, cache provider.ZoneC
 	return provider.NewDNSZoneState(dnssets), nil
 }
 
+func (h *Handler) ReportZoneStateConflict(zone provider.DNSHostedZone, err error) bool {
+	return h.cache.ReportZoneStateConflict(zone, err)
+}
+
 // ExecuteRequests applies a given change request to a given hosted zone.
 func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
 	err := h.executeRequests(logger, zone, state, reqs)

--- a/pkg/dns/provider/entry.go
+++ b/pkg/dns/provider/entry.go
@@ -523,6 +523,7 @@ func lookupHostIPv4(hostname string) ([]string, error) {
 type Entry struct {
 	lock       sync.Mutex
 	key        string
+	createdAt  time.Time
 	modified   bool
 	activezone string
 	state      *state
@@ -536,6 +537,7 @@ func NewEntry(v *EntryVersion, state *state) *Entry {
 		EntryVersion: v,
 		state:        state,
 		modified:     true,
+		createdAt:    time.Now(),
 		activezone:   utils.StringValue(v.status.Zone),
 	}
 }
@@ -554,6 +556,10 @@ func (this *Entry) IsActive() bool {
 
 func (this *Entry) IsModified() bool {
 	return this.modified
+}
+
+func (this *Entry) CreatedAt() time.Time {
+	return this.createdAt
 }
 
 func (this *Entry) Update(logger logger.LogContext, new *EntryVersion) *Entry {

--- a/pkg/dns/provider/errors/errors.go
+++ b/pkg/dns/provider/errors/errors.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *
+ */
+
+package errors
+
+import (
+	"fmt"
+	"github.com/gardener/controller-manager-library/pkg/resources"
+	"time"
+)
+
+type AlreadyBusyForEntry struct {
+	DNSName    string
+	ObjectName resources.ObjectName
+}
+
+func (e *AlreadyBusyForEntry) Error() string {
+	return fmt.Sprintf("DNS name %q already busy for %q", e.DNSName, e.ObjectName)
+}
+
+type AlreadyBusyForOwner struct {
+	DNSName        string
+	EntryCreatedAt time.Time
+	Owner          string
+	Retry          bool
+}
+
+func (e *AlreadyBusyForOwner) Error() string {
+	return fmt.Sprintf("DNS name %q already busy for owner %q", e.DNSName, e.Owner)
+}

--- a/pkg/dns/provider/interface.go
+++ b/pkg/dns/provider/interface.go
@@ -167,6 +167,7 @@ type DNSHandler interface {
 	ProviderType() string
 	GetZones() (DNSHostedZones, error)
 	GetZoneState(DNSHostedZone) (DNSZoneState, error)
+	ReportZoneStateConflict(zone DNSHostedZone, err error) bool
 	ExecuteRequests(logger logger.LogContext, zone DNSHostedZone, state DNSZoneState, reqs []*ChangeRequest) error
 	MapTarget(t Target) Target
 	Release()
@@ -213,6 +214,10 @@ type DNSProvider interface {
 
 	AccountHash() string
 	MapTarget(t Target) Target
+
+	// ReportZoneStateConflict is used to report a conflict because of stale data.
+	// It returns true if zone data will be updated and a retry may resolve the conflict
+	ReportZoneStateConflict(zone DNSHostedZone, err error) bool
 }
 
 type DoneHandler interface {

--- a/pkg/dns/provider/provider.go
+++ b/pkg/dns/provider/provider.go
@@ -90,6 +90,10 @@ func (this *DNSAccount) GetZoneState(zone DNSHostedZone) (DNSZoneState, error) {
 	return this.handler.GetZoneState(zone)
 }
 
+func (this *DNSAccount) ReportZoneStateConflict(zone DNSHostedZone, err error) bool {
+	return this.handler.ReportZoneStateConflict(zone, err)
+}
+
 func (this *DNSAccount) ExecuteRequests(logger logger.LogContext, zone DNSHostedZone, state DNSZoneState, reqs []*ChangeRequest) error {
 	return this.handler.ExecuteRequests(logger, zone, state, reqs)
 }
@@ -514,6 +518,10 @@ func (this *dnsProviderVersion) succeeded(logger logger.LogContext, modified boo
 
 func (this *dnsProviderVersion) GetZoneState(zone DNSHostedZone) (DNSZoneState, error) {
 	return this.account.GetZoneState(zone)
+}
+
+func (this *dnsProviderVersion) ReportZoneStateConflict(zone DNSHostedZone, err error) bool {
+	return this.account.ReportZoneStateConflict(zone, err)
 }
 
 func (this *dnsProviderVersion) ExecuteRequests(logger logger.LogContext, zone DNSHostedZone, state DNSZoneState, reqs []*ChangeRequest) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
If multiple dns-controller-manager operate on the same hosted zone and DNSEntries
are moved from one dns-controller-manager to another, the entries will be set to invalid
("already busy for owner ...") if the cache on the new dns-controller-manager still contains
stale data in the zone state cache. This is currently only resolved after the periodic cache refresh.
For example this can happen in Gardener if a shoot is deleted and immediately created on another seed.
With this PR, this situation is recognised and a cache refresh is initiated and the processing of the incoming DNSEntry is repeated.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
dealing with owner conflict caused by stale cache from external changes, e.g. for DNSEntries moved between two dns-controller-managers working on the same hosted zone.
```
