### PR TITLE
do not remove entry finalizer if provider backend is temporarily unavailable during reconciliation

### DIFF
--- a/pkg/dns/provider/state_entry.go
+++ b/pkg/dns/provider/state_entry.go
@@ -147,8 +147,12 @@ func (this *state) AddEntryVersion(logger logger.LogContext, v *EntryVersion, st
 					return new, reconcile.Succeeded(logger)
 				}
 			} else {
-				logger.Infof("dns zone '%s' of deleted entry gone", old.ZoneId())
-				err = this.RemoveFinalizer(v.object)
+				if old != nil {
+					logger.Infof("dns zone '%s' of deleted entry gone", old.ZoneId())
+				}
+				if v.object.Status() == nil || v.object.Status().Zone == nil {
+					err = this.RemoveFinalizer(v.object)
+				}
 			}
 		} else {
 			this.smartInfof(logger, "deleting yet unmanaged or errorneous entry")

--- a/pkg/dns/provider/statusupdate.go
+++ b/pkg/dns/provider/statusupdate.go
@@ -55,8 +55,13 @@ func (this *StatusUpdate) Failed(err error) {
 	if !this.done {
 		this.done = true
 		this.modified = false
-		this.fhandler.RemoveFinalizer(this.Entry.Object())
-		_, err := this.UpdateStatus(this.logger, api.STATE_ERROR, err.Error())
+		newState := api.STATE_ERROR
+		if this.Entry.status.State != api.STATE_READY && this.Entry.status.State != api.STATE_STALE {
+			this.fhandler.RemoveFinalizer(this.Entry.Object())
+		} else {
+			newState = api.STATE_STALE
+		}
+		_, err := this.UpdateStatus(this.logger, newState, err.Error())
 		if err != nil {
 			this.logger.Errorf("cannot update: %s", err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
If provider backend is temporarily not available the finalizer of an entry must not be removed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix: do not remove entry finalizer if provider backend is temporarily unavailable during reconciliation
```
