### PR TITLE
rate limiter for failed provider reconcilation

### DIFF
--- a/pkg/dns/provider/provider.go
+++ b/pkg/dns/provider/provider.go
@@ -61,6 +61,7 @@ func (this DNSProviders) LookupFor(dns string) DNSProvider {
 ///////////////////////////////////////////////////////////////////////////////
 
 type DNSAccount struct {
+	*dnsutils.RateLimiter
 	handler DNSHandler
 	config  utils.Properties
 
@@ -70,6 +71,16 @@ type DNSAccount struct {
 
 var _ DNSHandler = &DNSAccount{}
 var _ Metrics = &DNSAccount{}
+
+func NewDNSAccount(config utils.Properties, handler DNSHandler, hash string) *DNSAccount {
+	return &DNSAccount{
+		RateLimiter: dnsutils.NewRateLimiter(3*time.Second, 10*time.Minute, 3*time.Second),
+		config:      config,
+		handler:     handler,
+		hash:        hash,
+		clients:     resources.ObjectNameSet{},
+	}
+}
 
 func (this *DNSAccount) AddRequests(requestType string, n int) {
 	metrics.AddRequests(this.handler.ProviderType(), this.hash, requestType, n)
@@ -84,11 +95,23 @@ func (this *DNSAccount) Hash() string {
 }
 
 func (this *DNSAccount) GetZones() (DNSHostedZones, error) {
-	return this.handler.GetZones()
+	zones, err := this.handler.GetZones()
+	if err == nil {
+		this.Succeeded()
+	} else {
+		this.Failed()
+	}
+	return zones, err
 }
 
 func (this *DNSAccount) GetZoneState(zone DNSHostedZone) (DNSZoneState, error) {
-	return this.handler.GetZoneState(zone)
+	state, err := this.handler.GetZoneState(zone)
+	if err == nil {
+		this.Succeeded()
+	} else {
+		this.Failed()
+	}
+	return state, err
 }
 
 func (this *DNSAccount) ReportZoneStateConflict(zone DNSHostedZone, err error) bool {
@@ -115,7 +138,11 @@ type AccountCache struct {
 }
 
 func NewAccountCache(ttl time.Duration, dir string) *AccountCache {
-	return &AccountCache{ttl: ttl, dir: dir, cache: map[string]*DNSAccount{}}
+	return &AccountCache{
+		ttl:   ttl,
+		dir:   dir,
+		cache: map[string]*DNSAccount{},
+	}
 }
 
 func (this *AccountCache) Get(logger logger.LogContext, provider *dnsutils.DNSProviderObject, props utils.Properties, state *state) (*DNSAccount, error) {
@@ -127,7 +154,7 @@ func (this *AccountCache) Get(logger logger.LogContext, provider *dnsutils.DNSPr
 	defer this.lock.Unlock()
 	a := this.cache[hash]
 	if a == nil {
-		a = &DNSAccount{config: props, hash: hash, clients: resources.ObjectNameSet{}}
+		a = NewDNSAccount(props, nil, hash)
 		syncPeriod := state.GetContext().GetPoolPeriod("dns")
 		if syncPeriod == nil {
 			return nil, fmt.Errorf("Pool dns not found")
@@ -481,10 +508,17 @@ func (this *dnsProviderVersion) failed(logger logger.LogContext, modified bool, 
 		if errors.IsConflict(uerr) {
 			return reconcile.Repeat(logger, fmt.Errorf("cannot update provider %q: %s", this.ObjectName(), uerr))
 		}
-		return reconcile.Failed(logger, uerr)
+		return reconcile.Delay(logger, uerr)
 	}
 	if !temp {
+		if this.account != nil {
+			// reset rate limiter for persistent errors
+			this.account.Succeeded()
+		}
 		return reconcile.Failed(logger, err)
+	}
+	if this.account != nil {
+		return reconcile.Recheck(logger, err, this.account.RateLimit())
 	}
 	return reconcile.Delay(logger, err)
 }

--- a/pkg/dns/provider/state.go
+++ b/pkg/dns/provider/state.go
@@ -540,7 +540,7 @@ func (this *state) updateZones(logger logger.LogContext, last, new *dnsProviderV
 			zone := this.zones[z.Id()]
 			if zone == nil {
 				modified = true
-				zone = newDNSHostedZone(z)
+				zone = newDNSHostedZone(this.config.Delay, z)
 				this.zones[z.Id()] = zone
 				logger.Infof("adding hosted zone %q (%s)", z.Id(), z.Domain())
 				this.triggerHostedZone(zone.Id())
@@ -592,7 +592,7 @@ func (this *state) updateZones(logger logger.LogContext, last, new *dnsProviderV
 
 func (this *state) RefineLogger(logger logger.LogContext, ptype string) logger.LogContext {
 	if len(this.config.Enabled) > 1 && ptype != "" {
-		logger = logger.NewContext("provider", ptype)
+		logger = logger.NewContext("type", ptype)
 	}
 	return logger
 }
@@ -1187,6 +1187,9 @@ func (this *state) reconcileZoneBlockingEntries(logger logger.LogContext) int {
 }
 
 func (this *state) ReconcileZone(logger logger.LogContext, zoneid string) reconcile.Status {
+	logger.Infof("Initiate reconcilation of zone %s", zoneid)
+	defer logger.Infof("zone %s done", zoneid)
+
 	blockingCount := this.reconcileZoneBlockingEntries(logger)
 	if blockingCount > 0 {
 		logger.Infof("reconciliation of zone %s is blocked due to %d pending entry reconciliations", zoneid, blockingCount)
@@ -1205,6 +1208,7 @@ func (this *state) ReconcileZone(logger logger.LogContext, zoneid string) reconc
 		logger.Infof("too early (required delay between two reconciliations: %s) -> skip and reschedule", this.config.Delay)
 		return reconcile.Succeeded(logger).RescheduleAfter(delay)
 	}
+	logger.Infof("precondition fulfilled for zone %s", zoneid)
 	if done, err := this.StartZoneReconciliation(logger, req); done {
 		if err != nil {
 			if _, ok := err.(*perrs.NoSuchHostedZone); ok {
@@ -1301,7 +1305,7 @@ func (this *state) reconcileZone(logger logger.LogContext, req *zoneReconciliati
 		req.zone.Succeeded()
 		err = conflictErr
 	} else {
-		req.zone.Failed(this.config.Delay)
+		req.zone.Failed()
 	}
 	return err
 }

--- a/pkg/dns/utils/ratelimiter.go
+++ b/pkg/dns/utils/ratelimiter.go
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package utils
+
+import (
+	"time"
+)
+
+type RateLimiter struct {
+	min     time.Duration
+	max     time.Duration
+	minincr time.Duration
+
+	rate time.Duration
+}
+
+func NewRateLimiter(min, max, minincr time.Duration) *RateLimiter {
+	if min <= 0 {
+		min = time.Second
+	}
+	if max <= min {
+		max = min * 20
+	}
+	if minincr < min/10 {
+		minincr = min / 10
+	}
+	return &RateLimiter{
+		min: min,
+		max: max,
+	}
+}
+
+func (this *RateLimiter) RateLimit() time.Duration {
+	return this.rate
+}
+
+func (this *RateLimiter) Succeeded() {
+	this.rate = 0
+}
+
+func (this *RateLimiter) Failed() {
+	if this.rate == 0 {
+		this.rate = this.min
+	} else {
+		if this.rate < this.max {
+			this.rate = time.Duration(1.1*float64(this.rate)) + time.Second
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
The rate limiter for failed provider controller was using the default rate limiter of the kubernetes work queue which starts with delays in the millisecond region. If the provider backend reports errors because of throttling, the rate limiter should start with delay in the second range.
With this PR the provider controller uses an own rate limiter using delays in the range 3 s to 10 min.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
own rate limiter for failed provider reconcilation
```
