### PR TITLE
Moving DNS docs from /documentation

### DIFF
--- a/docs/installation/setup.md
+++ b/docs/installation/setup.md
@@ -1,0 +1,86 @@
+# Gardener DNS Management for Shoots
+
+## Introduction
+Gardener allows Shoot clusters to request DNS names for Ingresses and Services out of the box. 
+To support this the gardener must be installed with the `shoot-dns-service`
+extension.
+This extension uses the seed's dns management infrastructure to maintain DNS
+names for shoot clusters. So, far only the external DNS domain of a shoot
+(already used for the kubernetes api server and ingress DNS names) can be used
+for managed DNS names.
+
+<style>
+#body-inner blockquote {
+    border: 0;
+    padding: 10px;
+    margin-top: 40px;
+    margin-bottom: 40px;
+    border-radius: 4px;
+    background-color: rgba(0,0,0,0.05);
+    box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+    position:relative;
+    padding-left:60px;
+}
+#body-inner blockquote:before {
+    content: "!";
+    font-weight: bold;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    background-color: #00a273;
+    color: white;
+    vertical-align: middle;
+    margin: auto;
+    width: 36px;
+    font-size: 30px;
+    text-align: center;
+}
+</style>
+
+## Configuration
+
+A general description for configuring the DNS management of the
+gardener can be found [here](https://github.com/gardener/gardener/blob/master/docs/extensions/dns.md).
+
+To generally enable the DNS management for shoot objects the 
+`shoot-dns-service` extension must be registered by providing an
+appropriate [extension registration](https://github.com/gardener/gardener-extension-shoot-dns-service/blob/master/example/controller-registration.yaml) in the garden cluster.
+
+Here it is possible to decide whether the extension should be always available
+for all shoots or whether the extension must be separately enabled per shoot.
+
+If the extension should be used for all shoots the registration must set the *globallyEnabled* flag to `true`.
+
+```yaml
+spec:
+  resources:
+    - kind: Extension
+      type: shoot-dns-service
+      globallyEnabled: true
+```
+
+### Providing Base Domains usable for a Shoot
+
+So, far only the external DNS domain of a shoot already used
+for the kubernetes api server and ingress DNS names can be used for managed
+DNS names. This is either the shoot domain as subdomain of the default domain
+configured for the gardener installation or a dedicated domain with dedicated
+access credentials configured for a dedicated shoot via the shoot manifest.
+
+### Shoot Feature Gate
+
+If the shoot DNS feature is not globally enabled by default (depends on the 
+extension registration on the garden cluster), it must be enabled per shoot.
+
+To enable the feature for a shoot, the shoot manifest must explicitly add the
+`shoot-dns-service` extension.
+
+```yaml
+...
+spec:
+  extensions:
+    - type: shoot-dns-service
+...
+```
+

--- a/docs/usage/dns_names.md
+++ b/docs/usage/dns_names.md
@@ -1,0 +1,117 @@
+# Request DNS Names in Shoot Clusters
+
+## Introduction
+Within a shoot cluster, it is possible to request DNS records via the following resource types:
+- [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/)
+- [Service](https://kubernetes.io/docs/concepts/services-networking/service/)
+- [DNSEntry](https://github.com/gardener/external-dns-management/blob/master/examples/40-entry-dns.yaml)
+
+It is necessary that the Gardener installation your shoot cluster runs in is equipped with a `shoot-dns-service` extension. This extension uses the seed's dns management infrastructure to maintain DNS names for shoot clusters. Please ask your Gardener operator if the extension is available in your environment.
+
+## Shoot Feature Gate
+
+In some Gardener setups the `shoot-dns-service` extension is not enabled globally and thus must be configured per shoot cluster. Please adapt the shoot specification by the configuration shown below to activate the extension individually.
+
+```yaml
+kind: Shoot
+...
+spec:
+  extensions:
+    - type: shoot-dns-service
+...
+```
+
+## DNS providers, domain scope
+
+Gardener can only manage DNS records on your behalf if you have proper DNS providers in place. Please consult [this page](../dns_providers) for more information.
+
+## Request DNS records via Service/Ingress resources
+
+To request a DNS name for an Ingress or Service object in the shoot cluster
+it must be annotated with the DNS class `garden` and an annotation denoting
+the desired DNS names.
+
+For a Service (it must have the type `LoadBalancer`) this looks like this:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    dns.gardener.cloud/class: garden
+    dns.gardener.cloud/dnsnames: my.subdomain.for.shootsomain.cloud
+  name: my-service
+  namespace: default
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 80
+  type: LoadBalancer
+```
+
+The *dnsnames* annotation accepts a comma-separated list of DNS names, if
+multiple names are required.
+
+For an Ingress, the dns names are already declared in the specification.
+Nevertheless the *dnsnames* annotation must be present. Here a subset of the 
+dns names of the ingress can be specified. If DNS names for all names are
+desired, the value `all` can be used.
+
+If one of the accepted dns names is a direct subname of the shoot's ingress
+domain, this is already handled by the standard wildcard entry for the ingress
+domain. Therefore this name should be excluded from the *dnsnames* list in the
+annotation. If only this dns name is configured in the ingress, no explicit 
+dns entry is required, and the dns annotations should be omitted at all.
+
+## Request DNS records via DNSEntry resources
+
+```yaml
+apiVersion: dns.gardener.cloud/v1alpha1
+kind: DNSEntry
+metadata:
+  annotations:
+    dns.gardener.cloud/class: garden
+  name: dns
+  namespace: default
+spec:
+  dnsName: "my.subdomain.for.shootsomain.cloud"
+  ttl: 600
+  # txt records, either text or targets must be specified
+# text:
+# - foo-bar
+  targets:
+  # target records (CNAME or A records)
+  - 8.8.8.8
+```
+
+## DNS record events
+
+The DNS controller publishes Kubernetes events for the resource which requested the DNS record (Ingress, Service, DNSEntry). These events reveal more information about the DNS requests being processed and are especially useful to check any kind of misconfiguration, e.g. requests for a domain you don't own.
+
+Events for a successfully created DNS record:
+```
+$ kubectl -n default describe service my-service
+
+Events:
+  Type    Reason          Age                From                    Message
+  ----    ------          ----               ----                    -------
+  Normal  dns-annotation  19s                dns-controller-manager  my.subdomain.for.shootsomain.cloud: dns entry is pending
+  Normal  dns-annotation  19s (x3 over 19s)  dns-controller-manager  my.subdomain.for.shootsomain.cloud: dns entry pending: waiting for dns reconciliation
+  Normal  dns-annotation  9s (x3 over 10s)   dns-controller-manager  my.subdomain.for.shootsomain.cloud: dns entry active
+```
+
+Please note, events vanish after their retention period (usually `1h`).
+
+## DNSEntry status
+
+`DNSEntry` resources offer a `.status` sub-resource which can be used to check the current state of the object.
+
+Status of a erroneous `DNSEntry`.
+```
+  status:
+    message: No responsible provider found
+    observedGeneration: 3
+    provider: remote
+    state: Error
+```

--- a/docs/usage/dns_providers.md
+++ b/docs/usage/dns_providers.md
@@ -1,0 +1,39 @@
+# DNS Providers
+
+## Introduction
+
+Gardener can manage DNS records on your behalf, so that you can request them via different resource types (see [here](../dns_names)) within the shoot cluster. The domains for which you are permitted to request records, are however restricted and depend on the DNS provider configuration.
+
+## Shoot provider
+
+By default, every shoot cluster is equipped with a default provider. It is the very same provider that manages the shoot cluster's `kube-apiserver` public DNS record (DNS address in your Kubeconfig).
+
+```
+kind: Shoot
+...
+dns:
+  domain: shoot.project.default-domain.gardener.cloud
+```
+
+You are permitted to request any sub-domain of `.dns.domain` that is not already taken (e.g. `api.shoot.project.default-domain.gardener.cloud`, `*.ingress.shoot.project.default-domain.gardener.cloud`) with this provider.
+
+## Additional providers
+
+If you need to request DNS records for domains not managed by the [default provider](#Shoot-provider), additional providers must be configured in the shoot specification.
+
+For example:
+```
+kind: Shoot
+...
+dns:
+  domain: shoot.project.default-domain.gardener.cloud
+  providers:
+  - secretName: my-aws-account
+    type: aws-route53
+  - secretName: my-gcp-account
+    type: google-clouddns
+```
+
+> Please consult the [API-Reference](https://gardener.cloud/documentation/references/core/#core.gardener.cloud/v1beta1.DNSProvider) to get a complete list of supported fields and configuration options.
+
+Referenced secrets should exist in the project namespace in the Garden cluster and must comply with the provider specific credentials format. The **External-DNS-Management** project provides corresponding examples ([20-secret-\<provider-name>-credentials.yaml](https://github.com/gardener/external-dns-management/tree/master/examples)) for known providers.


### PR DESCRIPTION
**What this PR does / why we need it**:
As per the new documentation-as-code concept, component-specific documentation resides along the code it describes. Only cross-cutting topics will stay in the /documentation repo.
