### PR TITLE
DNS entries without targets are handled as invalid and can be deleted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ tmp/
 /test/functional/tmp-*.yaml
 /test/integration/kubebuilder*
 /test/integration/default.etcd
+/test/integration/integration.test
 .vscode/
 .kubeconfig-kind-integration

--- a/pkg/dns/provider/changemodel.go
+++ b/pkg/dns/provider/changemodel.go
@@ -92,9 +92,16 @@ func (this *ChangeGroup) cleanup(logger logger.LogContext, model *ChangeModel) b
 					}
 				} else {
 					model.Infof("found unapplied managed set '%s'", s.Name)
+					var done DoneHandler
+					for _, e := range model.context.entries {
+						if e.dnsname == s.Name {
+							done = NewStatusUpdate(logger, e, model.context.fhandler)
+							break
+						}
+					}
 					for ty := range s.Sets {
 						mod = true
-						this.addDeleteRequest(s, ty, model.wrappedDoneHandler(s.Name, nil))
+						this.addDeleteRequest(s, ty, model.wrappedDoneHandler(s.Name, done))
 					}
 				}
 			}

--- a/pkg/dns/provider/state.go
+++ b/pkg/dns/provider/state.go
@@ -48,6 +48,7 @@ type zoneReconciliation struct {
 	stale     DNSNames
 	dedicated bool
 	deleting  bool
+	fhandler  FinalizerHandler
 }
 
 type setup struct {
@@ -438,7 +439,9 @@ loop:
 				if utils.StringValue(e.object.Status().Provider) != "" {
 					logger.Infof("invalid entry %q (%s): %s (%s)", e.ObjectName(), e.DNSName(), e.State(), e.Message())
 				}
-				stale[e.DNSName()] = e
+				if e.KeepRecords() {
+					stale[e.DNSName()] = e
+				}
 			}
 		}
 	}

--- a/pkg/dns/provider/state_provider.go
+++ b/pkg/dns/provider/state_provider.go
@@ -207,6 +207,7 @@ func (this *state) removeLocalProvider(logger logger.LogContext, obj *dnsutils.D
 						stale:     nil,
 						dedicated: false,
 						deleting:  false,
+						fhandler:  this.context,
 					})
 					if !done {
 						return reconcile.Delay(logger, fmt.Errorf("zone reconcilation busy -> delay deletion"))

--- a/pkg/dns/provider/state_zone.go
+++ b/pkg/dns/provider/state_zone.go
@@ -50,7 +50,9 @@ func (this *state) TriggerHostedZones() {
 }
 
 func (this *state) GetZoneReconcilation(logger logger.LogContext, zoneid string) (time.Duration, bool, *zoneReconciliation) {
-	req := &zoneReconciliation{}
+	req := &zoneReconciliation{
+		fhandler: this.context,
+	}
 
 	this.lock.RLock()
 	defer this.lock.RUnlock()

--- a/test/integration/testenv.go
+++ b/test/integration/testenv.go
@@ -301,6 +301,21 @@ func (te *TestEnv) UpdateEntryDomain(obj resources.Object, domain string) (resou
 	return obj, err
 }
 
+func (te *TestEnv) UpdateEntryTargets(obj resources.Object, targets ...string) (resources.Object, error) {
+	obj, err := te.GetEntry(obj.GetName())
+	if err != nil {
+		return nil, err
+	}
+	e := UnwrapEntry(obj)
+	if len(targets) == 0 {
+		e.Spec.Targets = nil
+	} else {
+		e.Spec.Targets = targets
+	}
+	err = obj.Update()
+	return obj, err
+}
+
 func (te *TestEnv) DeleteEntryAndWait(obj resources.Object) error {
 	err := obj.Delete()
 	if err != nil {
@@ -528,6 +543,10 @@ func (te *TestEnv) AwaitEntryReady(name string) error {
 
 func (te *TestEnv) AwaitEntryStale(name string) error {
 	return te.AwaitEntryState(name, "Stale")
+}
+
+func (te *TestEnv) AwaitEntryInvalid(name string) error {
+	return te.AwaitEntryState(name, "Invalid")
 }
 
 func (te *TestEnv) AwaitEntryError(name string) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
The state `Stale` has a slightly different semantic since PR #165. Stale entries must not be deleted as the corresponding DNS records in the backend cannot be removed for some reason. DNS entries without targets have been marked as `Stale`, but are in fact `Invalid`. This PR corrects the behaviour for such entries.

**Which issue(s) this PR fixes**:
Fixes #169 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
DNS entries without targets are handled as invalid and can be deleted
```
