### PR TITLE
fix metadata domain name for wildcard on base domain name

### DIFF
--- a/pkg/dns/mapping.go
+++ b/pkg/dns/mapping.go
@@ -59,7 +59,7 @@ func MapToProvider(rtype string, dnsset *DNSSet, base string) (string, *RecordSe
 			add = "*."
 			name = name[2:]
 			if name == base {
-				prefix += "."
+				prefix += "-base."
 			}
 		}
 		return add + prefix + name, &new
@@ -80,7 +80,10 @@ func MapFromProvider(dns string, rs *RecordSet) (string, *RecordSet) {
 				new := *rs
 				new.Type = RS_META
 				dns = dns[len(prefix):]
-				if strings.HasPrefix(dns, ".") {
+				if strings.HasPrefix(dns, "-base.") {
+					dns = dns[6:]
+				} else if strings.HasPrefix(dns, ".") {
+					// for backwards compatibility of form *.comment-.basedomain
 					dns = dns[1:]
 				}
 				return add + dns, &new

--- a/pkg/dns/mapping_test.go
+++ b/pkg/dns/mapping_test.go
@@ -60,7 +60,7 @@ func TestMapToFromProvider(t *testing.T) {
 		{"a.myzone.de", false, "comment-a.myzone.de"},
 		{"a.myzone.de", true, "mycomment-a.myzone.de"},
 		{"*.a.myzone.de", false, "*.comment-a.myzone.de"},
-		{"*.myzone.de", false, "*.comment-.myzone.de"},
+		{"*.myzone.de", false, "*.comment--base.myzone.de"},
 	}
 
 	rtype := RS_META


### PR DESCRIPTION
**What this PR does / why we need it**:
If a DNS entry of the form `*.base.domain` is created, where `base.domain` is the hosted zone, this does not work for the provider `openstack-designate`. It is tried to use a metadata DNS record with the domain name `*.comment-.base.domain`. It contains a domain name part `comment-`, but according to the RFC it must not end with a dash.
This PR changes the used metadata domain name schema to `*.comment--base.base.domain`

**Which issue(s) this PR fixes**:
Fixes #82 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
fix creating DNS entry with wildcard on base domain of hosted zone for openstack-designate.  
```
