### PR TITLE
Keep finalizer for DNSEntry if its DNSProvider is not ready

### DIFF
--- a/charts/external-dns-management/templates/clusterrole.yaml
+++ b/charts/external-dns-management/templates/clusterrole.yaml
@@ -32,6 +32,7 @@ rules:
   - dnsannotations
   - dnsannotations/status
   - dnsowners
+  - dnsowners/status
   verbs:
   - get
   - list

--- a/pkg/dns/provider/interface.go
+++ b/pkg/dns/provider/interface.go
@@ -225,6 +225,7 @@ type DNSProviders map[resources.ObjectName]DNSProvider
 type DNSProvider interface {
 	ObjectName() resources.ObjectName
 	Object() resources.Object
+	TypeCode() string
 
 	GetZones() DNSHostedZones
 
@@ -232,6 +233,7 @@ type DNSProvider interface {
 	ExecuteRequests(logger logger.LogContext, zone DNSHostedZone, state DNSZoneState, requests []*ChangeRequest) error
 
 	Match(dns string) int
+	IsValid() bool
 
 	AccountHash() string
 	MapTarget(t Target) Target

--- a/pkg/dns/provider/selection/selection.go
+++ b/pkg/dns/provider/selection/selection.go
@@ -57,11 +57,12 @@ type LightDNSHostedZone interface {
 	ForwardedDomains() []string
 }
 
-// CalcZoneAndDomainSelection calculates the included/excluded domains and zones for the given spec and zones.
+// CalcZoneAndDomainSelection calculates the effective included/excluded domains and zones for the given spec and
+// zones supported by a provider.
 func CalcZoneAndDomainSelection(spec v1alpha1.DNSProviderSpec, zones []LightDNSHostedZone) SelectionResult {
 	this := SelectionResult{
-		SpecDomainSel: prepareSelection(spec.Domains),
-		SpecZoneSel:   prepareSelection(spec.Zones),
+		SpecDomainSel: PrepareSelection(spec.Domains),
+		SpecZoneSel:   PrepareSelection(spec.Zones),
 		ZoneSel:       NewSubSelection(),
 		DomainSel:     NewSubSelection(),
 	}
@@ -162,7 +163,7 @@ outer:
 	return this
 }
 
-func prepareSelection(sel *v1alpha1.DNSSelection) SubSelection {
+func PrepareSelection(sel *v1alpha1.DNSSelection) SubSelection {
 	subSel := NewSubSelection()
 	if sel != nil {
 		subSel.Include = utils.NewStringSetByArray(sel.Include)

--- a/pkg/dns/provider/state_entry.go
+++ b/pkg/dns/provider/state_entry.go
@@ -143,7 +143,7 @@ func (this *state) AddEntryVersion(logger logger.LogContext, v *EntryVersion, st
 			if this.zones[new.activezone] != nil {
 				if this.HasFinalizer(new.Object()) {
 					logger.Infof("deleting delayed until entry deleted in provider")
-					this.outdated[new.ObjectName()] = new
+					this.outdated.AddEntry(new)
 					return new, reconcile.Succeeded(logger)
 				}
 			} else {
@@ -231,6 +231,9 @@ func (this *state) EntryPremise(e *dnsutils.DNSEntryObject) (*EntryPremise, erro
 		p.ptype = zone.ProviderType()
 		p.zoneid = zone.Id()
 		p.zonedomain = zone.Domain()
+	} else if provider != nil && !provider.IsValid() && e.Status().Zone != nil {
+		p.ptype = provider.TypeCode()
+		p.zoneid = *e.Status().Zone
 	}
 	return p, err
 }

--- a/pkg/dns/provider/state_zone.go
+++ b/pkg/dns/provider/state_zone.go
@@ -207,13 +207,13 @@ func (this *state) reconcileZone(logger logger.LogContext, req *zoneReconciliati
 		err = changes.Update(logger)
 	}
 
-	for k, e := range this.outdated {
-		if e.activezone == zoneid {
-			logger.Infof("cleanup outdated entry %q", k)
-			err := e.RemoveFinalizer()
-			if err == nil || errors.IsNotFound(err) {
-				delete(this.outdated, k)
-			}
+	outdatedEntries := EntryList{}
+	this.outdated.AddActiveZoneTo(zoneid, &outdatedEntries)
+	for _, e := range outdatedEntries {
+		logger.Infof("cleanup outdated entry %q", e.ObjectName())
+		err := e.RemoveFinalizer()
+		if err == nil || errors.IsNotFound(err) {
+			this.outdated.Delete(e)
 		}
 	}
 	if err == nil {

--- a/test/integration/singleEntryOneProvider_test.go
+++ b/test/integration/singleEntryOneProvider_test.go
@@ -83,7 +83,7 @@ var _ = Describe("SingleEntryOneProvider", func() {
 		})
 		Ω(err).Should(BeNil())
 
-		err = testEnv.AwaitEntryError(e.GetName())
+		err = testEnv.AwaitEntryStale(e.GetName())
 		Ω(err).Should(BeNil())
 
 		pr, err = testEnv.UpdateProviderSpec(pr, func(spec *v1alpha1.DNSProviderSpec) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
If the state of a DNSProvider goes to "error", its associated DNSEntries must keep their finalizers.
Otherwise if such a DNSEntry is deleted while it has no finalizer, no DNS records will be deleted in the DNS backend.
This can cause problems later on, if the DNSEntry is recreated with a different owner ("already busy for owner" error message)

Additional minor fixes:
- fixed data race with outdated entries field in provider state
- fixed clusterrole for resource dnsowners/status

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Keep finalizer for DNSEntry if its DNSProvider is not ready
```
