### PR TITLE
Use MixedCaps for const naming

### DIFF
--- a/pkg/apis/dns/v1alpha1/state.go
+++ b/pkg/apis/dns/v1alpha1/state.go
@@ -16,9 +16,13 @@
 
 package v1alpha1
 
-const STATE_PENDING = "Pending"
-const STATE_ERROR = "Error"
-const STATE_INVALID = "Invalid"
-const STATE_STALE = "Stale"
-const STATE_READY = "Ready"
-const STATE_DELETING = "Deleting"
+// TODO: use string type aliases to express DNSEntryState and DNSProviderState.
+
+const (
+	StatePending  = "Pending"
+	StateError    = "Error"
+	StateInvalid  = "Invalid"
+	StateStale    = "Stale"
+	StateReady    = "Ready"
+	StateDeleting = "Deleting"
+)

--- a/pkg/controller/provider/cloudflare/state.go
+++ b/pkg/controller/provider/cloudflare/state.go
@@ -34,6 +34,6 @@ func (r *Record) GetValue() string {
 	}
 	return r.Content
 }
-func (r *Record) GetTTL() int       { return r.TTL }
-func (r *Record) SetTTL(ttl int)    { r.TTL = ttl }
-func (r *Record) Copy() raw.Record  { n := *r; return &n }
+func (r *Record) GetTTL() int      { return r.TTL }
+func (r *Record) SetTTL(ttl int)   { r.TTL = ttl }
+func (r *Record) Copy() raw.Record { n := *r; return &n }

--- a/pkg/dns/provider/changemodel.go
+++ b/pkg/dns/provider/changemodel.go
@@ -76,14 +76,14 @@ func (this *ChangeGroup) cleanup(logger logger.LogContext, model *ChangeModel) b
 					status := e.Object().Status()
 					msg := MSG_PRESERVED
 					trigger := false
-					if status.State == v1alpha1.STATE_ERROR || status.State == v1alpha1.STATE_INVALID {
+					if status.State == v1alpha1.StateError || status.State == v1alpha1.StateInvalid {
 						msg = msg + ": " + utils.StringValue(status.Message)
 						model.Infof("found stale set '%s': %s -> preserve unchanged", utils.StringValue(status.Message), s.Name)
 					} else {
 						model.Infof("found stale set '%s' -> preserve unchanged", s.Name)
 						trigger = true
 					}
-					upd, err := e.UpdateStatus(logger, v1alpha1.STATE_STALE, msg)
+					upd, err := e.UpdateStatus(logger, v1alpha1.StateStale, msg)
 					if trigger && (!upd || err != nil) {
 						e.Trigger(logger)
 					}

--- a/pkg/dns/provider/provider.go
+++ b/pkg/dns/provider/provider.go
@@ -462,7 +462,7 @@ func (this *dnsProviderVersion) MapTarget(t Target) Target {
 func (this *dnsProviderVersion) setError(modified bool, err error) error {
 	modified = this.object.SetSelection(utils.StringSet{}, utils.StringSet{}, &this.object.Status().Domains) || modified
 	modified = this.object.SetSelection(utils.StringSet{}, utils.StringSet{}, &this.object.Status().Zones) || modified
-	modified = this.object.SetState(api.STATE_ERROR, err.Error()) || modified
+	modified = this.object.SetState(api.StateError, err.Error()) || modified
 	if modified {
 		return this.object.UpdateStatus()
 	}
@@ -509,7 +509,7 @@ func (this *dnsProviderVersion) failedButRecheck(logger logger.LogContext, err e
 func (this *dnsProviderVersion) succeeded(logger logger.LogContext, modified bool) reconcile.Status {
 	status := &this.object.DNSProvider().Status
 	mod := resources.NewModificationState(this.object, modified)
-	mod.AssureStringValue(&status.State, api.STATE_READY)
+	mod.AssureStringValue(&status.State, api.StateReady)
 	mod.AssureStringPtrValue(&status.Message, "provider operational")
 	mod.AssureInt64Value(&status.ObservedGeneration, this.object.DNSProvider().Generation)
 	return reconcile.UpdateStatus(logger, mod.UpdateStatus())

--- a/pkg/dns/provider/state.go
+++ b/pkg/dns/provider/state.go
@@ -958,7 +958,7 @@ func (this *state) AddEntryVersion(logger logger.LogContext, v *EntryVersion, st
 					err := &perrs.AlreadyBusyForEntry{DNSName: dnsname, ObjectName: cur.ObjectName()}
 					logger.Warnf("%s", err)
 					if status.IsSucceeded() {
-						_, err := v.UpdateStatus(logger, api.STATE_ERROR, err.Error())
+						_, err := v.UpdateStatus(logger, api.StateError, err.Error())
 						if err != nil {
 							return new, reconcile.DelayOnError(logger, err)
 						}
@@ -973,10 +973,10 @@ func (this *state) AddEntryVersion(logger logger.LogContext, v *EntryVersion, st
 				}
 			}
 		}
-		if new.valid && new.status.State != api.STATE_READY && new.status.State != api.STATE_PENDING {
+		if new.valid && new.status.State != api.StateReady && new.status.State != api.StatePending {
 			msg := fmt.Sprintf("activating for %s", new.DNSName())
 			logger.Info(msg)
-			new.UpdateStatus(logger, api.STATE_PENDING, msg)
+			new.UpdateStatus(logger, api.StatePending, msg)
 		}
 		this.dnsnames[dnsname] = new
 	}

--- a/pkg/dns/provider/statusupdate.go
+++ b/pkg/dns/provider/statusupdate.go
@@ -45,7 +45,7 @@ func (this *StatusUpdate) SetInvalid(err error) {
 		this.done = true
 		this.modified = false
 		this.fhandler.RemoveFinalizer(this.Entry.object)
-		_, err := this.UpdateStatus(this.logger, api.STATE_INVALID, err.Error())
+		_, err := this.UpdateStatus(this.logger, api.StateInvalid, err.Error())
 		if err != nil {
 			this.logger.Errorf("cannot update: %s", err)
 		}
@@ -56,7 +56,7 @@ func (this *StatusUpdate) Failed(err error) {
 		this.done = true
 		this.modified = false
 		this.fhandler.RemoveFinalizer(this.Entry.Object())
-		_, err := this.UpdateStatus(this.logger, api.STATE_ERROR, err.Error())
+		_, err := this.UpdateStatus(this.logger, api.StateError, err.Error())
 		if err != nil {
 			this.logger.Errorf("cannot update: %s", err)
 		}
@@ -72,7 +72,7 @@ func (this *StatusUpdate) Succeeded() {
 		} else {
 			this.Entry.activezone = this.ZoneId()
 			this.fhandler.SetFinalizer(this.Entry.Object())
-			_, err := this.UpdateStatus(this.logger, api.STATE_READY, "dns entry active")
+			_, err := this.UpdateStatus(this.logger, api.StateReady, "dns entry active")
 			if err != nil {
 				this.logger.Errorf("cannot update: %s", err)
 			}

--- a/pkg/dns/source/reconciler.go
+++ b/pkg/dns/source/reconciler.go
@@ -248,10 +248,10 @@ outer:
 			s := found.Names[n]
 			if s != nil && !modified[n] {
 				switch s.State {
-				case api.STATE_ERROR:
-				case api.STATE_INVALID:
-				case api.STATE_PENDING:
-				case api.STATE_READY:
+				case api.StateError:
+				case api.StateInvalid:
+				case api.StatePending:
+				case api.StateReady:
 				default:
 					if s.CreationTimestamp.Time.Before(threshold) {
 						feedback.Pending(logger, n, "no dns controller running?", s)

--- a/pkg/dns/source/slaves.go
+++ b/pkg/dns/source/slaves.go
@@ -93,25 +93,25 @@ func (this *slaveReconciler) Reconcile(logger logger.LogContext, obj resources.O
 
 				logger.Infof("update event")
 				switch s.State {
-				case api.STATE_ERROR:
+				case api.StateError:
 					msg := fmt.Errorf("errornous dns entry")
 					if s.Message != nil {
 						msg = fmt.Errorf("%s: %s", msg, *s.Message)
 					}
 					fb.Failed(logger, n, msg, &stateCopy)
-				case api.STATE_INVALID:
+				case api.StateInvalid:
 					msg := fmt.Errorf("dns entry invalid")
 					if s.Message != nil {
 						msg = fmt.Errorf("%s: %s", msg, *s.Message)
 					}
 					fb.Invalid(logger, n, msg, &stateCopy)
-				case api.STATE_PENDING:
+				case api.StatePending:
 					msg := fmt.Sprintf("dns entry pending")
 					if s.Message != nil {
 						msg = fmt.Sprintf("%s: %s", msg, *s.Message)
 					}
 					fb.Pending(logger, n, msg, &stateCopy)
-				case api.STATE_READY:
+				case api.StateReady:
 					if stateCopy.Message == nil {
 						str := "dns entry ready"
 						stateCopy.Message = &str


### PR DESCRIPTION
**What this PR does / why we need it**:
Use MixedCaps for const naming as per convention.
See https://golang.org/doc/effective_go.html#mixed-caps

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
