### PR TITLE
Fix blueprint for landscaper based deployment of component dns-external

### DIFF
--- a/.landscaper/blueprint/deploy-executions.yaml
+++ b/.landscaper/blueprint/deploy-executions.yaml
@@ -16,7 +16,7 @@ deployItems:
           apiVersion: core.gardener.cloud/v1beta1
           kind: ControllerDeployment
           metadata:
-            name: dns-controller-manager
+            name: dns-external
           type: helm
           providerConfig:
             {{- $chart := getResource .cd "name" "dns-controller-manager-chart" }}
@@ -37,11 +37,11 @@ deployItems:
           apiVersion: core.gardener.cloud/v1beta1
           kind: ControllerRegistration
           metadata:
-            name: dns-controller-manager
+            name: dns-external
           spec:
             deployment:
               deploymentRefs:
-                - name: dns-controller-manager
+                - name: dns-external
             resources:
             - kind: DNSProvider
               type: aws-route53
@@ -55,7 +55,3 @@ deployItems:
               type: openstack-designate
             - kind: DNSProvider
               type: cloudflare-dns
-            - kind: DNSProvider
-              type: infoblox-dns
-            - kind: DNSProvider
-              type: netlify-dns 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR contains corrections for the blueprint of the dns-external component. It fixes:
- the names of the controller deployment and controller registration, and 
- the list of resources in the controller registration.

This PR concerns the landscaper based deployment, which is not yet active. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
