### PR TITLE
Faster recovery if zones request fails temporarily and some fine tuning

### DIFF
--- a/pkg/dns/provider/ownercache_test.go
+++ b/pkg/dns/provider/ownercache_test.go
@@ -30,9 +30,9 @@ var _ = ginkgo.Describe("Owner cache", func() {
 		Ident: "TEST",
 	}
 	key1 := resources.NewKey(resources.NewGroupKind("", "test"), "test", "o1")
-	name1 := key1.ObjectName().String()
+	name1 := OwnerName(key1.Name())
 	key2 := resources.NewKey(resources.NewGroupKind("", "test"), "test", "o2")
-	name2 := key2.ObjectName().String()
+	name2 := OwnerName(key2.Name())
 
 	ginkgo.It("initializes the cache correctly", func() {
 		cache := NewOwnerCache(config)

--- a/pkg/dns/provider/state_entry.go
+++ b/pkg/dns/provider/state_entry.go
@@ -106,6 +106,12 @@ func (this *state) GetEntry(name resources.ObjectName) *Entry {
 	return this.entries[name]
 }
 
+func (this *state) SmartInfof(logger logger.LogContext, format string, args ...interface{}) {
+	this.lock.RLock()
+	defer this.lock.RUnlock()
+	this.smartInfof(logger, format, args...)
+}
+
 func (this *state) smartInfof(logger logger.LogContext, format string, args ...interface{}) {
 	if this.hasProviders() {
 		logger.Infof(format, args...)
@@ -258,7 +264,7 @@ func (this *state) HandleUpdateEntry(logger logger.LogContext, op string, object
 			}
 		}
 		if new.IsModified() && new.ZoneId() != "" {
-			this.smartInfof(logger, "trigger zone %q", new.ZoneId())
+			this.SmartInfof(logger, "trigger zone %q", new.ZoneId())
 			this.TriggerHostedZone(new.ZoneId())
 		} else {
 			logger.Debugf("skipping trigger zone %q because entry not modified", new.ZoneId())

--- a/pkg/dns/provider/state_owner.go
+++ b/pkg/dns/provider/state_owner.go
@@ -44,7 +44,8 @@ func (this *state) UpdateOwner(logger logger.LogContext, owner *dnsutils.DNSOwne
 		logger.Infof("entries synchronized")
 	}
 	changed, active := this.ownerCache.UpdateOwner(owner)
-	logger.Infof("update: changed owner ids %s, active owner ids %s", changed, active)
+	logger.Infof("update: changed owner ids %s", changed)
+	logger.Debugf("       active owner ids %s", active)
 	if len(changed) > 0 {
 		this.TriggerEntriesByOwner(logger, changed)
 		this.TriggerHostedZones()
@@ -54,7 +55,8 @@ func (this *state) UpdateOwner(logger logger.LogContext, owner *dnsutils.DNSOwne
 
 func (this *state) OwnerDeleted(logger logger.LogContext, key resources.ObjectKey) reconcile.Status {
 	changed, active := this.ownerCache.DeleteOwner(key)
-	logger.Infof("delete: changed owner ids %s, active owner ids %s", changed, active)
+	logger.Infof("delete: changed owner ids %s", changed)
+	logger.Debugf("       active owner ids %s", active)
 	if len(changed) > 0 {
 		this.TriggerEntriesByOwner(logger, changed)
 		this.TriggerHostedZones()
@@ -95,7 +97,7 @@ func startOwnerUpdater(ctx Context, ownerresc resources.Interface) chan OwnerCou
 				log.Infof("starting owner update for %d changes", len(changes))
 				for n, counts := range changes {
 					log.Infof("  updating owner counts %v for %s", counts, n)
-					_, _, err := ownerresc.ModifyStatusByName(resources.NewObjectName(n), func(data resources.ObjectData) (bool, error) {
+					_, _, err := ownerresc.ModifyStatusByName(resources.NewObjectName(string(n)), func(data resources.ObjectData) (bool, error) {
 						owner, ok := data.(*v1alpha1.DNSOwner)
 						if !ok {
 							return false, fmt.Errorf("invalid owner object type %T", data)

--- a/pkg/dns/provider/state_zone.go
+++ b/pkg/dns/provider/state_zone.go
@@ -179,7 +179,8 @@ func (this *state) reconcileZone(logger logger.LogContext, req *zoneReconciliati
 	req.zone.next = time.Now().Add(this.config.Delay)
 	ownerids := this.ownerCache.GetIds()
 	metrics.ReportZoneEntries(req.zone.ProviderType(), zoneid, len(req.entries))
-	logger.Infof("reconcile ZONE %s (%s) for %d dns entries (%d stale) (ownerids: %s)", req.zone.Id(), req.zone.Domain(), len(req.entries), len(req.stale), ownerids)
+	logger.Infof("reconcile ZONE %s (%s) for %d dns entries (%d stale)", req.zone.Id(), req.zone.Domain(), len(req.entries), len(req.stale))
+	logger.Debugf("    ownerids: %s", ownerids)
 	changes := NewChangeModel(logger, ownerids, req, this.config)
 	err := changes.Setup()
 	if err != nil {


### PR DESCRIPTION

**What this PR does / why we need it**:
Requests to provider backends are always cached to avoid overloading/throttling. Request failures are also cached for this reason. If now the request for all zones fails temporarily for a provider, the request failure was cached for half of the TTL (15 minutes by default).
This causes very long recovery times for the affected DNSProviders and DNSEntries.
To speedup recovery for short lived failure conditions, the request failure is now cached using an exponential backoff starting with seconds.

Additionally some fine tuning was done to reduce repeated logging of ownerids. The update of ownercounts and one minor data race in the provider state was fixed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Faster recovery if zones request fails temporarily for a provider
```
```improvement operator
Reduce repeated logging of ownerids
```
