### PR TITLE
fix for rescheduling hosted zone

### DIFF
--- a/pkg/dns/provider/state.go
+++ b/pkg/dns/provider/state.go
@@ -496,7 +496,7 @@ func (this *state) updateZones(logger logger.LogContext, last, new *dnsProviderV
 			zone := this.zones[z.Id()]
 			if zone == nil {
 				modified = true
-				zone = newDNSHostedZone(this.config.Delay, z)
+				zone = newDNSHostedZone(this.config.RescheduleDelay, z)
 				this.zones[z.Id()] = zone
 				logger.Infof("adding hosted zone %q (%s)", z.Id(), z.Domain())
 				this.triggerHostedZone(zone.Id())

--- a/pkg/dns/provider/state_zone.go
+++ b/pkg/dns/provider/state_zone.go
@@ -183,6 +183,7 @@ func (this *state) reconcileZone(logger logger.LogContext, req *zoneReconciliati
 	changes := NewChangeModel(logger, ownerids, req, this.config)
 	err := changes.Setup()
 	if err != nil {
+		req.zone.Failed()
 		return err
 	}
 	modified := false

--- a/pkg/dns/utils/ratelimiter.go
+++ b/pkg/dns/utils/ratelimiter.go
@@ -48,7 +48,11 @@ func NewRateLimiter(min, max, minincr time.Duration) *RateLimiter {
 }
 
 func (this *RateLimiter) RateLimit() time.Duration {
-	return this.rate.Load()
+	rate := this.rate.Load()
+	if rate == 0 {
+		rate = this.min
+	}
+	return rate
 }
 
 func (this *RateLimiter) Succeeded() {


### PR DESCRIPTION
**What this PR does / why we need it**:
If listing records of an hosted zone fails, e.g. because of network problems, the reconcilation of this zone is stopped and not started again. This PR fixes the behaviour and reschedules the zone reconcilation (with rate limiter).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fix hosted zone reconcilation after backend is not available temporarily.
```
