### PR TITLE
ca cert and client cert support for openstack designate

### DIFF
--- a/pkg/controller/provider/openstack/handler.go
+++ b/pkg/controller/provider/openstack/handler.go
@@ -87,9 +87,13 @@ func readAuthConfig(c *provider.DNSHandlerConfig) (*clientAuthConfig, error) {
 	projectID := c.GetProperty("OS_PROJECT_ID", "tenantID")
 	userDomainName := c.GetProperty("OS_USER_DOMAIN_NAME", "userDomainName")
 	userDomainID := c.GetProperty("OS_USER_DOMAIN_ID", "userDomainID")
-
 	// optional restriction to region
 	regionName := c.GetProperty("OS_REGION_NAME")
+	// optional CA Certificate for keystone
+	caCert := c.GetProperty("CACERT", "caCert")
+	// optional Client Certificate
+	clientCert := c.GetProperty("CLIENTCERT", "clientCert")
+	clientKey := c.GetProperty("CLIENTKEY", "clientKey")
 
 	authConfig := clientAuthConfig{
 		AuthInfo: clientconfig.AuthInfo{
@@ -104,6 +108,9 @@ func readAuthConfig(c *provider.DNSHandlerConfig) (*clientAuthConfig, error) {
 			UserDomainName: userDomainName,
 		},
 		RegionName: regionName,
+		CACert:     caCert,
+		ClientCert: clientCert,
+		ClientKey:  clientKey,
 	}
 
 	return &authConfig, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Support usage of explicit CA certificates and client certificates for designate

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
For openstack designate it is possible now to 
specify a CA certificate in the credentails. The key is CACERT.
Additionally a dedicated client certificate and key can used
for the https requests (CLIENTCERT/CLIENTKEY)
```
