### PR TITLE
rate limiter for all dns providers

### DIFF
--- a/pkg/controller/provider/alicloud/controller/controller.go
+++ b/pkg/controller/provider/alicloud/controller/controller.go
@@ -24,5 +24,8 @@ import (
 func init() {
 	provider.DNSController("", alicloud.Factory).
 		FinalizerDomain("dns.gardener.cloud").
+		DefaultedBoolOption(provider.OPT_RATELIMITER_ENABLED, true, "enables rate limiter for Alicloud DNS requests").
+		DefaultedIntOption(provider.OPT_RATELIMITER_QPS, 25, "maximum requests/queries per second").
+		DefaultedIntOption(provider.OPT_RATELIMITER_BURST, 1, "number of burst requests for rate limiter").
 		MustRegister(provider.CONTROLLER_GROUP_DNS_CONTROLLERS)
 }

--- a/pkg/controller/provider/alicloud/handler.go
+++ b/pkg/controller/provider/alicloud/handler.go
@@ -53,7 +53,7 @@ func NewHandler(c *provider.DNSHandlerConfig) (provider.DNSHandler, error) {
 		return nil, err
 	}
 
-	access, err := NewAccess(accessKeyID, accessKeySecret, c.Metrics)
+	access, err := NewAccess(accessKeyID, accessKeySecret, c.Metrics, c.RateLimiter)
 	if err != nil {
 		return nil, perrs.WrapAsHandlerError(err, "Creating alicloud access with client credentials failed")
 	}

--- a/pkg/controller/provider/aws/controller/controller.go
+++ b/pkg/controller/provider/aws/controller/controller.go
@@ -24,5 +24,8 @@ import (
 func init() {
 	provider.DNSController("", aws.Factory).
 		FinalizerDomain("dns.gardener.cloud").
+		DefaultedBoolOption(provider.OPT_RATELIMITER_ENABLED, true, "enables rate limiter for AWS route 53 requests").
+		DefaultedIntOption(provider.OPT_RATELIMITER_QPS, 9, "maximum requests/queries per second").
+		DefaultedIntOption(provider.OPT_RATELIMITER_BURST, 10, "number of burst requests for rate limiter").
 		MustRegister(provider.CONTROLLER_GROUP_DNS_CONTROLLERS)
 }

--- a/pkg/controller/provider/azure/controller/controller.go
+++ b/pkg/controller/provider/azure/controller/controller.go
@@ -21,10 +21,11 @@ import (
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 )
 
-const TYPE_CODE = "azure-dns"
-
 func init() {
 	provider.DNSController("", azure.Factory).
 		FinalizerDomain("dns.gardener.cloud").
+		DefaultedBoolOption(provider.OPT_RATELIMITER_ENABLED, true, "enables rate limiter for Azure DNS requests").
+		DefaultedIntOption(provider.OPT_RATELIMITER_QPS, 50, "maximum requests/queries per second").
+		DefaultedIntOption(provider.OPT_RATELIMITER_BURST, 10, "number of burst requests for rate limiter").
 		MustRegister(provider.CONTROLLER_GROUP_DNS_CONTROLLERS)
 }

--- a/pkg/controller/provider/azure/execution.go
+++ b/pkg/controller/provider/azure/execution.go
@@ -22,6 +22,7 @@ import (
 
 	azure "github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2018-05-01/dns"
 	"github.com/gardener/controller-manager-library/pkg/logger"
+
 	"github.com/gardener/external-dns-management/pkg/dns"
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 )
@@ -133,6 +134,7 @@ func (exec *Execution) apply(action string, recordType azure.RecordType, rset *a
 }
 
 func (exec *Execution) update(recordType azure.RecordType, rset *azure.RecordSet, metrics provider.Metrics) error {
+	exec.handler.config.RateLimiter.Accept()
 	_, err := exec.handler.recordsClient.CreateOrUpdate(exec.handler.ctx, exec.resourceGroup, exec.zoneName, *rset.Name,
 		recordType, *rset, "", "")
 	metrics.AddRequests("RecordSetsClient_CreateOrUpdate", 1)
@@ -140,6 +142,7 @@ func (exec *Execution) update(recordType azure.RecordType, rset *azure.RecordSet
 }
 
 func (exec *Execution) delete(recordType azure.RecordType, rset *azure.RecordSet, metrics provider.Metrics) error {
+	exec.handler.config.RateLimiter.Accept()
 	_, err := exec.handler.recordsClient.Delete(exec.handler.ctx, exec.resourceGroup, exec.zoneName, *rset.Name, recordType, "")
 	metrics.AddRequests("RecordSetsClient_Delete", 1)
 	return err

--- a/pkg/controller/provider/azure/handler.go
+++ b/pkg/controller/provider/azure/handler.go
@@ -23,10 +23,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gardener/controller-manager-library/pkg/logger"
-
 	azure "github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2018-05-01/dns"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/gardener/controller-manager-library/pkg/logger"
 
 	"github.com/gardener/external-dns-management/pkg/dns"
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
@@ -84,6 +83,7 @@ func NewHandler(c *provider.DNSHandlerConfig) (provider.DNSHandler, error) {
 	// dummy call to check authentication
 	var one int32 = 1
 	ctx := context.TODO()
+	h.config.RateLimiter.Accept()
 	_, err = zonesClient.List(ctx, &one)
 	if err != nil {
 		return nil, perrs.WrapAsHandlerError(err, "Authentication test to Azure with client credentials failed. Please check secret for DNSProvider.")
@@ -112,6 +112,7 @@ func (h *Handler) GetZones() (provider.DNSHostedZones, error) {
 
 func (h *Handler) getZones(cache provider.ZoneCache) (provider.DNSHostedZones, error) {
 	zones := provider.DNSHostedZones{}
+	h.config.RateLimiter.Accept()
 	results, err := h.zonesClient.ListComplete(h.ctx, nil)
 	h.config.Metrics.AddRequests("ZonesClient_ListComplete", 1)
 	if err != nil {
@@ -143,6 +144,7 @@ func (h *Handler) collectForwardedSubzones(resourceGroup, zoneName string) []str
 	forwarded := []string{}
 	// There should only few NS entries. Therefore no paging is performed for simplicity.
 	var top int32 = 1000
+	h.config.RateLimiter.Accept()
 	result, err := h.recordsClient.ListByType(h.ctx, resourceGroup, zoneName, azure.NS, &top, "")
 	h.config.Metrics.AddRequests("RecordSetsClient_ListByType_NS", 1)
 	if err != nil {
@@ -176,6 +178,7 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, cache provider.ZoneC
 	dnssets := dns.DNSSets{}
 
 	resourceGroup, zoneName := splitZoneid(zone.Id())
+	h.config.RateLimiter.Accept()
 	results, err := h.recordsClient.ListAllByDNSZoneComplete(h.ctx, resourceGroup, zoneName, nil, "")
 	h.config.Metrics.AddRequests("RecordSetsClient_ListAllByDNSZoneComplete", 1)
 	if err != nil {

--- a/pkg/controller/provider/cloudflare/controller/controller.go
+++ b/pkg/controller/provider/cloudflare/controller/controller.go
@@ -24,5 +24,8 @@ import (
 func init() {
 	provider.DNSController("", cloudflare.Factory).
 		FinalizerDomain("dns.gardener.cloud").
+		DefaultedBoolOption(provider.OPT_RATELIMITER_ENABLED, true, "enables rate limiter for Cloudflare requests").
+		DefaultedIntOption(provider.OPT_RATELIMITER_QPS, 50, "maximum requests/queries per second").
+		DefaultedIntOption(provider.OPT_RATELIMITER_BURST, 10, "number of burst requests for rate limiter").
 		MustRegister(provider.CONTROLLER_GROUP_DNS_CONTROLLERS)
 }

--- a/pkg/controller/provider/cloudflare/handler.go
+++ b/pkg/controller/provider/cloudflare/handler.go
@@ -17,12 +17,14 @@
 package cloudflare
 
 import (
+	"strings"
+
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/gardener/controller-manager-library/pkg/logger"
+
 	"github.com/gardener/external-dns-management/pkg/dns"
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 	"github.com/gardener/external-dns-management/pkg/dns/provider/raw"
-	"strings"
 )
 
 type Handler struct {
@@ -52,7 +54,7 @@ func NewHandler(c *provider.DNSHandlerConfig) (provider.DNSHandler, error) {
 	//	return nil, err
 	//}
 
-	access, err := NewAccess(apiToken, c.Metrics)
+	access, err := NewAccess(apiToken, c.Metrics, c.RateLimiter)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/provider/google/controller/controller.go
+++ b/pkg/controller/provider/google/controller/controller.go
@@ -21,10 +21,11 @@ import (
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 )
 
-const TYPE_CODE = "google-clouddns"
-
 func init() {
 	provider.DNSController("", google.Factory).
 		FinalizerDomain("dns.gardener.cloud").
+		DefaultedBoolOption(provider.OPT_RATELIMITER_ENABLED, true, "enables rate limiter for Google Cloud DNS requests").
+		DefaultedIntOption(provider.OPT_RATELIMITER_QPS, 100, "maximum requests/queries per second").
+		DefaultedIntOption(provider.OPT_RATELIMITER_BURST, 20, "number of burst requests for rate limiter").
 		MustRegister(provider.CONTROLLER_GROUP_DNS_CONTROLLERS)
 }

--- a/pkg/controller/provider/google/execution.go
+++ b/pkg/controller/provider/google/execution.go
@@ -19,9 +19,10 @@ package google
 import (
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/utils"
+	googledns "google.golang.org/api/dns/v1"
+
 	"github.com/gardener/external-dns-management/pkg/dns"
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
-	googledns "google.golang.org/api/dns/v1"
 )
 
 const (
@@ -94,6 +95,7 @@ func (this *Execution) submitChanges(metrics provider.Metrics) error {
 	}
 
 	metrics.AddRequests(provider.M_UPDATERECORDS, 1)
+	this.handler.config.RateLimiter.Accept()
 	if _, err := this.handler.service.Changes.Create(this.handler.credentials.ProjectID, this.zone.Id(), this.change).Do(); err != nil {
 		this.Error(err)
 		for _, d := range this.done {

--- a/pkg/controller/provider/google/handler.go
+++ b/pkg/controller/provider/google/handler.go
@@ -27,6 +27,7 @@ import (
 	"golang.org/x/oauth2/google"
 
 	"github.com/gardener/controller-manager-library/pkg/logger"
+
 	"github.com/gardener/external-dns-management/pkg/dns"
 
 	googledns "google.golang.org/api/dns/v1"
@@ -109,6 +110,7 @@ func (h *Handler) getZones(cache provider.ZoneCache) (provider.DNSHostedZones, e
 		return nil
 	}
 
+	h.config.RateLimiter.Accept()
 	if err := h.service.ManagedZones.List(h.credentials.ProjectID).Pages(h.ctx, f); err != nil {
 		return nil, err
 	}
@@ -149,6 +151,7 @@ func (h *Handler) handleRecordSets(zone provider.DNSHostedZone, f func(r *google
 		rt = provider.M_PLISTRECORDS
 		return nil
 	}
+	h.config.RateLimiter.Accept()
 	err := h.service.ResourceRecordSets.List(h.credentials.ProjectID, zone.Id()).Pages(h.ctx, aggr)
 	return forwarded, err
 }

--- a/pkg/controller/provider/mock/controller/controller.go
+++ b/pkg/controller/provider/mock/controller/controller.go
@@ -21,10 +21,11 @@ import (
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 )
 
-const TYPE_CODE = "mock-inmemory"
-
 func init() {
 	provider.DNSController("", mock.Factory).
 		FinalizerDomain("dns.gardener.cloud").
+		DefaultedBoolOption(provider.OPT_RATELIMITER_ENABLED, true, "enables rate limiter for mocking requests").
+		DefaultedIntOption(provider.OPT_RATELIMITER_QPS, 100, "maximum requests/queries per second").
+		DefaultedIntOption(provider.OPT_RATELIMITER_BURST, 20, "number of burst requests for rate limiter").
 		MustRegister(provider.CONTROLLER_GROUP_DNS_CONTROLLERS)
 }

--- a/pkg/controller/provider/mock/handler.go
+++ b/pkg/controller/provider/mock/handler.go
@@ -84,6 +84,7 @@ func (h *Handler) getZones(cache provider.ZoneCache) (provider.DNSHostedZones, e
 	if h.mockConfig.FailGetZones {
 		return nil, fmt.Errorf("forced error by mockConfig.FailGetZones")
 	}
+	h.config.RateLimiter.Accept()
 	zones := h.mock.GetZones()
 	return zones, nil
 }
@@ -93,6 +94,7 @@ func (h *Handler) GetZoneState(zone provider.DNSHostedZone) (provider.DNSZoneSta
 }
 
 func (h *Handler) getZoneState(zone provider.DNSHostedZone, cache provider.ZoneCache) (provider.DNSZoneState, error) {
+	h.config.RateLimiter.Accept()
 	return h.mock.CloneZoneState(zone)
 }
 
@@ -109,6 +111,7 @@ func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHos
 func (h *Handler) executeRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
 	var succeeded, failed int
 	for _, r := range reqs {
+		h.config.RateLimiter.Accept()
 		err := h.mock.Apply(zone.Id(), r, h.config.Metrics)
 		if err != nil {
 			failed++

--- a/pkg/controller/provider/openstack/controller/controller.go
+++ b/pkg/controller/provider/openstack/controller/controller.go
@@ -21,10 +21,11 @@ import (
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 )
 
-const TYPE_CODE = "openstack-designate"
-
 func init() {
 	provider.DNSController("", openstack.Factory).
 		FinalizerDomain("dns.gardener.cloud").
+		DefaultedBoolOption(provider.OPT_RATELIMITER_ENABLED, true, "enables rate limiter for Openstack Designate requests").
+		DefaultedIntOption(provider.OPT_RATELIMITER_QPS, 100, "maximum requests/queries per second").
+		DefaultedIntOption(provider.OPT_RATELIMITER_BURST, 20, "number of burst requests for rate limiter").
 		MustRegister(provider.CONTROLLER_GROUP_DNS_CONTROLLERS)
 }

--- a/pkg/controller/provider/openstack/handler.go
+++ b/pkg/controller/provider/openstack/handler.go
@@ -22,11 +22,12 @@ import (
 	"strings"
 
 	"github.com/gardener/controller-manager-library/pkg/logger"
-	"github.com/gardener/external-dns-management/pkg/dns"
-	"github.com/gardener/external-dns-management/pkg/dns/provider"
 	"github.com/gophercloud/gophercloud/openstack/dns/v2/recordsets"
 	"github.com/gophercloud/gophercloud/openstack/dns/v2/zones"
 	"github.com/gophercloud/utils/openstack/clientconfig"
+
+	"github.com/gardener/external-dns-management/pkg/dns"
+	"github.com/gardener/external-dns-management/pkg/dns/provider"
 )
 
 // Handler is the main DNSHandler struct.
@@ -140,6 +141,7 @@ func (h *Handler) getZones(cache provider.ZoneCache) (provider.DNSHostedZones, e
 		return nil
 	}
 
+	h.config.RateLimiter.Accept()
 	if err := h.client.ForEachZone(zoneHandler); err != nil {
 		return nil, fmt.Errorf("listing DNS zones failed. Details: %s", err.Error())
 	}
@@ -158,6 +160,7 @@ func (h *Handler) collectForwardedSubzones(zone *zones.Zone) []string {
 		return nil
 	}
 
+	h.config.RateLimiter.Accept()
 	if err := h.client.ForEachRecordSetFilterByTypeAndName(zone.ID, "NS", "", recordSetHandler); err != nil {
 		logger.Infof("Failed fetching NS records for %s: %s", zone.Name, err.Error())
 		// just ignoring it
@@ -191,6 +194,7 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, cache provider.ZoneC
 		return nil
 	}
 
+	h.config.RateLimiter.Accept()
 	if err := h.client.ForEachRecordSet(zone.Id(), recordSetHandler); err != nil {
 		return nil, fmt.Errorf("Listing DNS zones failed for %s. Details: %s", zone.Id(), err.Error())
 	}

--- a/pkg/controller/provider/openstack/handler_test.go
+++ b/pkg/controller/provider/openstack/handler_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/gardener/controller-manager-library/pkg/logger"
+
 	"github.com/gardener/external-dns-management/pkg/dns"
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 
@@ -194,8 +195,14 @@ func newMockHandler(mockZones ...*zones.Zone) *Handler {
 		}
 	}
 
+	var rateLimiterConfig *provider.RateLimiterConfig
+	rateLimiter, _ := rateLimiterConfig.NewRateLimiter()
+
 	h := &Handler{
 		client: &c,
+		config: provider.DNSHandlerConfig{
+			RateLimiter: rateLimiter,
+		},
 	}
 
 	cache, _ := provider.NewZoneCache(provider.ZoneCacheConfig{}, mockMetrics, nil, h.getZones, h.getZoneState)

--- a/pkg/dns/provider/const.go
+++ b/pkg/dns/provider/const.go
@@ -39,4 +39,8 @@ const (
 	OPT_PROVIDERTYPES = "provider-types"
 
 	HOSTEDZONE_PREFIX = "hostedzone:"
+
+	OPT_RATELIMITER_ENABLED = "enable-ratelimiter"
+	OPT_RATELIMITER_QPS     = "ratelimiter-qps"
+	OPT_RATELIMITER_BURST   = "ratelimiter-burst"
 )

--- a/pkg/dns/provider/ratelimiter.go
+++ b/pkg/dns/provider/ratelimiter.go
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *
+ */
+
+package provider
+
+import (
+	"fmt"
+
+	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
+	"k8s.io/client-go/util/flowcontrol"
+)
+
+func NewRateLimiterConfig(c controller.Interface) *RateLimiterConfig {
+	enabled, _ := c.GetBoolOption(OPT_RATELIMITER_ENABLED)
+	if !enabled {
+		return nil
+	}
+	qps, _ := c.GetIntOption(OPT_RATELIMITER_QPS)
+	burst, _ := c.GetIntOption(OPT_RATELIMITER_BURST)
+	return &RateLimiterConfig{QPS: float32(qps), Burst: burst}
+}
+
+func (c *RateLimiterConfig) NewRateLimiter() (flowcontrol.RateLimiter, error) {
+	if c == nil {
+		return flowcontrol.NewFakeAlwaysRateLimiter(), nil
+	}
+
+	if c.QPS < 0.01 || c.QPS > 1e4 {
+		return nil, fmt.Errorf("invalid qps value %f", c.QPS)
+	}
+	if c.Burst < 0 || c.Burst > 10000 {
+		return nil, fmt.Errorf("invalid burst value %d", c.Burst)
+	}
+
+	return flowcontrol.NewTokenBucketRateLimiter(c.QPS, c.Burst), nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
The rate limiter used for the Alicloud DNS provider has been generalized for all DNS providers.
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
added generalized rate limiter for all DNS providers
```
