### PR TITLE
fix addallsplitted in controller-manager-library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go v1.19.41
 	github.com/cloudflare/cloudflare-go v0.11.4
 	github.com/emicklei/go-restful v2.9.6+incompatible // indirect
-	github.com/gardener/controller-manager-library v0.2.1-0.20200724135643-ae8c0a569c8a
+	github.com/gardener/controller-manager-library v0.2.1-0.20200729132713-ba1a401efd11
 	github.com/gophercloud/gophercloud v0.2.0
 	github.com/gophercloud/utils v0.0.0-20190527093828-25f1b77b8c03
 	github.com/imdario/mergo v0.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/gardener/controller-manager-library v0.2.1-0.20200724135643-ae8c0a569c8a h1:E6k0setWqG+6HOt0NLDAStx54JdkM72/+Qo9TvligcU=
-github.com/gardener/controller-manager-library v0.2.1-0.20200724135643-ae8c0a569c8a/go.mod h1:6R2+75JaFEdUXG5bdqTt+asSHac0Edf4QQl4ORF3onM=
+github.com/gardener/controller-manager-library v0.2.1-0.20200729132713-ba1a401efd11 h1:+SKJj7GcZKL5jyJQ3GwMutB43Ht0b1S8tv4gJRVZarU=
+github.com/gardener/controller-manager-library v0.2.1-0.20200729132713-ba1a401efd11/go.mod h1:6R2+75JaFEdUXG5bdqTt+asSHac0Edf4QQl4ORF3onM=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/vendor/github.com/gardener/controller-manager-library/pkg/utils/stringset.go
+++ b/vendor/github.com/gardener/controller-manager-library/pkg/utils/stringset.go
@@ -108,14 +108,31 @@ func (this StringSet) RemoveSet(sets ...StringSet) StringSet {
 }
 
 func (this StringSet) AddAllSplitted(n string, seps ...string) StringSet {
+	return this.AddAllSplittedSelected(n, StandardStringElement, seps...)
+}
+
+func StandardStringElement(s string) (string, bool) {
+	return strings.ToLower(strings.TrimSpace(s)), true
+}
+
+func StandardNonEmptyStringElement(s string) (string, bool) {
+	s, _ = StandardStringElement(s)
+	return s, s != ""
+}
+
+func NonEmptyStringElement(s string) (string, bool) {
+	s = strings.TrimSpace(s)
+	return s, s != ""
+}
+
+func (this StringSet) AddAllSplittedSelected(n string, sel func(s string) (string, bool), seps ...string) StringSet {
 	sep := ","
 	if len(seps) > 0 {
 		sep = seps[0]
 	}
 	for _, p := range strings.Split(n, sep) {
-		e := strings.TrimSpace(p)
-		if e != "" {
-			this.Add(strings.ToLower(e))
+		if v, ok := sel(p); ok {
+			this.Add(v)
 		}
 	}
 	return this

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -104,7 +104,7 @@ github.com/evanphx/json-patch
 github.com/fatih/color
 # github.com/fsnotify/fsnotify v1.4.9
 github.com/fsnotify/fsnotify
-# github.com/gardener/controller-manager-library v0.2.1-0.20200724135643-ae8c0a569c8a
+# github.com/gardener/controller-manager-library v0.2.1-0.20200729132713-ba1a401efd11
 ## explicit
 github.com/gardener/controller-manager-library/hack
 github.com/gardener/controller-manager-library/pkg/certmgmt


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes changed semantic of StringSet.AddAllSplitted, which caused removal of empty realm.
This caused errors like Gardener DNS providers using realms annotations:

```
(status=Stale, message=errorneous entry preserved in provider: gardener/cml/resources/PERMISSION_DENIED: permission denied by realms: default/gardener.cloud:dns.gardener.cloud/DNSEntry/shoot--it--tmxj4-m4z/ingress <use> default/gardener.cloud:dns.gardener.cloud/DNSProvider/shoot--it--tmxj4-m4z/external) 
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fix incompatibility in controller-manager-library leading to "permission denied by realms" errors
```
