### PR TITLE
Add VPA to external-dns-management chart

### DIFF
--- a/charts/external-dns-management/templates/vpa.yaml
+++ b/charts/external-dns-management/templates/vpa.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.vpa.enabled }}
+apiVersion: "autoscaling.k8s.io/v1beta2"
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "external-dns-management.fullname" . }}-vpa
+  namespace: {{ .Release.Namespace }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "external-dns-management.fullname" . }}
+  updatePolicy:
+    updateMode: {{ .Values.vpa.updatePolicy.updateMode }}
+{{- end }}

--- a/charts/external-dns-management/values.yaml
+++ b/charts/external-dns-management/values.yaml
@@ -16,6 +16,11 @@ resources:
    cpu: 200m
    memory: 128Mi
 
+vpa:
+  enabled: true
+  updatePolicy:
+    updateMode: "Auto"
+
 nodeSelector: {}
 tolerations: []
 affinity: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add VPA to external-dns-management chart (enabled by default)

**Which issue(s) this PR fixes**:
Fixes #111

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action operator
A `VerticalPodAutoscaler` definition has been added to the Helm chart which is enabled by default. In order to disable it, set `.vpa.enabled=false` in the Helm chart values.
```

/area auto-scaling
/kind enhancement
/exp beginner
/topology seed
/platform all
/size xs
