### PR TITLE
Fix stale entries on provider spec changes or errors

### DIFF
--- a/pkg/dns/provider/entry.go
+++ b/pkg/dns/provider/entry.go
@@ -625,6 +625,10 @@ func (this *Entry) Update(logger logger.LogContext, new *EntryVersion) *Entry {
 	}
 	this.EntryVersion = new
 
+	if new.valid && this.status.State == api.STATE_STALE {
+		this.modified = true
+	}
+
 	return this
 }
 

--- a/pkg/dns/provider/state.go
+++ b/pkg/dns/provider/state.go
@@ -25,12 +25,14 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
 	"github.com/gardener/controller-manager-library/pkg/ctxutil"
 	"github.com/gardener/controller-manager-library/pkg/resources/access"
+
 	"github.com/gardener/external-dns-management/pkg/dns"
 
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile"
 	"github.com/gardener/controller-manager-library/pkg/utils"
-	"github.com/gardener/external-dns-management/pkg/server/metrics"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gardener/external-dns-management/pkg/server/metrics"
 
 	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	perrs "github.com/gardener/external-dns-management/pkg/dns/provider/errors"
@@ -406,7 +408,7 @@ func (this *state) GetEntriesForZone(logger logger.LogContext, zoneid string) (E
 	return entries, nil, false
 }
 
-func (this *state) addEntriesForZone(logger logger.LogContext, entries Entries, stale DNSNames, zone *dnsHostedZone) (Entries, DNSNames, bool) {
+func (this *state) addEntriesForZone(logger logger.LogContext, entries Entries, stale DNSNames, zone DNSHostedZone) (Entries, DNSNames, bool) {
 	if entries == nil {
 		entries = Entries{}
 	}
@@ -546,7 +548,12 @@ func (this *state) updateZones(logger logger.LogContext, last, new *dnsProviderV
 			zone.update(z)
 
 			if this.isProviderForZone(z.Id(), name) {
-				keeping = append(keeping, fmt.Sprintf("keeping provider %q for hosted zone %q (%s)", name, z.Id(), z.Domain()))
+				if last != nil && (!new.included.Equals(last.included) || !new.excluded.Equals(last.excluded)) {
+					modified = true
+					logger.Infof("keeping provider %q for hosted zone %q (%s) with modified domain selection", name, z.Id(), z.Domain())
+				} else {
+					keeping = append(keeping, fmt.Sprintf("keeping provider %q for hosted zone %q (%s)", name, z.Id(), z.Domain()))
+				}
 			} else {
 				modified = true
 				logger.Infof("adding provider %q for hosted zone %q (%s)", name, z.Id(), z.Domain())
@@ -573,10 +580,10 @@ func (this *state) updateZones(logger logger.LogContext, last, new *dnsProviderV
 				}
 			}
 		}
-		if modified {
-			for _, m := range keeping {
-				logger.Info(m)
-			}
+	}
+	if modified {
+		for _, m := range keeping {
+			logger.Info(m)
 		}
 	}
 	this.providerzones[name] = result
@@ -631,10 +638,17 @@ func (this *state) _UpdateLocalProvider(logger logger.LogContext, obj *dnsutils.
 	if !status.IsSucceeded() {
 		logger.Infof("erroneous provider: %s", status.Error)
 		if last != nil {
-			logger.Infof("trigger old zones")
+			logger.Infof("trigger entries for old zones")
+			entries := Entries{}
+			stale := DNSNames{}
 			for _, z := range last.zones {
 				this.triggerHostedZone(z.Id())
+				this.addEntriesForZone(logger, entries, stale, z)
 			}
+			for _, s := range stale {
+				entries.AddEntry(s)
+			}
+			this.TriggerEntries(logger, entries)
 		}
 		if regmod {
 			return reconcile.Repeat(logger, regerr)

--- a/pkg/dns/provider/zone.go
+++ b/pkg/dns/provider/zone.go
@@ -103,6 +103,14 @@ func (this *dnsHostedZone) ForwardedDomains() []string {
 	return this.getZone().ForwardedDomains()
 }
 
+func (this *dnsHostedZone) Key() string {
+	return this.getZone().Key()
+}
+
+func (this *dnsHostedZone) IsPrivate() bool {
+	return this.getZone().IsPrivate()
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 func (this *dnsHostedZone) update(zone DNSHostedZone) {

--- a/test/integration/singleEntryOneProvider_test.go
+++ b/test/integration/singleEntryOneProvider_test.go
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *
+ */
+
+package integration
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+)
+
+var _ = Describe("SingleEntryOneProvider", func() {
+	It("should deal with included and excluded domains", func() {
+		baseDomain := "pr-1.inmemory.mock"
+		pr, domain, err := testEnv.CreateSecretAndProvider(baseDomain, 0)
+		Ω(err).Should(BeNil())
+		defer testEnv.DeleteProviderAndSecret(pr)
+
+		e, err := testEnv.CreateEntry(0, domain)
+		Ω(err).Should(BeNil())
+
+		checkProvider(pr)
+
+		checkEntry(e, pr)
+
+		pr, err = testEnv.UpdateProviderSpec(pr, func(spec *v1alpha1.DNSProviderSpec) error {
+			spec.Domains.Include = []string{"x." + baseDomain}
+			spec.Domains.Exclude = []string{}
+			return nil
+		})
+		Ω(err).Should(BeNil())
+
+		err = testEnv.AwaitEntryStale(e.GetName())
+		Ω(err).Should(BeNil())
+
+		pr, err = testEnv.UpdateProviderSpec(pr, func(spec *v1alpha1.DNSProviderSpec) error {
+			spec.Domains.Include = []string{domain}
+			spec.Domains.Exclude = []string{}
+			return nil
+		})
+		Ω(err).Should(BeNil())
+
+		err = testEnv.AwaitEntryReady(e.GetName())
+		Ω(err).Should(BeNil())
+
+		pr, err = testEnv.UpdateProviderSpec(pr, func(spec *v1alpha1.DNSProviderSpec) error {
+			spec.Domains.Include = []string{domain}
+			spec.Domains.Exclude = []string{UnwrapEntry(e).Spec.DNSName}
+			return nil
+		})
+		Ω(err).Should(BeNil())
+
+		err = testEnv.AwaitEntryStale(e.GetName())
+		Ω(err).Should(BeNil())
+
+		pr, err = testEnv.UpdateProviderSpec(pr, func(spec *v1alpha1.DNSProviderSpec) error {
+			spec.Domains.Include = []string{domain}
+			spec.Domains.Exclude = []string{}
+			return nil
+		})
+		Ω(err).Should(BeNil())
+
+		err = testEnv.AwaitEntryReady(e.GetName())
+		Ω(err).Should(BeNil())
+
+		pr, err = testEnv.UpdateProviderSpec(pr, func(spec *v1alpha1.DNSProviderSpec) error {
+			spec.ProviderConfig = BuildProviderConfig(domain, baseDomain, true)
+			return nil
+		})
+		Ω(err).Should(BeNil())
+
+		err = testEnv.AwaitEntryError(e.GetName())
+		Ω(err).Should(BeNil())
+
+		pr, err = testEnv.UpdateProviderSpec(pr, func(spec *v1alpha1.DNSProviderSpec) error {
+			spec.ProviderConfig = BuildProviderConfig(domain, baseDomain, false)
+			return nil
+		})
+		Ω(err).Should(BeNil())
+
+		err = testEnv.AwaitEntryReady(e.GetName())
+		Ω(err).Should(BeNil())
+
+		err = testEnv.DeleteEntryAndWait(e)
+		Ω(err).Should(BeNil())
+
+		err = testEnv.DeleteProviderAndSecret(pr)
+		Ω(err).Should(BeNil())
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
If the domains of a DNSProvider changes or the DNSProvider goes into error state, the entries are not updated accordingly.
This PR triggers the entries and adds test coverage of the desired behaviour in the integration tests.

**Which issue(s) this PR fixes**:
Fixes #75 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fix stale entries on provider spec changes or errors
```
