### PR TITLE
add support for image digest references in helm chart

### DIFF
--- a/charts/external-dns-management/templates/_helpers.tpl
+++ b/charts/external-dns-management/templates/_helpers.tpl
@@ -40,3 +40,11 @@ scheduling.k8s.io/v1beta1
 scheduling.k8s.io/v1alpha1
 {{- end -}}
 {{- end -}}
+
+{{- define "image" -}}
+{{- if hasPrefix "sha256:" (required "$.tag is required" $.tag) -}}
+{{ required "$.repository is required" $.repository }}@{{ required "$.tag is required" $.tag }}
+{{- else -}}
+{{ required "$.repository is required" $.repository }}:{{ required "$.tag is required" $.tag }}
+{{- end -}}
+{{- end -}}

--- a/charts/external-dns-management/templates/deployment.yaml
+++ b/charts/external-dns-management/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
         runAsUser: 65534
       containers:
       - name: dns-controller-manager
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ include "image" .Values.image }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support in the helm chart for image references with digest

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
