### PR TITLE
fix premature deletion of DNSEntry if deletion fails in provider

### DIFF
--- a/pkg/dns/provider/state_zone.go
+++ b/pkg/dns/provider/state_zone.go
@@ -200,6 +200,9 @@ func (this *state) reconcileZone(logger logger.LogContext, req *zoneReconciliati
 	outdatedEntries := EntryList{}
 	this.outdated.AddActiveZoneTo(zoneid, &outdatedEntries)
 	for _, e := range outdatedEntries {
+		if changes.IsFailed(e.DNSName()) {
+			continue
+		}
 		logger.Infof("cleanup outdated entry %q", e.ObjectName())
 		err := e.RemoveFinalizer()
 		if err == nil || errors.IsNotFound(err) {

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func checkHasFinalizer(obj resources.Object) {
-	err := testEnv.AwaitFinalizers(obj, "dns.gardener.cloud/mock-inmemory")
+	err := testEnv.AwaitFinalizers(obj, "dns.gardener.cloud/compound")
 	Ω(err).ShouldNot(HaveOccurred())
 }
 

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -23,7 +23,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	_ "github.com/gardener/external-dns-management/pkg/controller/provider/mock/controller"
+	_ "github.com/gardener/external-dns-management/pkg/controller/provider/compound/controller"
+	_ "github.com/gardener/external-dns-management/pkg/controller/provider/mock"
 	_ "github.com/gardener/external-dns-management/pkg/controller/source/ingress"
 	_ "github.com/gardener/external-dns-management/pkg/controller/source/service"
 
@@ -48,7 +49,7 @@ var _ = BeforeSuite(func() {
 	args := []string{
 		"--kubeconfig", kubeconfig,
 		"--identifier", "integrationtest",
-		"--controllers", "mock-inmemory,dnssources",
+		"--controllers", "dnscontrollers,dnssources",
 		"--omit-lease",
 		"--reschedule-delay", "15s",
 		"--pool.size", "10",


### PR DESCRIPTION
**What this PR does / why we need it**:
If deletion of DNS records fails in a DNS provider, the DNSEntry must not be deleted.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
fix premature deletion of DNSEntry if deletion fails in provider
```
