### PR TITLE
Fix provider domain selection: allow final dot and uppercase

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 #############      builder       #############
-FROM eu.gcr.io/gardener-project/3rd/golang:1.16.6 AS builder
+FROM eu.gcr.io/gardener-project/3rd/golang:1.16.7 AS builder
 
 WORKDIR /build
 COPY . .

--- a/pkg/dns/provider/selection/selection.go
+++ b/pkg/dns/provider/selection/selection.go
@@ -101,11 +101,11 @@ func CalcZoneAndDomainSelection(spec v1alpha1.DNSProviderSpec, zones []LightDNSH
 	}
 
 	var err error
-	this.DomainSel.Include, err = filterByZones(this.SpecDomainSel.Include, this.Zones)
+	this.DomainSel.Include, err = filterByZones(normalizeDomains(this.SpecDomainSel.Include), this.Zones)
 	if err != nil {
 		this.Warnings = append(this.Warnings, err.Error())
 	}
-	this.DomainSel.Exclude, err = filterByZones(this.SpecDomainSel.Exclude, this.Zones)
+	this.DomainSel.Exclude, err = filterByZones(normalizeDomains(this.SpecDomainSel.Exclude), this.Zones)
 	if err != nil {
 		this.Warnings = append(this.Warnings, err.Error())
 	}
@@ -224,4 +224,17 @@ func collectForwardedSubdomains(includedDomains utils.StringSet, excludedDomains
 		}
 	}
 	return include, exclude
+}
+
+func normalizeDomains(domains utils.StringSet) utils.StringSet {
+	if len(domains) == 0 {
+		return domains
+	}
+
+	normalized := utils.NewStringSet()
+	for k := range domains {
+		k = strings.TrimSuffix(strings.ToLower(k), ".")
+		normalized.Add(k)
+	}
+	return normalized
 }

--- a/pkg/dns/provider/selection/selection_test.go
+++ b/pkg/dns/provider/selection/selection_test.go
@@ -74,6 +74,32 @@ var _ = Describe("Selection", func() {
 		}))
 	})
 
+	It("deals with uppercase domain selection and final dot", func() {
+		spec := v1alpha1.DNSProviderSpec{
+			Domains: &v1alpha1.DNSSelection{
+				Include: []string{"A.b."},
+				Exclude: []string{"O.P."},
+			},
+		}
+		result := CalcZoneAndDomainSelection(spec, allzones)
+		Expect(result).To(Equal(SelectionResult{
+			Zones:       []LightDNSHostedZone{zab, zcab},
+			SpecZoneSel: NewSubSelection(),
+			SpecDomainSel: SubSelection{
+				Include: utils.NewStringSet("A.b."),
+				Exclude: utils.NewStringSet("O.P."),
+			},
+			ZoneSel: SubSelection{
+				Include: utils.NewStringSet("ZAB", "ZCAB"),
+				Exclude: utils.NewStringSet("ZOP"),
+			},
+			DomainSel: SubSelection{
+				Include: utils.NewStringSet("a.b", "c.a.b"),
+				Exclude: utils.NewStringSet("d.a.b", "o.p"),
+			},
+		}))
+	})
+
 	It("handles no zones", func() {
 		spec := v1alpha1.DNSProviderSpec{}
 		result := CalcZoneAndDomainSelection(spec, nozones)


### PR DESCRIPTION
**What this PR does / why we need it**:
The `DNSProvider` spec fields `spec.domains.include` and `spec.domains.exclude` did not deal with uppercase names and a final `.`. With the PR these values are normalised before they are used.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix provider domain selection: allow final dot and uppercase
```
