### PR TITLE
log if zone cache is dropped, don't drop on throttling

### DIFF
--- a/pkg/controller/provider/alicloud/handler.go
+++ b/pkg/controller/provider/alicloud/handler.go
@@ -146,7 +146,7 @@ func (h *Handler) ReportZoneStateConflict(zone provider.DNSHostedZone, err error
 
 func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
 	err := raw.ExecuteRequests(logger, &h.config, h.access, zone, state, reqs)
-	h.cache.ApplyRequests(err, zone, reqs)
+	h.cache.ApplyRequests(logger, err, zone, reqs)
 	return err
 }
 

--- a/pkg/controller/provider/aws/handler.go
+++ b/pkg/controller/provider/aws/handler.go
@@ -249,7 +249,7 @@ func (h *Handler) ReportZoneStateConflict(zone provider.DNSHostedZone, err error
 
 func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
 	err := h.executeRequests(logger, zone, state, reqs)
-	h.cache.ApplyRequests(err, zone, reqs)
+	h.cache.ApplyRequests(logger, err, zone, reqs)
 	return err
 }
 

--- a/pkg/controller/provider/azure/handler.go
+++ b/pkg/controller/provider/azure/handler.go
@@ -227,7 +227,7 @@ func (h *Handler) ReportZoneStateConflict(zone provider.DNSHostedZone, err error
 
 func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
 	err := h.executeRequests(logger, zone, state, reqs)
-	h.cache.ApplyRequests(err, zone, reqs)
+	h.cache.ApplyRequests(logger, err, zone, reqs)
 	return err
 }
 

--- a/pkg/controller/provider/cloudflare/handler.go
+++ b/pkg/controller/provider/cloudflare/handler.go
@@ -145,7 +145,7 @@ func (h *Handler) ReportZoneStateConflict(zone provider.DNSHostedZone, err error
 
 func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
 	err := raw.ExecuteRequests(logger, &h.config, h.access, zone, state, reqs)
-	h.cache.ApplyRequests(err, zone, reqs)
+	h.cache.ApplyRequests(logger, err, zone, reqs)
 	return err
 }
 

--- a/pkg/controller/provider/google/handler.go
+++ b/pkg/controller/provider/google/handler.go
@@ -192,7 +192,7 @@ func (h *Handler) ReportZoneStateConflict(zone provider.DNSHostedZone, err error
 
 func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
 	err := h.executeRequests(logger, zone, state, reqs)
-	h.cache.ApplyRequests(err, zone, reqs)
+	h.cache.ApplyRequests(logger, err, zone, reqs)
 	return err
 }
 

--- a/pkg/controller/provider/infoblox/handler.go
+++ b/pkg/controller/provider/infoblox/handler.go
@@ -272,6 +272,6 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, cache provider.ZoneC
 
 func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
 	err := raw.ExecuteRequests(logger, &h.config, h.access, zone, state, reqs)
-	h.ApplyRequests(err, zone, reqs)
+	h.ApplyRequests(logger, err, zone, reqs)
 	return err
 }

--- a/pkg/controller/provider/mock/handler.go
+++ b/pkg/controller/provider/mock/handler.go
@@ -107,7 +107,7 @@ func (h *Handler) ReportZoneStateConflict(zone provider.DNSHostedZone, err error
 
 func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
 	err := h.executeRequests(logger, zone, state, reqs)
-	h.cache.ApplyRequests(err, zone, reqs)
+	h.cache.ApplyRequests(logger, err, zone, reqs)
 	return err
 }
 

--- a/pkg/controller/provider/netlify/handler.go
+++ b/pkg/controller/provider/netlify/handler.go
@@ -140,7 +140,7 @@ func (h *Handler) ReportZoneStateConflict(zone provider.DNSHostedZone, err error
 
 func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
 	err := raw.ExecuteRequests(logger, &h.config, h.access, zone, state, reqs)
-	h.cache.ApplyRequests(err, zone, reqs)
+	h.cache.ApplyRequests(logger, err, zone, reqs)
 	return err
 }
 

--- a/pkg/controller/provider/openstack/handler.go
+++ b/pkg/controller/provider/openstack/handler.go
@@ -209,7 +209,7 @@ func (h *Handler) ReportZoneStateConflict(zone provider.DNSHostedZone, err error
 // ExecuteRequests applies a given change request to a given hosted zone.
 func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
 	err := h.executeRequests(logger, zone, state, reqs)
-	h.cache.ApplyRequests(err, zone, reqs)
+	h.cache.ApplyRequests(logger, err, zone, reqs)
 	return err
 }
 

--- a/pkg/dns/provider/errors/errors.go
+++ b/pkg/dns/provider/errors/errors.go
@@ -50,3 +50,20 @@ type NoSuchHostedZone struct {
 func (e *NoSuchHostedZone) Error() string {
 	return fmt.Sprintf("No such hosted zone %s: %s", e.ZoneId, e.Err)
 }
+
+func NewThrottlingError(err error) *ThrottlingError {
+	return &ThrottlingError{err: err}
+}
+
+type ThrottlingError struct {
+	err error
+}
+
+func (e *ThrottlingError) Error() string {
+	return fmt.Sprintf("Throttling: %s", e.err)
+}
+
+func IsThrottlingError(err error) bool {
+	_, ok := err.(*ThrottlingError)
+	return ok
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Log if the zone cache is dropped because of error(s) during updating DNS records in the provider (`ExecuteRequests`).
If the error on `ExecuteRequests` is only caused by throttling, keep cache as nothing changed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
log if zone cache is dropped
```
