### PR TITLE
consider provider zone on adding entries to zone

### DIFF
--- a/pkg/controller/provider/openstack/handler_test.go
+++ b/pkg/controller/provider/openstack/handler_test.go
@@ -72,6 +72,10 @@ func (tz *testzone) IsPrivate() bool {
 	return false
 }
 
+func (tz *testzone) Match(dnsname string) int {
+	return provider.Match(tz, dnsname)
+}
+
 type designateMockClient struct {
 	tzmap map[string]*testzone
 }

--- a/pkg/dns/provider/default.go
+++ b/pkg/dns/provider/default.go
@@ -16,7 +16,10 @@
 
 package provider
 
-import "github.com/gardener/external-dns-management/pkg/dns"
+import (
+	"github.com/gardener/external-dns-management/pkg/dns"
+	dnsutils "github.com/gardener/external-dns-management/pkg/dns/utils"
+)
 
 ////////////////////////////////////////////////////////////////////////////////
 //  Default Implementation for DNSZoneState
@@ -76,6 +79,22 @@ func (this *DefaultDNSHostedZone) ForwardedDomains() []string {
 
 func (this *DefaultDNSHostedZone) IsPrivate() bool {
 	return this.isPrivate
+}
+
+func (this *DefaultDNSHostedZone) Match(dnsname string) int {
+	return Match(this, dnsname)
+}
+
+func Match(zone DNSHostedZone, dnsname string) int {
+	for _, forwardedDomain := range zone.ForwardedDomains() {
+		if dnsutils.Match(dnsname, forwardedDomain) {
+			return 0
+		}
+	}
+	if dnsutils.Match(dnsname, zone.Domain()) {
+		return len(zone.Domain())
+	}
+	return 0
 }
 
 func NewDNSHostedZone(ptype string, id, domain, key string, forwarded []string, isPrivate bool) DNSHostedZone {

--- a/pkg/dns/provider/interface.go
+++ b/pkg/dns/provider/interface.go
@@ -118,6 +118,7 @@ type DNSHostedZone interface {
 	Id() string
 	Domain() string
 	ForwardedDomains() []string
+	Match(dnsname string) int
 	IsPrivate() bool
 }
 
@@ -230,11 +231,13 @@ type DNSProvider interface {
 	DefaultTTL() int64
 
 	GetZones() DNSHostedZones
+	IncludesZone(zoneID string) bool
 
 	GetZoneState(zone DNSHostedZone) (DNSZoneState, error)
 	ExecuteRequests(logger logger.LogContext, zone DNSHostedZone, state DNSZoneState, requests []*ChangeRequest) error
 
 	Match(dns string) int
+	MatchZone(dns string) int
 	IsValid() bool
 
 	AccountHash() string

--- a/pkg/dns/provider/provider.go
+++ b/pkg/dns/provider/provider.go
@@ -483,7 +483,17 @@ func (this *dnsProviderVersion) Match(dns string) int {
 	if ilen > elen {
 		return ilen
 	}
-	return -1
+	return 0
+}
+
+func (this *dnsProviderVersion) MatchZone(dns string) int {
+	for _, zone := range this.zones {
+		ilen := zone.Match(dns)
+		if ilen > 0 {
+			return ilen
+		}
+	}
+	return 0
 }
 
 func (this *dnsProviderVersion) MapTarget(t Target) Target {
@@ -565,4 +575,8 @@ func (this *dnsProviderVersion) ReportZoneStateConflict(zone DNSHostedZone, err 
 
 func (this *dnsProviderVersion) ExecuteRequests(logger logger.LogContext, zone DNSHostedZone, state DNSZoneState, reqs []*ChangeRequest) error {
 	return this.account.ExecuteRequests(logger, zone, state, reqs)
+}
+
+func (this *dnsProviderVersion) IncludesZone(zoneID string) bool {
+	return this.included_zones != nil && this.included_zones.Contains(zoneID)
 }

--- a/pkg/dns/provider/state_zone.go
+++ b/pkg/dns/provider/state_zone.go
@@ -49,17 +49,6 @@ func (this *state) TriggerHostedZones() {
 	}
 }
 
-func (this *state) GetZoneInfo(logger logger.LogContext, zoneid string) (*dnsHostedZone, DNSProviders, Entries, DNSNames, bool) {
-	this.lock.RLock()
-	defer this.lock.RUnlock()
-	zone := this.zones[zoneid]
-	if zone == nil {
-		return nil, nil, nil, nil, false
-	}
-	entries, stale, deleting := this.addEntriesForZone(logger, nil, nil, zone)
-	return zone, this.getProvidersForZone(zoneid), entries, stale, deleting
-}
-
 func (this *state) GetZoneReconcilation(logger logger.LogContext, zoneid string) (time.Duration, bool, *zoneReconciliation) {
 	req := &zoneReconciliation{}
 

--- a/pkg/dns/provider/utils.go
+++ b/pkg/dns/provider/utils.go
@@ -41,3 +41,14 @@ func errorValue(format string, err error) string {
 	}
 	return fmt.Sprintf(format, err.Error())
 }
+
+func filterZoneByProvider(zones []*dnsHostedZone, provider DNSProvider) *dnsHostedZone {
+	if provider != nil {
+		for _, zone := range zones {
+			if provider.IncludesZone(zone.Id()) {
+				return zone
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/dns/provider/zone.go
+++ b/pkg/dns/provider/zone.go
@@ -93,6 +93,10 @@ func (this *dnsHostedZone) IsPrivate() bool {
 	return this.getZone().IsPrivate()
 }
 
+func (this *dnsHostedZone) Match(dnsname string) int {
+	return Match(this, dnsname)
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 func (this *dnsHostedZone) update(zone DNSHostedZone) {


### PR DESCRIPTION
**What this PR does / why we need it**:
If there are multiple providers with the same domain (e.g. if private zones are used), the zone of the provider must be considered on adding a DNS entry to the zone.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
consider provider zone on adding entries to zone
```
