### PR TITLE
Adds Artifacts for Landscaper Integration

### DIFF
--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+# For the component_descriptor step concourse will set the following environment variables:
+# COMPONENT_DESCRIPTOR_DIR - path to directory which contains the base component descriptor
+# SOURCE_PATH - path to the locally cloned GitHub source repo
+
+echo "start component_descriptor build"
+
+# change directory to parent as the script will be called from within ${COMPONENT_DESCRIPTOR_DIR} 
+cd "../"
+
+echo "compute path variables"
+component_descriptor_dir="$(readlink -f ${COMPONENT_DESCRIPTOR_DIR})"
+base_cd_file="${component_descriptor_dir}/base_component_descriptor_v2"
+ctf_out_file="${component_descriptor_dir}/cnudie-transport-format.out"
+source_dir="$(readlink -f ${SOURCE_PATH})"
+component_cli_file="$(pwd)/component-cli"
+
+echo "component_descriptor_dir = ${component_descriptor_dir}"
+echo "base_cd_file = ${base_cd_file}"
+echo "ctf_out_file = ${ctf_out_file}"
+echo "source_dir = ${source_dir}"
+echo "component_cli_file = ${component_cli_file}"
+
+echo "download component-cli"
+curl -L https://github.com/gardener/component-cli/releases/latest/download/componentcli-linux-amd64.gz --output "${component_cli_file}.gz"
+gunzip "${component_cli_file}.gz"
+chmod +x "${component_cli_file}"
+
+pushd "${source_dir}/.landscaper" >/dev/null
+
+echo "copy base component descriptor"
+cp "${base_cd_file}" ./component-descriptor.yaml
+
+echo "add resources to component descriptor"
+"${component_cli_file}" component-archive resources add . resources.yaml
+
+echo "--- final component descriptor"
+cat ./component-descriptor.yaml
+echo "---"
+
+echo "create component archive"
+"${component_cli_file}" component-archive export . --format tar -o "ca.tar"
+
+echo "add component archive to ctf"
+"${component_cli_file}" ctf add "${ctf_out_file}" -f "ca.tar"
+
+popd >/dev/null
+
+echo "finished component_descriptor build"

--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -1,52 +1,17 @@
 #!/usr/bin/env bash
 
-set -eu -o pipefail
+set -o errexit
+set -o nounset
+set -o pipefail
 
-# For the component_descriptor step concourse will set the following environment variables:
-# COMPONENT_DESCRIPTOR_DIR - path to directory which contains the base component descriptor
-# SOURCE_PATH - path to the locally cloned GitHub source repo
+SOURCE_PATH="$(dirname $0)/.."
 
-echo "start component_descriptor build"
+"$SOURCE_PATH"/vendor/github.com/gardener/gardener/hack/.ci/component_descriptor "$SOURCE_PATH"
 
-# change directory to parent as the script will be called from within ${COMPONENT_DESCRIPTOR_DIR} 
-cd "../"
+echo "> building component dns-controller-manager"
 
-echo "compute path variables"
-component_descriptor_dir="$(readlink -f ${COMPONENT_DESCRIPTOR_DIR})"
-base_cd_file="${component_descriptor_dir}/base_component_descriptor_v2"
-ctf_out_file="${component_descriptor_dir}/cnudie-transport-format.out"
-source_dir="$(readlink -f ${SOURCE_PATH})"
-component_cli_file="$(pwd)/component-cli"
-
-echo "component_descriptor_dir = ${component_descriptor_dir}"
-echo "base_cd_file = ${base_cd_file}"
-echo "ctf_out_file = ${ctf_out_file}"
-echo "source_dir = ${source_dir}"
-echo "component_cli_file = ${component_cli_file}"
-
-echo "download component-cli"
-curl -L https://github.com/gardener/component-cli/releases/latest/download/componentcli-linux-amd64.gz --output "${component_cli_file}.gz"
-gunzip "${component_cli_file}.gz"
-chmod +x "${component_cli_file}"
-
-pushd "${source_dir}/.landscaper" >/dev/null
-
-echo "copy base component descriptor"
-cp "${base_cd_file}" ./component-descriptor.yaml
-
-echo "add resources to component descriptor"
-"${component_cli_file}" component-archive resources add . resources.yaml
-
-echo "--- final component descriptor"
-cat ./component-descriptor.yaml
-echo "---"
-
-echo "create component archive"
-"${component_cli_file}" component-archive export . --format tar -o "ca.tar"
-
-echo "add component archive to ctf"
-"${component_cli_file}" ctf add "${ctf_out_file}" -f "ca.tar"
-
-popd >/dev/null
-
-echo "finished component_descriptor build"
+CA_PATH="$(mktemp -d)"
+mv "$COMPONENT_DESCRIPTOR_PATH" "$CA_PATH/component-descriptor.yaml"
+component-cli ca "${CA_PATH}" "${CTF_PATH}" \
+    -r  "$SOURCE_PATH"/.landscaper/resources.yaml \
+    VERSION=${EFFECTIVE_VERSION}

--- a/.landscaper/blueprint/blueprint.yaml
+++ b/.landscaper/blueprint/blueprint.yaml
@@ -1,0 +1,16 @@
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Blueprint
+
+imports:
+- name: cluster
+  targetType: landscaper.gardener.cloud/kubernetes-cluster
+
+- name: chartValues
+  schema:
+    type: object
+
+deployExecutions:
+- file: /deploy-executions.yaml
+  name: manifests
+  type: GoTemplate
+

--- a/.landscaper/blueprint/blueprint.yaml
+++ b/.landscaper/blueprint/blueprint.yaml
@@ -6,6 +6,7 @@ imports:
   targetType: landscaper.gardener.cloud/kubernetes-cluster
 
 - name: chartValues
+  required: false
   schema:
     type: object
 

--- a/.landscaper/blueprint/deploy-executions.yaml
+++ b/.landscaper/blueprint/deploy-executions.yaml
@@ -29,6 +29,10 @@ deployItems:
             type: openstack-designate
           - kind: DNSProvider
             type: cloudflare-dns
+          - kind: DNSProvider
+            type: infoblox-dns
+          - kind: DNSProvider
+            type: netlify-dns 
           deployment:
             type: helm
             providerConfig:
@@ -39,6 +43,8 @@ deployItems:
                   {{- $image := getResource .cd "name" "dns-controller-manager" }}
                   repository: {{ ociRefRepo ( $image.access.imageReference ) }}
                   tag: {{ ociRefVersion ( $image.access.imageReference ) }}
+                {{- if .imports.chartValues }}
                 {{- $values := .imports.chartValues }}
                 {{- $values = unset $values "image" }}
                 {{- toYaml $values | nindent 16 }}
+                {{- end }}

--- a/.landscaper/blueprint/deploy-executions.yaml
+++ b/.landscaper/blueprint/deploy-executions.yaml
@@ -5,46 +5,57 @@ deployItems:
     name: {{ .imports.cluster.metadata.name }}
     namespace: {{ .imports.cluster.metadata.namespace }}
   config:
-    apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha1
+    apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha2
     kind: ProviderConfiguration
 
     updateStrategy: patch
 
     manifests:
-      - apiVersion: core.gardener.cloud/v1beta1
-        kind: ControllerRegistration
-        metadata:
-          name: external-dns-management
-        spec:
-          resources:
-          - kind: DNSProvider
-            type: aws-route53
-          - kind: DNSProvider
-            type: alicloud-dns
-          - kind: DNSProvider
-            type: azure-dns
-          - kind: DNSProvider
-            type: google-clouddns
-          - kind: DNSProvider
-            type: openstack-designate
-          - kind: DNSProvider
-            type: cloudflare-dns
-          - kind: DNSProvider
-            type: infoblox-dns
-          - kind: DNSProvider
-            type: netlify-dns 
-          deployment:
-            type: helm
-            providerConfig:
-              {{- $chart := getResource .cd "name" "dns-controller-manager-chart" }}
-              chart: {{ resolve ( $chart.access ) | toString | b64enc }}
-              values:
-                image:
-                  {{- $image := getResource .cd "name" "dns-controller-manager" }}
-                  repository: {{ ociRefRepo ( $image.access.imageReference ) }}
-                  tag: {{ ociRefVersion ( $image.access.imageReference ) }}
-                {{- if .imports.chartValues }}
-                {{- $values := .imports.chartValues }}
-                {{- $values = unset $values "image" }}
-                {{- toYaml $values | nindent 16 }}
-                {{- end }}
+      - policy: manage
+        manifest:
+          apiVersion: core.gardener.cloud/v1beta1
+          kind: ControllerDeployment
+          metadata:
+            name: dns-controller-manager
+          type: helm
+          providerConfig:
+            {{- $chart := getResource .cd "name" "dns-controller-manager-chart" }}
+            chart: {{ resolve ( $chart.access ) | toString | b64enc }}
+            values:
+              image:
+                {{- $image := getResource .cd "name" "dns-controller-manager" }}
+                repository: {{ ociRefRepo ( $image.access.imageReference ) }}
+                tag: {{ ociRefVersion ( $image.access.imageReference ) }}
+              {{- if .imports.chartValues }}
+              {{- $values := .imports.chartValues }}
+              {{- $values = unset $values "image" }}
+              {{- toYaml $values | nindent 14 }}
+              {{- end }}
+
+      - policy: manage
+        manifest:
+          apiVersion: core.gardener.cloud/v1beta1
+          kind: ControllerRegistration
+          metadata:
+            name: dns-controller-manager
+          spec:
+            deployment:
+              deploymentRefs:
+                - name: dns-controller-manager
+            resources:
+            - kind: DNSProvider
+              type: aws-route53
+            - kind: DNSProvider
+              type: alicloud-dns
+            - kind: DNSProvider
+              type: azure-dns
+            - kind: DNSProvider
+              type: google-clouddns
+            - kind: DNSProvider
+              type: openstack-designate
+            - kind: DNSProvider
+              type: cloudflare-dns
+            - kind: DNSProvider
+              type: infoblox-dns
+            - kind: DNSProvider
+              type: netlify-dns 

--- a/.landscaper/blueprint/deploy-executions.yaml
+++ b/.landscaper/blueprint/deploy-executions.yaml
@@ -1,0 +1,44 @@
+deployItems:
+- name: deploy
+  type: landscaper.gardener.cloud/kubernetes-manifest
+  target:
+    name: {{ .imports.cluster.metadata.name }}
+    namespace: {{ .imports.cluster.metadata.namespace }}
+  config:
+    apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha1
+    kind: ProviderConfiguration
+
+    updateStrategy: patch
+
+    manifests:
+      - apiVersion: core.gardener.cloud/v1beta1
+        kind: ControllerRegistration
+        metadata:
+          name: external-dns-management
+        spec:
+          resources:
+          - kind: DNSProvider
+            type: aws-route53
+          - kind: DNSProvider
+            type: alicloud-dns
+          - kind: DNSProvider
+            type: azure-dns
+          - kind: DNSProvider
+            type: google-clouddns
+          - kind: DNSProvider
+            type: openstack-designate
+          - kind: DNSProvider
+            type: cloudflare-dns
+          deployment:
+            type: helm
+            providerConfig:
+              {{- $chart := getResource .cd "name" "dns-controller-manager-chart" }}
+              chart: {{ resolve ( $chart.access ) | toString | b64enc }}
+              values:
+                image:
+                  {{- $image := getResource .cd "name" "dns-controller-manager" }}
+                  repository: {{ ociRefRepo ( $image.access.imageReference ) }}
+                  tag: {{ ociRefVersion ( $image.access.imageReference ) }}
+                {{- $values := .imports.chartValues }}
+                {{- $values = unset $values "image" }}
+                {{- toYaml $values | nindent 16 }}

--- a/.landscaper/component-descriptor.yaml
+++ b/.landscaper/component-descriptor.yaml
@@ -1,1 +1,0 @@
-# the base component descriptor will be provided by the pipeline and modified by the .ci/component_descriptor script

--- a/.landscaper/component-descriptor.yaml
+++ b/.landscaper/component-descriptor.yaml
@@ -1,0 +1,1 @@
+# the base component descriptor will be provided by the pipeline and modified by the .ci/component_descriptor script

--- a/.landscaper/resources.yaml
+++ b/.landscaper/resources.yaml
@@ -1,6 +1,6 @@
 ---
-type: blueprint
-name: dns-controller-manager-blueprint
+type: landscaper.gardener.cloud/blueprint
+name: dns-controller-manager-controller-registration
 relation: local
 input:
   type: "dir"
@@ -8,7 +8,7 @@ input:
   compress: true
   mediaType: "application/vnd.gardener.landscaper.blueprint.v1+tar+gzip"
 ---
-type: helm
+type: helm.io/chart
 name: dns-controller-manager-chart
 relation: local
 input:

--- a/.landscaper/resources.yaml
+++ b/.landscaper/resources.yaml
@@ -6,7 +6,7 @@ input:
   type: "dir"
   path: "./blueprint"
   compress: true
-  mediaType: "application/vnd.gardener.landscaper.blueprint.v1+tar+gzip"
+  mediaType: "application/vnd.gardener.landscaper.blueprint.v1.tar+gzip"
 ---
 type: helm.io/chart
 name: dns-controller-manager-chart
@@ -15,4 +15,5 @@ input:
   type: "dir"
   path: "../charts/external-dns-management"
   compress: true
+  preserveDir: true
 ---

--- a/.landscaper/resources.yaml
+++ b/.landscaper/resources.yaml
@@ -1,0 +1,18 @@
+---
+type: blueprint
+name: dns-controller-manager-blueprint
+relation: local
+input:
+  type: "dir"
+  path: "./blueprint"
+  compress: true
+  mediaType: "application/vnd.gardener.landscaper.blueprint.v1+tar+gzip"
+---
+type: helm
+name: dns-controller-manager-chart
+relation: local
+input:
+  type: "dir"
+  path: "../charts/external-dns-management"
+  compress: true
+---


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds artifacts for Landscaper integration. Pipeline now produces a CTF that contains the Component Descriptor, Blueprint, and Helm Chart (as Blobs) for this component.

Co-authored by @enrico-kaack-comp 

**Which issue(s) this PR fixes**:
https://github.com/gardener/landscapercli/issues/64

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
