### PR TITLE
Add PodSecurityPolicy to charts

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -21,4 +21,6 @@ ADD bin/rel/dns-controller-manager /dns-controller-manager
 
 WORKDIR /
 
+USER 65534:65534
+
 ENTRYPOINT ["/dns-controller-manager"]

--- a/charts/external-dns-management/templates/clusterrole.yaml
+++ b/charts/external-dns-management/templates/clusterrole.yaml
@@ -53,3 +53,11 @@ rules:
   - list
   - update
   - create
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - {{ include "external-dns-management.fullname" . }}
+  verbs:
+  - use

--- a/charts/external-dns-management/templates/deployment.yaml
+++ b/charts/external-dns-management/templates/deployment.yaml
@@ -19,14 +19,31 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
+      annotations:
+        checksum/psp: {{ include (print $.Template.BasePath "/psp.yaml") . | sha256sum }}
       labels:
         app.kubernetes.io/name: {{ include "external-dns-management.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      hostIPC: false
+      hostNetwork: false
+      hostPID: false
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
         args:
         - --name={{ include "external-dns-management.fullname" . }}
         {{- if or .Values.configuration.identifier (not .Values.gardener.seed.identity) }}

--- a/charts/external-dns-management/templates/psp.yaml
+++ b/charts/external-dns-management/templates/psp.yaml
@@ -1,0 +1,53 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "external-dns-management.fullname" . }}
+  labels:
+    helm.sh/chart: {{ include "external-dns-management.chart" . }}
+    app.kubernetes.io/name: {{ include "external-dns-management.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if or .Values.security.apparmorEnabled .Values.security.seccompEnabled }}
+  annotations:
+{{- if .Values.security.apparmorEnabled }}
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+{{- end }}
+{{- if .Values.security.seccompEnabled }}
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+{{- end }}
+{{- end }}
+spec:
+  allowedCapabilities: []
+  defaultAddCapabilities: []
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+  - ALL
+  volumes:
+  - secret
+{{- if .Values.configuration.persistentCache }}
+  - persistentVolumeClaim
+{{- end }}
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: MustRunAs
+    ranges:
+    - min: 65534
+      max: 65534
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: MustRunAs
+    ranges:
+    - min: 65534
+      max: 65534
+  fsGroup:
+    rule: MustRunAs
+    ranges:
+    - min: 65534
+      max: 65534
+  readOnlyRootFilesystem: true

--- a/charts/external-dns-management/values.yaml
+++ b/charts/external-dns-management/values.yaml
@@ -211,3 +211,7 @@ gardener:
   seed:
     identity: ""
     provider: ""
+
+security:
+  apparmorEnabled: false
+  seccompEnabled: false


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `PodSecurityPolicy` for clusters using a `PodSecurityPolicy` admission controller.

**Which issue(s) this PR fixes**:
Fixes # n/a

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
`PodSecurityPolicy` has been added and all linux capabilities are dropped by default. The UID and GID of `dns-controller-manager` container are now both `65534`.
```
