### PR TITLE
Restrict caching to target namespace for DNS source controllers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go v1.19.41
 	github.com/cloudflare/cloudflare-go v0.11.4
 	github.com/emicklei/go-restful v2.9.6+incompatible // indirect
-	github.com/gardener/controller-manager-library v0.2.1-0.20201001155040-bf2105cb64b4
+	github.com/gardener/controller-manager-library v0.2.1-0.20201009144316-bfa57b871e60
 	github.com/gophercloud/gophercloud v0.2.0
 	github.com/gophercloud/utils v0.0.0-20190527093828-25f1b77b8c03
 	github.com/imdario/mergo v0.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/gardener/controller-manager-library v0.2.1-0.20201001155040-bf2105cb64b4 h1:oqpO2lMsVq8epGelI5QgTWptLy+OR+3ppniMGJW4Tlw=
-github.com/gardener/controller-manager-library v0.2.1-0.20201001155040-bf2105cb64b4/go.mod h1:XMp1tPcX3SP/dMd+3id418f5Cqu44vydeTkBRbW8EvQ=
+github.com/gardener/controller-manager-library v0.2.1-0.20201009144316-bfa57b871e60 h1:JONXsPxZeieknWEiqPy07HWMUsBBaLSTNN5yXLF90js=
+github.com/gardener/controller-manager-library v0.2.1-0.20201009144316-bfa57b871e60/go.mod h1:XMp1tPcX3SP/dMd+3id418f5Cqu44vydeTkBRbW8EvQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/pkg/dns/source/reconciler.go
+++ b/pkg/dns/source/reconciler.go
@@ -38,6 +38,12 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 )
 
+func NewSlaveAccessSpec(c controller.Interface, sourceType DNSSourceType) reconcilers.SlaveAccessSpec {
+	spec := reconcilers.NewSlaveAccessSpec(c, sourceType.Name(), SlaveResources, MasterResourcesType(sourceType.GroupKind()))
+	spec.Namespace, _ = c.GetStringOption(OPT_NAMESPACE)
+	return spec
+}
+
 func SourceReconciler(sourceType DNSSourceType, rtype controller.ReconcilerType) controller.ReconcilerType {
 	return func(c controller.Interface) (reconcile.Interface, error) {
 		source, err := sourceType.Create(c)
@@ -54,7 +60,7 @@ func SourceReconciler(sourceType DNSSourceType, rtype controller.ReconcilerType)
 		classes := controller.NewClassesByOption(c, OPT_CLASS, dns.CLASS_ANNOTATION, dns.DEFAULT_CLASS)
 		c.SetFinalizerHandler(controller.NewFinalizerForClasses(c, c.GetDefinition().FinalizerName(), classes))
 		targetclasses := controller.NewTargetClassesByOption(c, OPT_TARGET_CLASS, dns.CLASS_ANNOTATION, classes)
-		slaves := reconcilers.NewSlaveAccess(c, sourceType.Name(), SlaveResources, MasterResourcesType(sourceType.GroupKind()))
+		slaves := reconcilers.NewSlaveAccessBySpec(c, NewSlaveAccessSpec(c, sourceType))
 		reconciler := &sourceReconciler{
 			SlaveAccess:   slaves,
 			classes:       classes,

--- a/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile/reconcilers/usagecache.go
+++ b/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile/reconcilers/usagecache.go
@@ -8,7 +8,6 @@ package reconcilers
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
@@ -40,6 +39,7 @@ type UsedExtractorFactory func(controller.Interface) resources.UsedExtractor
 
 type UsageAccessSpec struct {
 	Name                string
+	Namespace           string
 	MasterResources     Resources
 	Extractor           resources.UsedExtractor
 	ExtractorFactory    UsedExtractorFactory
@@ -78,7 +78,7 @@ func (this *UsageAccess) setupUsageCache() interface{} {
 
 	this.Infof("setup %s usage cache", this.name)
 	for _, r := range this.master_resources.resources {
-		list, _ := r.ListCached(labels.Everything())
+		list, _ := listCachedWithNamespace(r, this.spec.Namespace)
 		cache.Setup(list)
 	}
 	this.Infof("found %d %s(s) for %d objects", cache.UsedCount(), this.name, cache.Size())

--- a/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile/reconcilers/utils.go
+++ b/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile/reconcilers/utils.go
@@ -9,6 +9,7 @@ package reconcilers
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
@@ -32,4 +33,11 @@ func ClusterResources(cluster string, gks ...schema.GroupKind) Resources {
 
 func MainResources(gks ...schema.GroupKind) Resources {
 	return ClusterResources("", gks...)
+}
+
+func listCachedWithNamespace(r resources.Interface, namespace string) ([]resources.Object, error) {
+	if namespace != "" {
+		return r.Namespace(namespace).ListCached(labels.Everything())
+	}
+	return r.ListCached(labels.Everything())
 }

--- a/vendor/github.com/gardener/controller-manager-library/pkg/resources/resource.go
+++ b/vendor/github.com/gardener/controller-manager-library/pkg/resources/resource.go
@@ -7,6 +7,7 @@
 package resources
 
 import (
+	"fmt"
 	"reflect"
 
 	"k8s.io/api/core/v1"
@@ -96,7 +97,11 @@ func (this *_resource) AddRawEventHandler(handlers cache.ResourceEventHandlerFun
 }
 
 func (this *_resource) AddRawSelectedEventHandler(handlers cache.ResourceEventHandlerFuncs, namespace string, optionsFunc TweakListOptionsFunc) error {
-	logger.Infof("adding watch for %s", this.GroupVersionKind())
+	withNamespace := "global"
+	if namespace != "" {
+		withNamespace = fmt.Sprintf("namespace %s", namespace)
+	}
+	logger.Infof("adding watch for %s (cluster %s, %s)", this.GroupVersionKind(), this.GetCluster().GetId(), withNamespace)
 	informer, err := this.helper.Internal.I_getInformer(namespace, optionsFunc)
 	if err != nil {
 		return err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -104,7 +104,7 @@ github.com/evanphx/json-patch
 github.com/fatih/color
 # github.com/fsnotify/fsnotify v1.4.9
 github.com/fsnotify/fsnotify
-# github.com/gardener/controller-manager-library v0.2.1-0.20201001155040-bf2105cb64b4
+# github.com/gardener/controller-manager-library v0.2.1-0.20201009144316-bfa57b871e60
 ## explicit
 github.com/gardener/controller-manager-library/hack
 github.com/gardener/controller-manager-library/pkg/certmgmt


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the shoot-dns-service produces a lot of logging because DNSEntries on the target cluster are watched for all namespaces.
With this PR the watched of the slave caches are restricted to the target namespace if specified explicitly.
This should reduce both CPU load and logging activities of all DNS source controllers.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
restrict caching to target namespace for DNS source controllers to reduce logging
```
