### PR TITLE
dealing with hosted zone deleted in DNS server backend

### DIFF
--- a/pkg/controller/provider/aws/handler.go
+++ b/pkg/controller/provider/aws/handler.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/gardener/external-dns-management/pkg/dns/provider/errors"
 	"strings"
 
 	"github.com/gardener/controller-manager-library/pkg/logger"
@@ -192,6 +193,9 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, cache provider.ZoneC
 	}
 	forwarded, err := h.handleRecordSets(zone, aggr)
 	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NoSuchHostedZone" {
+			err = &errors.NoSuchHostedZone{ZoneId: zone.Id(), Err: err}
+		}
 		return nil, err
 	}
 

--- a/pkg/dns/provider/errors/errors.go
+++ b/pkg/dns/provider/errors/errors.go
@@ -40,3 +40,12 @@ type AlreadyBusyForOwner struct {
 func (e *AlreadyBusyForOwner) Error() string {
 	return fmt.Sprintf("DNS name %q already busy for owner %q", e.DNSName, e.Owner)
 }
+
+type NoSuchHostedZone struct {
+	ZoneId string
+	Err    error
+}
+
+func (e *NoSuchHostedZone) Error() string {
+	return fmt.Sprintf("No such hosted zone %s: %s", e.ZoneId, e.Err)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
If a hosted zone is deleted in the backend service of a DNS provider, the internal state is
not aware of this change. It will still be tried to reconcile the zone. And deleting the
DNSProvider resource fails during cleanup with "zone cleanup failed: NoSuchHostedZone...".
With this fix, reconciliation for the DNSProvider is triggered and deleting a DNSProvider works
again if the DNSHandler returns a NoSuchHostedZone error. The handler of aws-route53 has been
adapted accordingly.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
If a hosted zone is deleted in AWS Route53, related DNSProvider resources are now updated on 
reconciliation of the zone. Deleting such a DNSProvider also works now without restart
of the dns-controller-manager.
```
