### PR TITLE
use component prefix for prometheus metrics names

### DIFF
--- a/pkg/dns/provider/state_zone.go
+++ b/pkg/dns/provider/state_zone.go
@@ -178,7 +178,7 @@ func (this *state) reconcileZone(logger logger.LogContext, req *zoneReconciliati
 	}
 	req.zone.next = time.Now().Add(this.config.Delay)
 	ownerids := this.ownerCache.GetIds()
-	metrics.ReportZoneEntries(req.zone.ProviderType(), zoneid, len(req.entries))
+	metrics.ReportZoneEntries(req.zone.ProviderType(), zoneid, len(req.entries), len(req.stale))
 	logger.Infof("reconcile ZONE %s (%s) for %d dns entries (%d stale)", req.zone.Id(), req.zone.Domain(), len(req.entries), len(req.stale))
 	logger.Debugf("    ownerids: %s", ownerids)
 	changes := NewChangeModel(logger, ownerids, req, this.config)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR renames the component specific prometheus metrics to follow the best practices.
Additionally a metrics for stale entries per hosted zone has been added.
The new metrics names are:
```
# HELP external_dns_management_account_providers Total number of providers per account
# HELP external_dns_management_dns_entries Total number of dns entries per hosted zone
# HELP external_dns_management_dns_entries_stale Total number of stale dns entries per hosted zone
# HELP external_dns_management_dns_owners Total number of dns entries per owner
# HELP external_dns_management_total_provider_requests Total requests per provider type and credential set
```

**Which issue(s) this PR fixes**:
Fixes #125 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
use component prefix for prometheus metrics names
```
