### PR TITLE
Deduplicate targets for multiple CNAME targets

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 #############      builder       #############
-FROM eu.gcr.io/gardener-project/3rd/golang:1.15.5 AS builder
+FROM eu.gcr.io/gardener-project/3rd/golang:1.16.2 AS builder
 
 WORKDIR /build
 COPY . .
@@ -21,7 +21,7 @@ COPY . .
 RUN make release
 
 ############# base
-FROM eu.gcr.io/gardener-project/3rd/alpine:3.12.1 AS base
+FROM eu.gcr.io/gardener-project/3rd/alpine:3.13.4 AS base
 
 #############      dns-controller-manager     #############
 FROM base AS dns-controller-manager

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/external-dns-management
 
-go 1.14
+go 1.16
 
 require (
 	github.com/Azure/azure-sdk-for-go v39.0.0+incompatible

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -18,6 +18,7 @@ package integration
 
 import (
 	"github.com/gardener/controller-manager-library/pkg/resources"
+	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	. "github.com/onsi/gomega"
 )
 
@@ -33,7 +34,7 @@ func checkProvider(obj resources.Object) {
 	checkHasFinalizer(obj)
 }
 
-func checkEntry(obj resources.Object, provider resources.Object) {
+func checkEntry(obj resources.Object, provider resources.Object) *v1alpha1.DNSEntry {
 	err := testEnv.AwaitEntryReady(obj.GetName())
 	Ω(err).Should(BeNil())
 
@@ -47,4 +48,5 @@ func checkEntry(obj resources.Object, provider resources.Object) {
 	Ω(entry.Status.Provider).ShouldNot(BeNil(), "Missing provider")
 	providerName := provider.ObjectName().String()
 	Ω(*entry.Status.Provider).Should(Equal(providerName))
+	return entry
 }


### PR DESCRIPTION

**What this PR does / why we need it**:
If a `DNSEntry` has multiple cname targets, they may resolve to the same IP address.
With this fix, these targets are deduplicated to avoid e.g. InvalidChangeBatch errors in the AWS provider.
Additionally, the docker base image has been updated to `alpine:3.13.4` and `golang@1.16.2` is used.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Deduplication of targets if mutiple CNAME targets are provided
```
