### PR TITLE
Only reconcile affected zones on owner changes to reduce work load

### DIFF
--- a/pkg/dns/dnsset.go
+++ b/pkg/dns/dnsset.go
@@ -85,6 +85,18 @@ func (dnssets DNSSets) Clone() DNSSets {
 	return clone
 }
 
+// GetOwners returns all owners for all DNSSets
+func (dnssets DNSSets) GetOwners() utils.StringSet {
+	owners := utils.NewStringSet()
+	for _, dnsset := range dnssets {
+		o := dnsset.GetAttr(ATTR_OWNER)
+		if o != "" {
+			owners.Add(o)
+		}
+	}
+	return owners
+}
+
 const (
 	ATTR_OWNER  = "owner"
 	ATTR_PREFIX = "prefix"

--- a/pkg/dns/provider/changemodel.go
+++ b/pkg/dns/provider/changemodel.go
@@ -218,6 +218,7 @@ func (this *ChangeModel) Setup() error {
 		return err
 	}
 	sets := this.zonestate.GetDNSSets()
+	this.context.zone.SetOwners(sets.GetOwners())
 	this.dangling = newChangeGroup("dangling entries", provider, this)
 	for dnsName, set := range sets {
 		var view *ChangeGroup

--- a/pkg/dns/provider/state.go
+++ b/pkg/dns/provider/state.go
@@ -566,15 +566,15 @@ func (this *state) updateZones(logger logger.LogContext, last, new *dnsProviderV
 		name = last.ObjectName()
 		old := this.providerzones[name]
 		if old != nil {
-			for n, z := range old {
-				if result[n] == nil {
+			for zoneid, z := range old {
+				if result[zoneid] == nil {
 					modified = true
-					this.removeProviderForZone(n, name)
+					this.removeProviderForZone(zoneid, name)
 					logger.Infof("removing provider %q for hosted zone %q (%s)", name, z.Id(), z.Domain())
-					if !this.hasProvidersForZone(n) {
+					if !this.hasProvidersForZone(zoneid) {
 						logger.Infof("removing hosted zone %q (%s)", z.Id(), z.Domain())
 						metrics.DeleteZone(z.Id())
-						delete(this.zones, n)
+						delete(this.zones, zoneid)
 					}
 				}
 			}

--- a/pkg/dns/provider/state_owner.go
+++ b/pkg/dns/provider/state_owner.go
@@ -51,7 +51,7 @@ func (this *state) UpdateOwner(logger logger.LogContext, owner *dnsutils.DNSOwne
 	logger.Debugf("       active owner ids %s", active)
 	if len(changed) > 0 {
 		this.TriggerEntriesByOwner(logger, changed)
-		this.TriggerHostedZones()
+		this.TriggerHostedZonesByChangedOwners(logger, changed)
 	}
 	return reconcile.Succeeded(logger)
 }
@@ -64,7 +64,7 @@ func (this *state) OwnerDeleted(logger logger.LogContext, key resources.ObjectKe
 	logger.Debugf("       active owner ids %s", active)
 	if len(changed) > 0 {
 		this.TriggerEntriesByOwner(logger, changed)
-		this.TriggerHostedZones()
+		this.TriggerHostedZonesByChangedOwners(logger, changed)
 	}
 	return reconcile.Succeeded(logger)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR avoids reconciliations of all zones if `DNSOwners` are added or removed.
Only zones are fully reconciled which have DNS records for the changed owners.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Only reconcile affected zones on owner changes to reduce work load
```
