### PR TITLE
infoblox: allow SSL_VERIFY to be specified in the DNSProvider secret

### DIFF
--- a/docs/infoblox/README.md
+++ b/docs/infoblox/README.md
@@ -20,12 +20,21 @@ type: Opaque
 data:
   USERNAME: bXktdGVjaG5pY2FsLXVzZXI=
   PASSWORD: bXktcGFzc3dvcmQ=
+  # The providerConfig parameters of the DNS provider can be specified here alternatively (not recommenended)
+  #HOST: MTAuMTEuMjMuNDU=
+  #PORT: NDQz
+  #VERSION: Mi4xMA==
+  #VIEW: ZGVmYXVsdA==
+  #SSL_VERIFY: ZmFsc2U=
+  #HTTP_POOL_CONNECTIONS: MTA=
+  #HTTP_REQUEST_TIMEOUT: NjA=
+  #PROXY_URL: aHR0cDovLzEwLjEuMi4zOjg4ODg=
 ```
 
 ## Create DNS provider
 
-The Infoblox `DNSProvider` needs additional parameters as `providerConfig`. `host` and `version` parameters is required.
-All others are optional.
+The Infoblox `DNSProvider` needs additional parameters as `providerConfig`. The `host` parameter is required.
+The `version` parameter is defaulted to `2.10`, but can be overwritten. All others are optional.
 
 ```yaml
 apiVersion: dns.gardener.cloud/v1alpha1
@@ -41,11 +50,11 @@ spec:
     host: 10.11.23.45
     #port: 443
     
-    # sslVerify is the flag to use HTTPS for API reqeust. Set to true by default.
+    # sslVerify is the flag to use HTTPS for API request. Set to true by default.
     #sslVerify: true
 
-    # version is the api version
-    version: "2.10"
+    # version is the api version. Set to "2.10" by default.
+    #version: "2.10"
    
     # view is the Infoblox DNS view to use
     #view: default

--- a/pkg/controller/provider/infoblox/handler.go
+++ b/pkg/controller/provider/infoblox/handler.go
@@ -87,7 +87,7 @@ func NewHandler(config *provider.DNSHandlerConfig) (provider.DNSHandler, error) 
 		return nil, err
 	}
 
-	if err := config.FillRequiredProperty(&infobloxConfig.Version, "VERSION", "password"); err != nil {
+	if err := config.FillDefaultedProperty(&infobloxConfig.Version, "2.10", "VERSION", "version"); err != nil {
 		return nil, err
 	}
 	if err := config.FillDefaultedProperty(&infobloxConfig.View, "default", "VIEW", "view"); err != nil {
@@ -106,6 +106,9 @@ func NewHandler(config *provider.DNSHandlerConfig) (provider.DNSHandler, error) 
 		return nil, err
 	}
 	if err := config.FillDefaultedProperty(&infobloxConfig.ProxyURL, "", "PROXY_URL", "proxy_url"); err != nil {
+		return nil, err
+	}
+	if err := config.FillDefaultedBoolProperty(&infobloxConfig.SSLVerify, true, "SSL_VERIFY", "ssl_verify"); err != nil {
 		return nil, err
 	}
 

--- a/pkg/dns/provider/config.go
+++ b/pkg/dns/provider/config.go
@@ -100,6 +100,14 @@ func (c *DNSHandlerConfig) GetRequiredIntProperty(key string, altKeys ...string)
 	return strconv.Atoi(value)
 }
 
+func (c *DNSHandlerConfig) GetRequiredBoolProperty(key string, altKeys ...string) (bool, error) {
+	value, err := c.getProperty(key, true, altKeys...)
+	if err != nil {
+		return false, err
+	}
+	return strconv.ParseBool(value)
+}
+
 func (c *DNSHandlerConfig) GetDefaultedProperty(key string, def string, altKeys ...string) string {
 	value, _ := c.getProperty(key, false, altKeys...)
 	if value == "" {
@@ -114,6 +122,14 @@ func (c *DNSHandlerConfig) GetDefaultedIntProperty(key string, def int, altKeys 
 		return def, nil
 	}
 	return strconv.Atoi(value)
+}
+
+func (c *DNSHandlerConfig) GetDefaultedBoolProperty(key string, def bool, altKeys ...string) (bool, error) {
+	value, _ := c.getProperty(key, false, altKeys...)
+	if value == "" {
+		return def, nil
+	}
+	return strconv.ParseBool(value)
 }
 
 func (c *DNSHandlerConfig) getProperty(key string, required bool, altKeys ...string) (string, error) {
@@ -208,6 +224,23 @@ func (c *DNSHandlerConfig) FillDefaultedProperty(target **string, def string, pr
 			return nil
 		}
 		*target = &value
+		return nil
+	}
+	return c.checkNotDefinedInConfig(prop, alt...)
+}
+
+func (c *DNSHandlerConfig) FillDefaultedBoolProperty(target **bool, def bool, prop string, alt ...string) error {
+	if *target == nil || **target == def {
+		value := c.GetProperty(prop, alt...)
+		if value == "" {
+			*target = &def
+			return nil
+		}
+		b, err := strconv.ParseBool(value)
+		if err != nil {
+			return err
+		}
+		*target = &b
 		return nil
 	}
 	return c.checkNotDefinedInConfig(prop, alt...)


### PR DESCRIPTION
**What this PR does / why we need it**:
To use infoblox-dns as a provider in Gardener, all parameters must be specified in the secret of the DNSProvider currently.
The `providerConfig` is not yet supported in the Gardener code creating the DNSProvider resources.
This PR adds the one missing parameter: `SSL_VERIFY`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
infoblox: allow SSL_VERIFY to be specified in the DNSProvider secret
```
