### PR TITLE
updated AWS alias targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ tmp/
 /local/
 /local
 /dns-controller-manager
+/dns-controller-manager-compound
 /cmd/dns/dns-controller-manager
 /main
 /test/functional/tmp-*.yaml

--- a/pkg/controller/provider/aws/aliastarget.go
+++ b/pkg/controller/provider/aws/aliastarget.go
@@ -48,6 +48,8 @@ var (
 		"sa-east-1.elb.amazonaws.com":         "Z2P70J7HTTTPLU",
 		"cn-north-1.elb.amazonaws.com.cn":     "Z3BX2TMKNYI13Y",
 		"cn-northwest-1.elb.amazonaws.com.cn": "Z3BX2TMKNYI13Y",
+		"us-gov-west-1.amazonaws.com":         "Z1K6XKP9SAGWDV",
+		"me-south-1.elb.amazonaws.com":        "ZS929ML54UICD",
 		// Network Load Balancers
 		"elb.us-east-2.amazonaws.com":         "ZLMOA37VPKANP",
 		"elb.us-east-1.amazonaws.com":         "Z26RNL4JYFTOTI",
@@ -68,6 +70,7 @@ var (
 		"elb.sa-east-1.amazonaws.com":         "ZTK26PT1VY4CU",
 		"elb.cn-north-1.amazonaws.com.cn":     "Z3QFB96KMJ7ED6",
 		"elb.cn-northwest-1.amazonaws.com.cn": "ZQEIKTCZ8352D",
+		"elb.me-south-1.amazonaws.com":        "Z3QSRYVP46NYYV",
 	}
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Added AWS alias targets for regions `us-gov-west-1` AWS GovCloud (US) and `me-south-1` Middle East (Bahrain)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Added AWS alias targets for regions `us-gov-west-1` AWS GovCloud (US) and `me-south-1` Middle East (Bahrain)
```
