### PR TITLE
infoblox: set TTL on record creation

### DIFF
--- a/pkg/controller/provider/infoblox/access.go
+++ b/pkg/controller/provider/infoblox/access.go
@@ -62,17 +62,17 @@ func (this *access) DeleteRecord(r raw.Record) error {
 	return err
 }
 
-func (this *access) NewRecord(fqdn string, rtype string, value string, zone provider.DNSHostedZone, ttl int64) raw.Record {
+func (this *access) NewRecord(fqdn string, rtype string, value string, zone provider.DNSHostedZone, ttl int64) (record raw.Record) {
 	switch rtype {
 	case dns.RS_A:
-		return (*RecordA)(ibclient.NewRecordA(ibclient.RecordA{
+		record = (*RecordA)(ibclient.NewRecordA(ibclient.RecordA{
 			Name:     fqdn,
 			Ipv4Addr: value,
 			//Zone:     zone.Key(),
 			View: this.view,
 		}))
 	case dns.RS_CNAME:
-		return (*RecordCNAME)(ibclient.NewRecordCNAME(ibclient.RecordCNAME{
+		record = (*RecordCNAME)(ibclient.NewRecordCNAME(ibclient.RecordCNAME{
 			Name:      fqdn,
 			Canonical: value,
 			//Zone:      zone.Key(),
@@ -82,12 +82,15 @@ func (this *access) NewRecord(fqdn string, rtype string, value string, zone prov
 		if n, err := strconv.Unquote(value); err == nil && !strings.Contains(value, " ") {
 			value = n
 		}
-		return (*RecordTXT)(ibclient.NewRecordTXT(ibclient.RecordTXT{
+		record = (*RecordTXT)(ibclient.NewRecordTXT(ibclient.RecordTXT{
 			Name: fqdn,
 			Text: value,
 			//Zone: zone.Key(),
 			View: this.view,
 		}))
 	}
-	return nil
+	if record != nil {
+		record.SetTTL(int(ttl))
+	}
+	return
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The TTL was not set on DNS record creation for the Infoblox provider.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
infoblox: set TTL on record creation explicitly
```
