### PR TITLE
Don't set new DNSEntry to invalid if DNSOwner is pending

### DIFF
--- a/pkg/dns/provider/entry.go
+++ b/pkg/dns/provider/entry.go
@@ -336,7 +336,7 @@ func validate(logger logger.LogContext, state *state, entry *EntryVersion, p *En
 	}
 
 	if utils.StringValue(effspec.OwnerId) != "" {
-		if !state.ownerCache.IsResponsibleFor(*effspec.OwnerId) {
+		if !state.ownerCache.IsResponsibleFor(*effspec.OwnerId) && !state.ownerCache.IsResponsiblePendingFor(*effspec.OwnerId) {
 			err = fmt.Errorf("unknown owner id '%s'", *effspec.OwnerId)
 		}
 	}

--- a/pkg/dns/provider/state.go
+++ b/pkg/dns/provider/state.go
@@ -44,6 +44,7 @@ type zoneReconciliation struct {
 	zone      *dnsHostedZone
 	providers DNSProviders
 	entries   Entries
+	ownerIds  utils.StringSet
 	stale     DNSNames
 	dedicated bool
 	deleting  bool

--- a/pkg/dns/provider/state_owner.go
+++ b/pkg/dns/provider/state_owner.go
@@ -43,7 +43,9 @@ func (this *state) UpdateOwner(logger logger.LogContext, owner *dnsutils.DNSOwne
 		}
 		logger.Infof("entries synchronized")
 	}
+	this.lock.Lock()
 	changed, active := this.ownerCache.UpdateOwner(owner)
+	this.lock.Unlock()
 	logger.Infof("update: changed owner ids %s", changed)
 	logger.Debugf("       active owner ids %s", active)
 	if len(changed) > 0 {
@@ -54,7 +56,9 @@ func (this *state) UpdateOwner(logger logger.LogContext, owner *dnsutils.DNSOwne
 }
 
 func (this *state) OwnerDeleted(logger logger.LogContext, key resources.ObjectKey) reconcile.Status {
+	this.lock.Lock()
 	changed, active := this.ownerCache.DeleteOwner(key)
+	this.lock.Unlock()
 	logger.Infof("delete: changed owner ids %s", changed)
 	logger.Debugf("       active owner ids %s", active)
 	if len(changed) > 0 {

--- a/pkg/dns/provider/state_owner.go
+++ b/pkg/dns/provider/state_owner.go
@@ -37,6 +37,7 @@ import (
 func (this *state) UpdateOwner(logger logger.LogContext, owner *dnsutils.DNSOwnerObject, setup bool) reconcile.Status {
 	if !setup && !this.ownerCache.IsResponsibleFor(owner.GetOwnerId()) && owner.IsActive() {
 		logger.Infof("would activate new owner -> ensure all entries are synchronized")
+		this.ownerCache.SetPending(owner.GetOwnerId())
 		done, err := this.context.Synchronize(logger, SYNC_ENTRIES, owner.Object)
 		if !done || err != nil {
 			return reconcile.DelayOnError(logger, err)

--- a/pkg/dns/provider/state_zone.go
+++ b/pkg/dns/provider/state_zone.go
@@ -66,6 +66,7 @@ func (this *state) GetZoneReconcilation(logger logger.LogContext, zoneid string)
 	this.lock.RLock()
 	defer this.lock.RUnlock()
 
+	req.ownerIds = this.ownerCache.GetIds()
 	hasProviders := this.hasProviders()
 	zone := this.zones[zoneid]
 	if zone == nil {
@@ -177,7 +178,7 @@ func (this *state) reconcileZone(logger logger.LogContext, req *zoneReconciliati
 		return nil
 	}
 	req.zone.next = time.Now().Add(this.config.Delay)
-	ownerids := this.ownerCache.GetIds()
+	ownerids := req.ownerIds
 	metrics.ReportZoneEntries(req.zone.ProviderType(), zoneid, len(req.entries), len(req.stale))
 	logger.Infof("reconcile ZONE %s (%s) for %d dns entries (%d stale)", req.zone.Id(), req.zone.Domain(), len(req.entries), len(req.stale))
 	logger.Debugf("    ownerids: %s", ownerids)


### PR DESCRIPTION
**What this PR does / why we need it**:
Improve parallel reconcilation of DNSEntry and DNSOwner.
If on reconciling a DNSEntry the referenced DNSOwner is not activated but already reconciled ("pending"), the DNSEntry is not marked as invalid. 

**Which issue(s) this PR fixes**:
Fixes #134 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
don't set new DNSEntry to invalid if DNSOwner is pending
```
