### PR TITLE
VerticalPodAutoscaler defintion for dns-controller-manager

### DIFF
--- a/charts/external-dns-management/templates/deployment.yaml
+++ b/charts/external-dns-management/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 65534
       containers:
-      - name: {{ .Chart.Name }}
+      - name: dns-controller-manager
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:

--- a/charts/external-dns-management/templates/vpa.yaml
+++ b/charts/external-dns-management/templates/vpa.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.vpa.enabled }}
+apiVersion: "autoscaling.k8s.io/v1beta2"
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "external-dns-management.fullname" . }}-vpa
+  namespace: {{ .Release.Namespace }}
+spec:
+  resourcePolicy:
+    containerPolicies:
+      - containerName: '*'
+        minAllowed:
+          cpu: {{ .Values.vpa.minAllowed.cpu }}
+          memory: {{ .Values.vpa.minAllowed.memory }}
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "external-dns-management.fullname" . }}
+  updatePolicy:
+    updateMode: {{ .Values.vpa.updatePolicy.updateMode }}
+{{- end }}

--- a/charts/external-dns-management/values.yaml
+++ b/charts/external-dns-management/values.yaml
@@ -16,6 +16,14 @@ resources:
    cpu: 200m
    memory: 128Mi
 
+vpa:
+  enabled: true
+  minAllowed:
+    cpu: 20m
+    memory: 50Mi
+  updatePolicy:
+    updateMode: "Auto"
+
 nodeSelector: {}
 tolerations: []
 affinity: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
A `VerticalPodAutoscaler` definition is added to the external-dns-management chart.

**Which issue(s) this PR fixes**:
Fixes #111 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Added `VerticalPodAutoscaler` definition to the external-dns-management chart.
```
