### PR TITLE
Move type registration to main init

### DIFF
--- a/cmd/compound/main.go
+++ b/cmd/compound/main.go
@@ -24,7 +24,9 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/cluster"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/mappings"
+	"github.com/gardener/controller-manager-library/pkg/resources"
 
+	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	dnsprovider "github.com/gardener/external-dns-management/pkg/dns/provider"
 	dnssource "github.com/gardener/external-dns-management/pkg/dns/source"
 
@@ -52,6 +54,7 @@ func init() {
 	mappings.ForControllerGroup(dnsprovider.CONTROLLER_GROUP_DNS_CONTROLLERS).
 		Map(controller.CLUSTER_MAIN, dnssource.TARGET_CLUSTER).MustRegister()
 
+	resources.Register(v1alpha1.SchemeBuilder)
 }
 
 func main() {

--- a/cmd/dns/main.go
+++ b/cmd/dns/main.go
@@ -24,7 +24,9 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/cluster"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/mappings"
+	"github.com/gardener/controller-manager-library/pkg/resources"
 
+	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	dnsprovider "github.com/gardener/external-dns-management/pkg/dns/provider"
 	dnssource "github.com/gardener/external-dns-management/pkg/dns/source"
 
@@ -55,6 +57,7 @@ func init() {
 	mappings.ForControllerGroup(dnsprovider.CONTROLLER_GROUP_DNS_CONTROLLERS).
 		Map(controller.CLUSTER_MAIN, dnssource.TARGET_CLUSTER).MustRegister()
 
+	resources.Register(v1alpha1.SchemeBuilder)
 }
 
 func main() {

--- a/pkg/apis/dns/v1alpha1/register.go
+++ b/pkg/apis/dns/v1alpha1/register.go
@@ -17,7 +17,6 @@
 package v1alpha1
 
 import (
-	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/external-dns-management/pkg/apis/dns"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -68,8 +67,4 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil
-}
-
-func init() {
-	resources.Register(SchemeBuilder)
 }

--- a/test/integration/testenv.go
+++ b/test/integration/testenv.go
@@ -40,7 +40,7 @@ import (
 	extensions "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	v1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"github.com/gardener/external-dns-management/pkg/controller/source/service"
 
 	dnsprovider "github.com/gardener/external-dns-management/pkg/dns/provider"
@@ -64,6 +64,8 @@ func doInit() {
 
 	mappings.ForControllerGroup(dnsprovider.CONTROLLER_GROUP_DNS_CONTROLLERS).
 		Map(controller.CLUSTER_MAIN, dnssource.TARGET_CLUSTER).MustRegister()
+
+	resources.Register(v1alpha1.SchemeBuilder)
 }
 
 func runControllerManager(args []string) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR moves the scheme registration from the `v1alpha1` package to the main initialization functions of the controllers.

It mainly eliminates the indirect dependency to the `controller-manager-library` for every component which wants to use the types in `v1alpha1`, e.g. github.com/gardener/gardener.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
