### PR TITLE
Add annotation for prometheus scraping

### DIFF
--- a/charts/external-dns-management/templates/deployment.yaml
+++ b/charts/external-dns-management/templates/deployment.yaml
@@ -22,6 +22,10 @@ spec:
     metadata:
       annotations:
         checksum/psp: {{ include (print $.Template.BasePath "/psp.yaml") . | sha256sum }}
+{{- if .Values.configuration.serverPortHttp }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "{{- .Values.configuration.serverPortHttp }}"
+{{- end }}
       labels:
         app.kubernetes.io/name: {{ include "external-dns-management.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
**What this PR does / why we need it**:
To enable scraping by prometheus, annotations have to be added for the extension pods.
See https://github.com/gardener/gardener/pull/4560

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add annotation for prometheus scraping
```
