### PR TITLE
Restrict leader election to target cluster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go v1.19.41
 	github.com/cloudflare/cloudflare-go v0.11.4
 	github.com/emicklei/go-restful v2.9.6+incompatible // indirect
-	github.com/gardener/controller-manager-library v0.2.1-0.20200814085853-45032cce52c3
+	github.com/gardener/controller-manager-library v0.2.1-0.20200826092304-559a0c67bfe5
 	github.com/gophercloud/gophercloud v0.2.0
 	github.com/gophercloud/utils v0.0.0-20190527093828-25f1b77b8c03
 	github.com/imdario/mergo v0.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/gardener/controller-manager-library v0.2.1-0.20200814085853-45032cce52c3 h1:/FR89opaR3lbLX0is9f3ioc+i4k3cMpYxOKEwi6UzMg=
-github.com/gardener/controller-manager-library v0.2.1-0.20200814085853-45032cce52c3/go.mod h1:XMp1tPcX3SP/dMd+3id418f5Cqu44vydeTkBRbW8EvQ=
+github.com/gardener/controller-manager-library v0.2.1-0.20200826092304-559a0c67bfe5 h1:GoWGcENumGAEYjVWNQsp0UOOUnhMIshw43Vex90hUCA=
+github.com/gardener/controller-manager-library v0.2.1-0.20200826092304-559a0c67bfe5/go.mod h1:XMp1tPcX3SP/dMd+3id418f5Cqu44vydeTkBRbW8EvQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/pkg/dns/provider/controller.go
+++ b/pkg/dns/provider/controller.go
@@ -111,7 +111,6 @@ func DNSController(name string, factory DNSHandlerFactory) controller.Configurat
 		name = factory.Name()
 	}
 	cfg := controller.Configure(name).
-		RequireLease().
 		DefaultedStringOption(OPT_CLASS, dns.DEFAULT_CLASS, "Class identifier used to differentiate responsible controllers for entry resources").
 		DefaultedStringOption(OPT_IDENTIFIER, "dnscontroller", "Identifier used to mark DNS entries in DNS system").
 		DefaultedStringOption(OPT_CACHE_DIR, "", "Directory to store zone caches (for reload after restart)").
@@ -145,7 +144,8 @@ func DNSController(name string, factory DNSHandlerFactory) controller.Configurat
 		).
 		WorkerPool("dns", 1, 15*time.Minute).CommandMatchers(utils.NewStringGlobMatcher(CMD_HOSTEDZONE_PREFIX+"*")).
 		WorkerPool("statistic", 1, 0).Commands(CMD_STATISTIC).
-		OptionSource(FACTORY_OPTIONS, FactoryOptionSourceCreator(factory))
+		OptionSource(FACTORY_OPTIONS, FactoryOptionSourceCreator(factory)).
+		RequireLease(TARGET_CLUSTER)
 	return cfg
 }
 

--- a/pkg/dns/source/controller.go
+++ b/pkg/dns/source/controller.go
@@ -68,7 +68,6 @@ func DNSSourceController(source DNSSourceType, reconcilerType controller.Reconci
 	gk := source.GroupKind()
 	return controller.Configure(source.Name()).
 		After(annotation.CONTROLLER).
-		RequireLease().
 		DefaultedStringOption(OPT_CLASS, dns.DEFAULT_CLASS, "identifier used to differentiate responsible controllers for entries").
 		StringOption(OPT_TARGET_CLASS, "identifier used to differentiate responsible dns controllers for target entries").
 		StringArrayOption(OPT_EXCLUDE, "excluded domains").
@@ -89,7 +88,8 @@ func DNSSourceController(source DNSSourceType, reconcilerType controller.Reconci
 		Cluster(TARGET_CLUSTER).
 		CustomResourceDefinitions(ENTRY).
 		WorkerPool("targets", 2, 0).
-		ReconcilerWatch("entries", api.GroupName, api.DNSEntryKind)
+		ReconcilerWatch("entries", api.GroupName, api.DNSEntryKind).
+		RequireLease(TARGET_CLUSTER)
 }
 
 var SlaveResources = reconcilers.ClusterResources(TARGET_CLUSTER, ENTRY)

--- a/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/extension.go
+++ b/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/extension.go
@@ -249,7 +249,8 @@ func (this *Extension) Start(ctx context.Context) error {
 	for _, cntr := range this.controllers {
 		def := this.registrations[cntr.GetName()]
 		if def.RequireLease() {
-			this.getLeaseStartupGroup(cntr.GetMainCluster()).Add(cntr)
+			cluster := cntr.GetCluster(def.LeaseClusterName())
+			this.getLeaseStartupGroup(cluster).Add(cntr)
 		} else {
 			this.getPlainStartupGroup(cntr.GetMainCluster()).Add(cntr)
 		}

--- a/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/interface.go
+++ b/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/interface.go
@@ -166,6 +166,7 @@ type Definition interface {
 	RequiredControllers() []string
 	CustomResourceDefinitions() map[string][]*apiextensions.CustomResourceDefinitionVersions
 	RequireLease() bool
+	LeaseClusterName() string
 	FinalizerName() string
 	ActivateExplicitly() bool
 	ConfigOptions() map[string]OptionDefinition

--- a/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/syncer.go
+++ b/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/syncer.go
@@ -194,16 +194,16 @@ func (this *SyncRequest) update(log logger.LogContext, initiator resources.Objec
 
 	if this.resourceVersion == initiator.GetResourceVersion() {
 		if len(this.syncPoints) == 0 {
-			log.Info("synchronization %s(%s) for %s(%s) done", this.name, this.resource, initiator.ClusterKey(), this.resourceVersion)
+			log.Infof("synchronization %s(%s) for %s(%s) done", this.name, this.resource, initiator.ClusterKey(), this.resourceVersion)
 			return true, nil
 		}
-		log.Info("synchronization %s(%s) for %s(%s) still pending", this.name, this.resource, initiator.ClusterKey(), this.resourceVersion)
+		log.Infof("synchronization %s(%s) for %s(%s) still pending", this.name, this.resource, initiator.ClusterKey(), this.resourceVersion)
 		return false, nil
 	}
 	if this.resourceVersion == "" {
-		log.Info("synchronizing %s(%s) for %s(%s)", this.name, this.resource, initiator, initiator.GetResourceVersion())
+		log.Infof("synchronizing %s(%s) for %s(%s)", this.name, this.resource, initiator, initiator.GetResourceVersion())
 	} else {
-		log.Info("resynchronizing %s(%s) for %s(%s->%s)", this.name, this.resource, initiator, this.resourceVersion, initiator.GetResourceVersion())
+		log.Infof("resynchronizing %s(%s) for %s(%s->%s)", this.name, this.resource, initiator, this.resourceVersion, initiator.GetResourceVersion())
 	}
 	this.resourceVersion = initiator.GetResourceVersion()
 	reconcilers := this.controller.mappings.Get(this.cluster, this.resource.GroupKind())
@@ -216,7 +216,7 @@ func (this *SyncRequest) update(log logger.LogContext, initiator resources.Objec
 	}
 	this.syncPoints = SyncPoints{}
 	if len(list) == 0 {
-		log.Info("  no %s found for sync -> done", this.resource)
+		log.Infof("  no %s found for sync -> done", this.resource)
 		return true, nil
 	}
 	if len(reconcilers) == 1 {

--- a/vendor/github.com/gardener/controller-manager-library/pkg/resources/interface.go
+++ b/vendor/github.com/gardener/controller-manager-library/pkg/resources/interface.go
@@ -132,6 +132,7 @@ type Interface interface {
 	New(ObjectName) Object
 
 	GetInto(ObjectName, ObjectData) (Object, error)
+	GetInto1(ObjectData) (Object, error)
 
 	GetCached(interface{}) (Object, error)
 	// GET_ deprecrated: use Get
@@ -183,6 +184,7 @@ type Resources interface {
 	Decode(bytes []byte) (Object, error)
 
 	GetObjectInto(ObjectName, ObjectData) (Object, error)
+	GetObjectInto1(ObjectData) (Object, error)
 
 	GetObject(spec interface{}) (Object, error)
 	GetCachedObject(spec interface{}) (Object, error)

--- a/vendor/github.com/gardener/controller-manager-library/pkg/resources/res_cached.go
+++ b/vendor/github.com/gardener/controller-manager-library/pkg/resources/res_cached.go
@@ -55,7 +55,7 @@ func (this *_resource) GetCached(obj interface{}) (Object, error) {
 		if err := this.CheckOType(o); err != nil {
 			return nil, err
 		}
-		return this.helper.ObjectAsResource(o), nil
+		return this.getCached(o.GetNamespace(), o.GetName())
 	case ObjectKey:
 		if o.GroupKind() != this.GroupKind() {
 			return nil, errors.ErrResourceMismatch.New(this.GroupVersionKind(), o.GroupKind())

--- a/vendor/github.com/gardener/controller-manager-library/pkg/resources/res_uncached.go
+++ b/vendor/github.com/gardener/controller-manager-library/pkg/resources/res_uncached.go
@@ -158,6 +158,16 @@ func (this *AbstractResource) GetInto(name ObjectName, obj ObjectData) (Object, 
 	return this.helper.Get(name.Namespace(), name.Name(), obj)
 }
 
+func (this *AbstractResource) GetInto1(obj ObjectData) (Object, error) {
+	if o, ok := obj.(Object); ok {
+		obj = o.Data()
+	}
+	if err := this.CheckOType(obj, true); err != nil {
+		return nil, err
+	}
+	return this.helper.Get(obj.GetNamespace(), obj.GetName(), obj)
+}
+
 func (this *AbstractResource) Get_(obj interface{}) (Object, error) {
 	return this.Get(obj)
 }

--- a/vendor/github.com/gardener/controller-manager-library/pkg/resources/resources.go
+++ b/vendor/github.com/gardener/controller-manager-library/pkg/resources/resources.go
@@ -222,6 +222,15 @@ func (this *_resources) GetObject(spec interface{}) (Object, error) {
 	return h.Get(spec)
 }
 
+func (this *_resources) GetObjectInto1(obj ObjectData) (Object, error) {
+	h, err := this.GetByExample(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	return h.GetInto1(obj)
+}
+
 func (this *_resources) GetObjectInto(name ObjectName, obj ObjectData) (Object, error) {
 	h, err := this.GetByExample(obj)
 	if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -104,7 +104,7 @@ github.com/evanphx/json-patch
 github.com/fatih/color
 # github.com/fsnotify/fsnotify v1.4.9
 github.com/fsnotify/fsnotify
-# github.com/gardener/controller-manager-library v0.2.1-0.20200814085853-45032cce52c3
+# github.com/gardener/controller-manager-library v0.2.1-0.20200826092304-559a0c67bfe5
 ## explicit
 github.com/gardener/controller-manager-library/hack
 github.com/gardener/controller-manager-library/pkg/certmgmt


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the leader election happens for the DNS controllers on the target cluster, but on the default cluster for the source controllers.
With this PR the leader election is always performed on the target cluster (seed in Gardener context).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Restrict leader election to target cluster
```
