### PR TITLE
improve error message for 'no domain matching zones'

### DIFF
--- a/pkg/dns/provider/selection/selection.go
+++ b/pkg/dns/provider/selection/selection.go
@@ -18,6 +18,7 @@ package selection
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/gardener/controller-manager-library/pkg/utils"
 
@@ -121,8 +122,13 @@ func CalcZoneAndDomainSelection(spec v1alpha1.DNSProviderSpec, zones []LightDNSH
 		if len(this.DomainSel.Include) == 0 {
 			this.ZoneSel.Exclude.AddSet(this.ZoneSel.Include)
 			this.ZoneSel.Include = utils.NewStringSet()
+			zoneDomains := []string{}
+			for _, z := range this.Zones {
+				zoneDomains = append(zoneDomains, z.Domain())
+			}
 			this.Zones = nil
-			this.Error = "no domain matching hosting zones"
+			this.Error = fmt.Sprintf("no domain matching hosting zones. Need to be a (sub)domain of [%s]",
+				strings.Join(zoneDomains, ", "))
 			return this
 		}
 	}

--- a/pkg/dns/provider/selection/selection_test.go
+++ b/pkg/dns/provider/selection/selection_test.go
@@ -249,7 +249,7 @@ var _ = Describe("Selection", func() {
 				Include: utils.NewStringSet(),
 				Exclude: utils.NewStringSet(),
 			},
-			Error: "no domain matching hosting zones",
+			Error: "no domain matching hosting zones. Need to be a (sub)domain of [a.b, c.a.b, o.p]",
 			Warnings: []string{
 				"domain \"y.z\" not in hosted domains",
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
The error message for 'no domain matching zones' now includes a list valid base domains of the available zones.
Additionally the status fields for zones and domains are updated on error.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
improve error message for 'no domain matching zones'
```
