### PR TITLE
Fix apiVersion for rbac

### DIFF
--- a/charts/external-dns-management/templates/clusterrole.yaml
+++ b/charts/external-dns-management/templates/clusterrole.yaml
@@ -1,9 +1,5 @@
 ---
-{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
 apiVersion: rbac.authorization.k8s.io/v1
-{{- else }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
-{{- end }}
 kind: ClusterRole
 metadata:
   name: {{ include "external-dns-management.fullname" . }}

--- a/charts/external-dns-management/templates/clusterrolebinding.yaml
+++ b/charts/external-dns-management/templates/clusterrolebinding.yaml
@@ -1,9 +1,5 @@
 ---
-{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
 apiVersion: rbac.authorization.k8s.io/v1
-{{- else }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
-{{- end }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "external-dns-management.fullname" . }}

--- a/charts/external-dns-management/templates/role.yaml
+++ b/charts/external-dns-management/templates/role.yaml
@@ -1,9 +1,5 @@
 ---
-{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
 apiVersion: rbac.authorization.k8s.io/v1
-{{- else }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
-{{- end }}
 kind: Role
 metadata:
   name: {{ include "external-dns-management.fullname" . }}

--- a/charts/external-dns-management/templates/rolebinding.yaml
+++ b/charts/external-dns-management/templates/rolebinding.yaml
@@ -1,9 +1,5 @@
 ---
-{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
 apiVersion: rbac.authorization.k8s.io/v1
-{{- else }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
-{{- end }}
 kind: RoleBinding
 metadata:
   name: {{ include "external-dns-management.fullname" . }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Deployment of chart as `ManagedResource` fails as Helm function `.Capabilities.APIVersions.Has` is not supported in this context. Therefore the apiVersion `rbac.authorization.k8s.io/v1` is always used now.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix deployment of chart as ManagedResource for K8s >=1.22 because of wrong apiVersion of RBAC
```
