### PR TITLE
stop using pkg/errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/netlify/open-api v1.1.0
 	github.com/onsi/ginkgo v1.15.0
 	github.com/onsi/gomega v1.10.5
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.7.1
 	go.uber.org/atomic v1.6.0
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b

--- a/pkg/controller/provider/infoblox/handler.go
+++ b/pkg/controller/provider/infoblox/handler.go
@@ -27,8 +27,6 @@ import (
 	"strconv"
 
 	"github.com/gardener/controller-manager-library/pkg/logger"
-	"github.com/pkg/errors"
-
 	"github.com/gardener/external-dns-management/pkg/dns"
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 	"github.com/gardener/external-dns-management/pkg/dns/provider/raw"
@@ -132,14 +130,14 @@ func NewHandler(config *provider.DNSHandlerConfig) (provider.DNSHandler, error) 
 	if infobloxConfig.CaCert != nil && verify == "true" {
 		tmpfile, err := ioutil.TempFile("", "cacert")
 		if err != nil {
-			return nil, errors.Wrap(err, "cannot create temporary file for cacert")
+			return nil, fmt.Errorf("cannot create temporary file for cacert: %w", err)
 		}
 		defer os.Remove(tmpfile.Name())
 		if _, err := tmpfile.Write([]byte(*infobloxConfig.CaCert)); err != nil {
-			return nil, errors.Wrap(err, "cannot write temporary file for cacert")
+			return nil, fmt.Errorf("cannot write temporary file for cacert: %w", err)
 		}
 		if err := tmpfile.Close(); err != nil {
-			return nil, errors.Wrap(err, "cannot close temporary file for cacert")
+			return nil, fmt.Errorf("cannot close temporary file for cacert: %w", err)
 		}
 		verify = tmpfile.Name()
 	}
@@ -151,7 +149,7 @@ func NewHandler(config *provider.DNSHandlerConfig) (provider.DNSHandler, error) 
 	if infobloxConfig.ProxyURL != nil && *infobloxConfig.ProxyURL != "" {
 		u, err := url.Parse(*infobloxConfig.ProxyURL)
 		if err != nil {
-			return nil, errors.Wrap(err, "parsing proxy url failed")
+			return nil, fmt.Errorf("parsing proxy url failed: %w", err)
 		}
 		transportConfig.ProxyUrl = u
 	}

--- a/pkg/controller/replication/dnsprovider/handler.go
+++ b/pkg/controller/replication/dnsprovider/handler.go
@@ -32,7 +32,6 @@ import (
 	"github.com/gardener/external-dns-management/pkg/dns"
 	"github.com/gardener/external-dns-management/pkg/dns/source"
 	dnsutils "github.com/gardener/external-dns-management/pkg/dns/utils"
-	errors2 "github.com/pkg/errors"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 )
@@ -276,7 +275,7 @@ func (this *sourceReconciler) updateEntryFor(logger logger.LogContext, obj resou
 
 		changed, err := this.updateSecretIfNeeded(logger, target, slave, obj)
 		if err != nil {
-			return false, errors2.Wrapf(err, "updating secret failed")
+			return false, fmt.Errorf("updating secret failed: %w", err)
 		}
 		mod.Modify(changed)
 
@@ -367,7 +366,7 @@ func (this *sourceReconciler) writeTargetSecret(logger logger.LogContext, target
 	resources.SetOwnerReference(secret, slave.GetOwnerReference())
 	_, err := this.resTargetSecrets.CreateOrUpdate(secret)
 	if err != nil {
-		return errors2.Wrapf(err, "cannot write secret %s for slave provider %s/%s", secret.Name, target.Namespace, target.Name)
+		return fmt.Errorf("cannot write secret %s for slave provider %s/%s: %w", secret.Name, target.Namespace, target.Name, err)
 	}
 	target.Spec.SecretRef = &core.SecretReference{
 		Name:      secret.Name,
@@ -386,7 +385,7 @@ func (this *sourceReconciler) updateSourceStatus(source *api.DNSProvider, source
 		return mod.IsModified(), nil
 	})
 	if err != nil {
-		return false, errors2.Wrapf(err, "cannot update source DNS provider")
+		return false, fmt.Errorf("cannot update source DNS provider: %w", err)
 	}
 	return mod, nil
 }

--- a/pkg/controller/replication/dnsprovider/slaves.go
+++ b/pkg/controller/replication/dnsprovider/slaves.go
@@ -17,6 +17,7 @@
 package dnsprovider
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
@@ -27,7 +28,6 @@ import (
 	utils2 "github.com/gardener/controller-manager-library/pkg/utils"
 	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"github.com/gardener/external-dns-management/pkg/dns/source"
-	errors2 "github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gardener/external-dns-management/pkg/dns/utils"
@@ -101,7 +101,7 @@ func (this *slaveReconciler) Reconcile(logger logger.LogContext, obj resources.O
 				if mod.IsModified() {
 					err = o.UpdateStatus()
 					if err != nil {
-						return reconcile.DelayOnError(logger, errors2.Wrapf(err, "Cannot update status of %s", o.ObjectName()))
+						return reconcile.DelayOnError(logger, fmt.Errorf("cannot update status of %s: %w", o.ObjectName(), err))
 					}
 				}
 			} else {

--- a/pkg/dns/provider/config.go
+++ b/pkg/dns/provider/config.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/gardener/controller-manager-library/pkg/config"
 	"github.com/gardener/controller-manager-library/pkg/utils"
-	pkgerrors "github.com/pkg/errors"
 )
 
 // FactoryOptions is a set of generic options and
@@ -269,7 +268,7 @@ func (c *DNSHandlerConfig) Complete() error {
 		var err error
 		rateLimiter, err = rateLimiterConfig.NewRateLimiter()
 		if err != nil {
-			return pkgerrors.Wrap(err, "invalid rate limiter")
+			return fmt.Errorf("invalid rate limiter: %w", err)
 		}
 		c.Logger.Infof("rate limiter: %v", rateLimiterConfig)
 	}

--- a/pkg/dns/provider/errors/handlererror.go
+++ b/pkg/dns/provider/errors/handlererror.go
@@ -17,7 +17,7 @@
 package errors
 
 import (
-	pkgerrors "github.com/pkg/errors"
+	"fmt"
 )
 
 type handlerError struct {
@@ -25,11 +25,12 @@ type handlerError struct {
 }
 
 func WrapAsHandlerError(err error, msg string) error {
-	return pkgerrors.Wrap(&handlerError{err: err}, msg)
+	return fmt.Errorf("%s: %w", msg, &handlerError{err: err})
 }
 
 func WrapfAsHandlerError(err error, msg string, args ...interface{}) error {
-	return pkgerrors.Wrapf(&handlerError{err: err}, msg, args...)
+	s := fmt.Sprintf(msg, args...)
+	return WrapAsHandlerError(err, s)
 }
 
 func IsHandlerError(err error) bool {

--- a/pkg/dns/provider/provider.go
+++ b/pkg/dns/provider/provider.go
@@ -27,8 +27,6 @@ import (
 	"sync"
 	"time"
 
-	pkgerrors "github.com/pkg/errors"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -381,7 +379,7 @@ func updateDNSProvider(logger logger.LogContext, state *state, provider *dnsutil
 	zones, err := this.account.GetZones()
 	if err != nil {
 		this.zones = nil
-		return this, this.failed(logger, false, pkgerrors.Wrap(err, "cannot get hosted zones"), true)
+		return this, this.failed(logger, false, fmt.Errorf("cannot get hosted zones: %w", err), true)
 	}
 	if len(zones) == 0 {
 		empty := utils.StringSet{}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -342,7 +342,6 @@ github.com/onsi/gomega/types
 # github.com/pelletier/go-toml v1.8.1
 github.com/pelletier/go-toml
 # github.com/pkg/errors v0.9.1
-## explicit
 github.com/pkg/errors
 # github.com/prometheus/client_golang v1.7.1
 ## explicit


### PR DESCRIPTION
**What this PR does / why we need it**:
Replace usage of `github.com/pkg/errors` with using `%w` to wrap error.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Similar to https://github.com/gardener/gardener/pull/4338

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
