### PR TITLE
Added requests_per_zone and zone_cache_discardings metrics

### DIFF
--- a/pkg/controller/provider/alicloud/handler.go
+++ b/pkg/controller/provider/alicloud/handler.go
@@ -102,7 +102,7 @@ func (h *Handler) getZones(cache provider.ZoneCache) (provider.DNSHostedZones, e
 				}
 				return true, nil
 			}
-			err := h.access.ListRecords(z.DomainName, f)
+			err := h.access.ListRecords(z.DomainId, z.DomainName, f)
 			if err != nil {
 				if checkAccessForbidden(err) {
 					// It is reasonable for some RAM user, it is only allowed to access certain domain's records detail
@@ -132,7 +132,7 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, cache provider.ZoneC
 		//fmt.Printf("**** found %s %s: %s\n", a.GetType(), a.GetDNSName(), a.GetValue() )
 		return true, nil
 	}
-	err := h.access.ListRecords(zone.Key(), f)
+	err := h.access.ListRecords(zone.Id(), zone.Key(), f)
 	if err != nil {
 		return nil, perrs.WrapAsHandlerError(err, "list records failed")
 	}

--- a/pkg/controller/provider/aws/execution.go
+++ b/pkg/controller/provider/aws/execution.go
@@ -124,7 +124,7 @@ func (this *Execution) submitChanges(metrics provider.Metrics) error {
 			},
 		}
 
-		metrics.AddRequests(provider.M_UPDATERECORDS, 1)
+		metrics.AddZoneRequests(this.zone.Id(), provider.M_UPDATERECORDS, 1)
 		this.rateLimiter.Accept()
 		if _, err := this.r53.ChangeResourceRecordSets(params); err != nil {
 			this.Errorf("%d records in zone %s fail: %s", len(changes), this.zone.Id(), err)

--- a/pkg/controller/provider/aws/handler.go
+++ b/pkg/controller/provider/aws/handler.go
@@ -132,7 +132,7 @@ func (h *Handler) getZones(cache provider.ZoneCache) (provider.DNSHostedZones, e
 		for _, zone := range resp.HostedZones {
 			raw = append(raw, zone)
 		}
-		h.config.Metrics.AddRequests(rt, 1)
+		h.config.Metrics.AddGenericRequests(rt, 1)
 		rt = provider.M_PLISTZONES
 		return true
 	}
@@ -224,7 +224,7 @@ func (h *Handler) handleRecordSets(zone provider.DNSHostedZone, f func(rs *route
 	inp := (&route53.ListResourceRecordSetsInput{}).SetHostedZoneId(zone.Id())
 	forwarded := []string{}
 	aggr := func(resp *route53.ListResourceRecordSetsOutput, lastPage bool) (shouldContinue bool) {
-		h.config.Metrics.AddRequests(rt, 1)
+		h.config.Metrics.AddZoneRequests(zone.Id(), rt, 1)
 		for _, r := range resp.ResourceRecordSets {
 			f(r)
 			if aws.StringValue(r.Type) == dns.RS_NS {

--- a/pkg/controller/provider/azure/execution.go
+++ b/pkg/controller/provider/azure/execution.go
@@ -137,13 +137,15 @@ func (exec *Execution) update(recordType azure.RecordType, rset *azure.RecordSet
 	exec.handler.config.RateLimiter.Accept()
 	_, err := exec.handler.recordsClient.CreateOrUpdate(exec.handler.ctx, exec.resourceGroup, exec.zoneName, *rset.Name,
 		recordType, *rset, "", "")
-	metrics.AddRequests("RecordSetsClient_CreateOrUpdate", 1)
+	zoneID := makeZoneID(exec.resourceGroup, exec.zoneName)
+	metrics.AddZoneRequests(zoneID, provider.M_UPDATERECORDS, 1)
 	return err
 }
 
 func (exec *Execution) delete(recordType azure.RecordType, rset *azure.RecordSet, metrics provider.Metrics) error {
 	exec.handler.config.RateLimiter.Accept()
 	_, err := exec.handler.recordsClient.Delete(exec.handler.ctx, exec.resourceGroup, exec.zoneName, *rset.Name, recordType, "")
-	metrics.AddRequests("RecordSetsClient_Delete", 1)
+	zoneID := makeZoneID(exec.resourceGroup, exec.zoneName)
+	metrics.AddZoneRequests(zoneID, provider.M_DELETERECORDS, 1)
 	return err
 }

--- a/pkg/controller/provider/google/execution.go
+++ b/pkg/controller/provider/google/execution.go
@@ -94,7 +94,7 @@ func (this *Execution) submitChanges(metrics provider.Metrics) error {
 		this.Infof("desired change: Addition %s %s: %s", c.Name, c.Type, utils.Strings(c.Rrdatas...))
 	}
 
-	metrics.AddRequests(provider.M_UPDATERECORDS, 1)
+	metrics.AddZoneRequests(this.zone.Id(), provider.M_UPDATERECORDS, 1)
 	this.handler.config.RateLimiter.Accept()
 	projectID, zoneName := SplitZoneID(this.zone.Id())
 	if _, err := this.handler.service.Changes.Create(projectID, zoneName, this.change).Do(); err != nil {

--- a/pkg/controller/provider/google/handler.go
+++ b/pkg/controller/provider/google/handler.go
@@ -110,7 +110,7 @@ func (h *Handler) getZones(cache provider.ZoneCache) (provider.DNSHostedZones, e
 		for _, zone := range resp.ManagedZones {
 			raw = append(raw, zone)
 		}
-		h.config.Metrics.AddRequests(rt, 1)
+		h.config.Metrics.AddGenericRequests(rt, 1)
 		rt = provider.M_PLISTZONES
 		return nil
 	}
@@ -153,7 +153,7 @@ func (h *Handler) handleRecordSets(zone provider.DNSHostedZone, f func(r *google
 				}
 			}
 		}
-		h.config.Metrics.AddRequests(rt, 1)
+		h.config.Metrics.AddZoneRequests(zone.Id(), rt, 1)
 		rt = provider.M_PLISTRECORDS
 		return nil
 	}

--- a/pkg/controller/provider/infoblox/access.go
+++ b/pkg/controller/provider/infoblox/access.go
@@ -44,20 +44,20 @@ func NewAccess(client ibclient.IBConnector, view string, metrics provider.Metric
 	}
 }
 
-func (this *access) CreateRecord(r raw.Record) error {
-	this.metrics.AddRequests(provider.M_CREATERECORDS, 1)
+func (this *access) CreateRecord(r raw.Record, zone provider.DNSHostedZone) error {
+	this.metrics.AddZoneRequests(zone.Id(), provider.M_CREATERECORDS, 1)
 	_, err := this.CreateObject(r.(ibclient.IBObject))
 	return err
 }
 
-func (this *access) UpdateRecord(r raw.Record) error {
-	this.metrics.AddRequests(provider.M_CREATERECORDS, 1)
+func (this *access) UpdateRecord(r raw.Record, zone provider.DNSHostedZone) error {
+	this.metrics.AddZoneRequests(zone.Id(), provider.M_CREATERECORDS, 1)
 	_, err := this.UpdateObject(r.(Record).PrepareUpdate().(ibclient.IBObject), r.GetId())
 	return err
 }
 
-func (this *access) DeleteRecord(r raw.Record) error {
-	this.metrics.AddRequests(provider.M_DELETERECORDS, 1)
+func (this *access) DeleteRecord(r raw.Record, zone provider.DNSHostedZone) error {
+	this.metrics.AddZoneRequests(zone.Id(), provider.M_DELETERECORDS, 1)
 	_, err := this.DeleteObject(r.GetId())
 	return err
 }

--- a/pkg/controller/provider/infoblox/handler.go
+++ b/pkg/controller/provider/infoblox/handler.go
@@ -181,7 +181,7 @@ func NewHandler(config *provider.DNSHandlerConfig) (provider.DNSHandler, error) 
 
 func (h *Handler) getZones(cache provider.ZoneCache) (provider.DNSHostedZones, error) {
 	var raw []ibclient.ZoneAuth
-	h.config.Metrics.AddRequests(provider.M_LISTZONES, 1)
+	h.config.Metrics.AddGenericRequests(provider.M_LISTZONES, 1)
 	obj := ibclient.NewZoneAuth(ibclient.ZoneAuth{})
 	err := h.access.GetObject(obj, "", &raw)
 	if err != nil {
@@ -190,7 +190,7 @@ func (h *Handler) getZones(cache provider.ZoneCache) (provider.DNSHostedZones, e
 
 	zones := provider.DNSHostedZones{}
 	for _, z := range raw {
-		h.config.Metrics.AddRequests(provider.M_LISTRECORDS, 1)
+		h.config.Metrics.AddZoneRequests(z.Ref, provider.M_LISTRECORDS, 1)
 		var resN []RecordNS
 		objN := ibclient.NewRecordNS(
 			ibclient.RecordNS{
@@ -218,7 +218,7 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, cache provider.ZoneC
 	state := raw.NewState()
 	rt := provider.M_LISTRECORDS
 
-	h.config.Metrics.AddRequests(rt, 1)
+	h.config.Metrics.AddZoneRequests(zone.Id(), rt, 1)
 	var resA []RecordA
 	objA := ibclient.NewRecordA(
 		ibclient.RecordA{
@@ -234,7 +234,7 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, cache provider.ZoneC
 		state.AddRecord((*RecordA)(&res).Copy())
 	}
 
-	h.config.Metrics.AddRequests(rt, 1)
+	h.config.Metrics.AddZoneRequests(zone.Id(), rt, 1)
 	var resC []RecordCNAME
 	objC := ibclient.NewRecordCNAME(
 		ibclient.RecordCNAME{
@@ -250,7 +250,7 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, cache provider.ZoneC
 		state.AddRecord((*RecordCNAME)(&res).Copy())
 	}
 
-	h.config.Metrics.AddRequests(rt, 1)
+	h.config.Metrics.AddZoneRequests(zone.Id(), rt, 1)
 	var resT []RecordTXT
 	objT := ibclient.NewRecordTXT(
 		ibclient.RecordTXT{

--- a/pkg/controller/provider/openstack/handler_test.go
+++ b/pkg/controller/provider/openstack/handler_test.go
@@ -178,14 +178,6 @@ func (c *designateMockClient) DeleteRecordSet(zoneID, recordSetID string) error 
 	return nil
 }
 
-func (c *designateMockClient) GetRecordSet(zoneID, recordSetID string, handler func(recordSet *recordsets.RecordSet) error) error {
-	_, rs, err := c.getRecordSet(zoneID, recordSetID)
-	if err != nil {
-		return err
-	}
-	return handler(rs)
-}
-
 func newMockHandler(mockZones ...*zones.Zone) *Handler {
 	c := designateMockClient{
 		tzmap: map[string]*testzone{},

--- a/pkg/dns/provider/inmemory.go
+++ b/pkg/dns/provider/inmemory.go
@@ -99,13 +99,13 @@ func (m *InMemory) AddZone(zone DNSHostedZone) bool {
 	return true
 }
 
-func (m *InMemory) Apply(zoneId string, request *ChangeRequest, metrics Metrics) error {
+func (m *InMemory) Apply(zoneID string, request *ChangeRequest, metrics Metrics) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	data, ok := m.zones[zoneId]
+	data, ok := m.zones[zoneID]
 	if !ok {
-		return fmt.Errorf("DNSZone %s not hosted", zoneId)
+		return fmt.Errorf("DNSZone %s not hosted", zoneID)
 	}
 
 	name, rset := buildRecordSet(request)
@@ -113,10 +113,10 @@ func (m *InMemory) Apply(zoneId string, request *ChangeRequest, metrics Metrics)
 	switch request.Action {
 	case R_CREATE, R_UPDATE:
 		data.dnssets.AddRecordSet(name, rset)
-		metrics.AddRequests("AddRecordSet", 1)
+		metrics.AddZoneRequests(zoneID, M_UPDATERECORDS, 1)
 	case R_DELETE:
 		data.dnssets.RemoveRecordSet(name, rset.Type)
-		metrics.AddRequests("RemoveRecordSet", 1)
+		metrics.AddZoneRequests(zoneID, M_DELETERECORDS, 1)
 	}
 	return nil
 }

--- a/pkg/dns/provider/interface.go
+++ b/pkg/dns/provider/interface.go
@@ -174,7 +174,8 @@ const (
 )
 
 type Metrics interface {
-	AddRequests(request_type string, n int)
+	AddGenericRequests(request_type string, n int)
+	AddZoneRequests(zoneID, request_type string, n int)
 }
 
 type Finalizers interface {

--- a/pkg/dns/provider/provider.go
+++ b/pkg/dns/provider/provider.go
@@ -84,8 +84,12 @@ func NewDNSAccount(config utils.Properties, handler DNSHandler, hash string) *DN
 	}
 }
 
-func (this *DNSAccount) AddRequests(requestType string, n int) {
-	metrics.AddRequests(this.handler.ProviderType(), this.hash, requestType, n)
+func (this *DNSAccount) AddGenericRequests(requestType string, n int) {
+	metrics.AddRequests(this.handler.ProviderType(), this.hash, requestType, n, nil)
+}
+
+func (this *DNSAccount) AddZoneRequests(zoneID, requestType string, n int) {
+	metrics.AddRequests(this.handler.ProviderType(), this.hash, requestType, n, &zoneID)
 }
 
 func (this *DNSAccount) ProviderType() string {

--- a/pkg/dns/provider/raw/execution.go
+++ b/pkg/dns/provider/raw/execution.go
@@ -26,9 +26,9 @@ import (
 )
 
 type Executor interface {
-	CreateRecord(r Record) error
-	UpdateRecord(r Record) error
-	DeleteRecord(r Record) error
+	CreateRecord(r Record, zone provider.DNSHostedZone) error
+	UpdateRecord(r Record, zone provider.DNSHostedZone) error
+	DeleteRecord(r Record, zone provider.DNSHostedZone) error
 
 	NewRecord(fqdn, rtype, value string, zone provider.DNSHostedZone, ttl int64) Record
 }
@@ -171,8 +171,8 @@ func (this *Execution) SubmitChanges() error {
 	return nil
 }
 
-func (this *Execution) submit(f func(record Record) error, r Record) {
-	err := f(r)
+func (this *Execution) submit(f func(record Record, zone provider.DNSHostedZone) error, r Record) {
+	err := f(r, this.zone)
 	if err != nil {
 		res := this.results[r.GetDNSName()]
 		if res != nil {

--- a/pkg/dns/provider/utils.go
+++ b/pkg/dns/provider/utils.go
@@ -24,7 +24,10 @@ type NullMetrics struct{}
 
 var _ Metrics = &NullMetrics{}
 
-func (m *NullMetrics) AddRequests(request_type string, n int) {
+func (m *NullMetrics) AddGenericRequests(request_type string, n int) {
+}
+
+func (m *NullMetrics) AddZoneRequests(zon, request_type string, n int) {
 }
 
 func copyZones(src map[string]*dnsHostedZone) dnsHostedZones {


### PR DESCRIPTION

**What this PR does / why we need it**:
The metrics `external_dns_management_total_provider_requests` does not contain information about the zone and if there are multiple zones per account, the counts cannot distinguish between them.
This PR addes a metrics `external_dns_management_requests_per_zone` which provides a metrics for each zone and account hash.
Additionally a metrics `external_dns_management_zone_cache_discardings` was added to allow monitoring of zone cache discards. 
The request_test for updates was harmonized for all providers.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Added `external_dns_management_requests_per_zone` and `external_dns_management_zone_cache_discardings` metrics
```
