### PR TITLE
alicloud: avoid provider update race if get zones fails

### DIFF
--- a/pkg/controller/provider/cloudflare/state.go
+++ b/pkg/controller/provider/cloudflare/state.go
@@ -34,6 +34,6 @@ func (r *Record) GetValue() string {
 	}
 	return r.Content
 }
-func (r *Record) GetTTL() int       { return r.TTL }
-func (r *Record) SetTTL(ttl int)    { r.TTL = ttl }
-func (r *Record) Copy() raw.Record  { n := *r; return &n }
+func (r *Record) GetTTL() int      { return r.TTL }
+func (r *Record) SetTTL(ttl int)   { r.TTL = ttl }
+func (r *Record) Copy() raw.Record { n := *r; return &n }

--- a/pkg/dns/provider/errors/handlererror.go
+++ b/pkg/dns/provider/errors/handlererror.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *
+ */
+
+package errors
+
+import (
+	pkgerrors "github.com/pkg/errors"
+)
+
+type handlerError struct {
+	err error
+}
+
+func WrapAsHandlerError(err error, msg string) error {
+	return pkgerrors.Wrap(&handlerError{err: err}, msg)
+}
+
+func WrapfAsHandlerError(err error, msg string, args ...interface{}) error {
+	return pkgerrors.Wrapf(&handlerError{err: err}, msg, args...)
+}
+
+func IsHandlerError(err error) bool {
+	_, ok := err.(*handlerError)
+	return ok
+}
+
+func (e *handlerError) Error() string {
+	return e.err.Error()
+}
+
+func (e *handlerError) Cause() error {
+	return e.err
+}

--- a/pkg/dns/provider/provider.go
+++ b/pkg/dns/provider/provider.go
@@ -25,6 +25,9 @@ import (
 	"sync"
 	"time"
 
+	pkgerrors "github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/gardener/external-dns-management/pkg/server/metrics"
@@ -36,9 +39,6 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/utils"
-
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 )
 
 const ZoneCachePrefix = "zc-"
@@ -323,7 +323,7 @@ func updateDNSProvider(logger logger.LogContext, state *state, provider *dnsutil
 	zones, err := this.account.GetZones()
 	if err != nil {
 		this.zones = nil
-		return this, this.failed(logger, false, fmt.Errorf("cannot get zones: %s", err), true)
+		return this, this.failed(logger, false, pkgerrors.Wrap(err, "cannot get zones"), true)
 	}
 
 	zinc, zexc := prepareSelection(provider.DNSProvider().Spec.Zones)


### PR DESCRIPTION
**What this PR does / why we need it**:
The rate limiter did not work if getting zones fails for an alicloud provider, as the error message
contains a request id. This id changes with every call and was added to the provider status error message. This caused a new reconciliation which caused an update of the status again.
To break the circle, the status error message is now only updated if the error message without the handler specific part has changed.
In the reported alicloud issue, the error was caused by some temporary throttling, which caused just more requests with the above behaviour.

**Which issue(s) this PR fixes**:
Fixes #71 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
alicloud: avoid provider update race if get zones fails
```
