### PR TITLE
Ensure stable provider result in method DNSProviders.LookupFor

### DIFF
--- a/pkg/dns/provider/provider.go
+++ b/pkg/dns/provider/provider.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -51,7 +52,7 @@ func (this DNSProviders) LookupFor(dns string) DNSProvider {
 	for _, p := range this {
 		n := p.Match(dns)
 		if n > 0 {
-			if match < n {
+			if match < n || match == n && found != nil && strings.Compare(p.AccountHash(), found.AccountHash()) < 0 {
 				found = p
 				match = n
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
DNS entries of a hosted DNS zone are updated per account hash, which is calculated from credentials and other properties. If there are multiple providers with different account hashes but with the same zone(s) a problem was observed. DNS entries which can be assigned to multiple account hashes go to state `Stale` temporarily and it is tried to recreate the DNS records on zone reconciliations. This is caused by flipping account hash assignments of the DNS entries, caused by an instable iteration order in the method `DNSProviders.LookupFor` which returned potential different provider for the same DNS name on each call.
The user are not directly affected by this bug, but it causes additional work load and additional requests (creation of already existing records and reload of zone state as zone cache is discarded because of failed creation). 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
ensure stable provider result in method DNSProviders.LookupFor
```
