### PR TITLE
helm charts: no deployment of CRDs by default

### DIFF
--- a/charts/external-dns-management/templates/vpa.yaml
+++ b/charts/external-dns-management/templates/vpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.vpa.enabled }}
-apiVersion: "autoscaling.k8s.io/v1beta2"
+apiVersion: "autoscaling.k8s.io/v1"
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ include "external-dns-management.fullname" . }}-vpa

--- a/charts/external-dns-management/values.yaml
+++ b/charts/external-dns-management/values.yaml
@@ -30,7 +30,7 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 
-createCRDs: true
+createCRDs: false
 
 #serviceAccountAnnotations:
 #  annotkey1: annotvalue1


### PR DESCRIPTION

**What this PR does / why we need it**:
CRDs should not be deployed by the helm chart by default.
Besides the version of the group `autoscaling.k8s.io` has been updated to `v1`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
CRDs are not deployed by the helm chart with default values anymore.
```
