### PR TITLE
Environment variables configurable in values-file of Helm

### DIFF
--- a/charts/external-dns-management/templates/deployment.yaml
+++ b/charts/external-dns-management/templates/deployment.yaml
@@ -871,6 +871,10 @@ spec:
         ports:
         - containerPort: {{ .Values.configuration.serverPortHttp }}
           protocol: TCP
+        {{- if .Values.env }}
+        env:
+        {{- toYaml .Values.env | nindent 8 }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/external-dns-management/values.yaml
+++ b/charts/external-dns-management/values.yaml
@@ -8,6 +8,8 @@ image:
   tag: v0.7.22-master
   pullPolicy: IfNotPresent
 
+env: []
+
 resources:
   requests:
    cpu: 100m


### PR DESCRIPTION
**What this PR does / why we need it**:

This change allows us to set environment variables to the deployment. For example we could use `http_proxy`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Environment variables can now be set via values.yaml
```
