### PR TITLE
Landscaper based deployment: change updateStrategy from patch to update

### DIFF
--- a/.landscaper/blueprint/deploy-executions.yaml
+++ b/.landscaper/blueprint/deploy-executions.yaml
@@ -8,7 +8,7 @@ deployItems:
     apiVersion: manifest.deployer.landscaper.gardener.cloud/v1alpha2
     kind: ProviderConfiguration
 
-    updateStrategy: patch
+    updateStrategy: update
 
     manifests:
       - policy: manage


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR concerns the Landscaper based deployment of the dns-external component. It does not change the deployed resources, but only the behaviour of the Landscaper:
- the updateStrategy in the manifest deploy item is changed to `update`.

The Landscaper based deployment is not yet activated. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
