### PR TITLE
set zone domain for raw provider

### DIFF
--- a/pkg/dns/provider/raw/execution.go
+++ b/pkg/dns/provider/raw/execution.go
@@ -58,6 +58,7 @@ func NewExecution(logger logger.LogContext, e Executor, state *ZoneState, zone p
 		executor:   e,
 		zone:       zone,
 		state:      state,
+		domain:     zone.Domain(),
 		results:    map[string]*result{},
 		additions:  RecordSet{},
 		updates:    RecordSet{},


### PR DESCRIPTION
**What this PR does / why we need it**:
On factoring out of the raw provider, it was forgotten to set the zone domain.
This leads to crashes of the alicloud-dns provider if it tried to create a wildcard domain for the base domain of the zone.
This also effects the other providers using the raw provider: cloudflare-dns, infoblox

**Which issue(s) this PR fixes**:
Fixes #121

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
alicloud-dns/cloudflare-dns/infoblox providers: fix creation of DNSEntry for wildcard domain for the base domain of a hosted zone
```
