### PR TITLE
avoid azure provider update race if credentials are invalid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/miekg/dns v1.1.14
 	github.com/onsi/ginkgo v1.10.1
 	github.com/onsi/gomega v1.7.0
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v0.9.3
 	github.com/spf13/cobra v0.0.6 // indirect
 	golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3

--- a/pkg/controller/provider/azure/handler.go
+++ b/pkg/controller/provider/azure/handler.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/gardener/controller-manager-library/pkg/logger"
+	"github.com/pkg/errors"
 
 	azure "github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2018-05-01/dns"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
@@ -71,7 +72,7 @@ func NewHandler(c *provider.DNSHandlerConfig) (provider.DNSHandler, error) {
 
 	authorizer, err := auth.NewClientCredentialsConfig(clientID, clientSecret, tenantID).Authorizer()
 	if err != nil {
-		return nil, fmt.Errorf("Creating Azure authorizer with client credentials failed: %s", err.Error())
+		return nil, errors.Wrap(err, "Creating Azure authorizer with client credentials failed")
 	}
 
 	zonesClient := azure.NewZonesClient(subscriptionID)
@@ -85,7 +86,7 @@ func NewHandler(c *provider.DNSHandlerConfig) (provider.DNSHandler, error) {
 	ctx := context.TODO()
 	_, err = zonesClient.List(ctx, &one)
 	if err != nil {
-		return nil, fmt.Errorf("Authentication test to Azure with client credentials failed. Please check secret for DNSProvider. Details: %s", err.Error())
+		return nil, errors.Wrap(err, "Authentication test to Azure with client credentials failed. Please check secret for DNSProvider.")
 	}
 
 	h.zonesClient = &zonesClient
@@ -114,7 +115,7 @@ func (h *Handler) getZones(cache provider.ZoneCache) (provider.DNSHostedZones, e
 	results, err := h.zonesClient.ListComplete(h.ctx, nil)
 	h.config.Metrics.AddRequests("ZonesClient_ListComplete", 1)
 	if err != nil {
-		return nil, fmt.Errorf("Listing DNS zones failed. Details: %s", err.Error())
+		return nil, errors.Wrap(err, "Listing DNS zones failed")
 	}
 
 	for ; results.NotDone(); results.Next() {
@@ -178,7 +179,7 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, cache provider.ZoneC
 	results, err := h.recordsClient.ListAllByDNSZoneComplete(h.ctx, resourceGroup, zoneName, nil, "")
 	h.config.Metrics.AddRequests("RecordSetsClient_ListAllByDNSZoneComplete", 1)
 	if err != nil {
-		return nil, fmt.Errorf("Listing DNS zones failed. Details: %s", err.Error())
+		return nil, errors.Wrapf(err, "Listing DNS zone state for zone %s failed", zoneName)
 	}
 
 	for ; results.NotDone(); results.Next() {

--- a/pkg/dns/provider/provider.go
+++ b/pkg/dns/provider/provider.go
@@ -25,8 +25,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gardener/external-dns-management/pkg/server/metrics"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gardener/external-dns-management/pkg/server/metrics"
 
 	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	dnsutils "github.com/gardener/external-dns-management/pkg/dns/utils"
@@ -315,7 +316,7 @@ func updateDNSProvider(logger logger.LogContext, state *state, provider *dnsutil
 
 	this.account, err = state.GetDNSAccount(logger, provider, props)
 	if err != nil {
-		return this, this.failed(logger, false, fmt.Errorf("%s", err), true)
+		return this, this.failed(logger, false, err, true)
 	}
 
 	this.def_include, this.def_exclude = prepareSelection(provider.DNSProvider().Spec.Domains)
@@ -462,7 +463,7 @@ func (this *dnsProviderVersion) MapTarget(t Target) Target {
 func (this *dnsProviderVersion) setError(modified bool, err error) error {
 	modified = this.object.SetSelection(utils.StringSet{}, utils.StringSet{}, &this.object.Status().Domains) || modified
 	modified = this.object.SetSelection(utils.StringSet{}, utils.StringSet{}, &this.object.Status().Zones) || modified
-	modified = this.object.SetState(api.STATE_ERROR, err.Error()) || modified
+	modified = this.object.SetStateWithError(api.STATE_ERROR, err) || modified
 	if modified {
 		return this.object.UpdateStatus()
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Azure DNS provider is updated indefinitely without rate limit if the credentials are wrong.
This is caused by time stamp & correlation id in the cause part of the error message which is written to the provider status and changes each time.
With this fix the status is only updated if the error changes without looking at the cause part.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
avoid azure provider update race if credentials are invalid
```
