### PR TITLE
fixing dnsinfo addallsplitted semantics

### DIFF
--- a/pkg/dns/source/dnsinfo.go
+++ b/pkg/dns/source/dnsinfo.go
@@ -50,13 +50,13 @@ func (this *sourceReconciler) getDNSInfo(logger logger.LogContext, obj resources
 	}
 	annos := obj.GetAnnotations()
 	current.AnnotatedNames = utils.StringSet{}
-	current.AnnotatedNames.AddAllSplitted(annos[DNS_ANNOTATION])
+	current.AnnotatedNames.AddAllSplittedSelected(annos[DNS_ANNOTATION], utils.StandardNonEmptyStringElement)
 
 	addons := this.annotations.GetInfoFor(obj.ClusterKey())
 	if len(addons) > 0 {
 		for k, v := range addons {
 			if k == DNS_ANNOTATION {
-				current.AnnotatedNames.AddAllSplitted(v)
+				current.AnnotatedNames.AddAllSplittedSelected(v, utils.StandardNonEmptyStringElement)
 				logger.Infof("adding dns names by annotation injection: %s", v)
 			} else {
 				if _, ok := annos[k]; !ok {


### PR DESCRIPTION
**What this PR does / why we need it**:
After restoring the original semantics of addallsplitted, it was missed, that it is still needed to remove empty strings in the function `func (this *sourceReconciler) getDNSInfo()`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
