### PR TITLE
Fix provider zones check if forwarded subdomain included

### DIFF
--- a/pkg/controller/provider/mock/handler.go
+++ b/pkg/controller/provider/mock/handler.go
@@ -38,8 +38,9 @@ type Handler struct {
 }
 
 type MockZone struct {
-	ZonePrefix string `json:"zonePrefix"`
-	DNSName    string `json:"dnsName"`
+	ZonePrefix       string   `json:"zonePrefix"`
+	DNSName          string   `json:"dnsName"`
+	ForwardedDomains []string `json:"forwardedDomains,omitempty"`
 }
 
 type MockConfig struct {
@@ -75,7 +76,11 @@ func NewHandler(config *provider.DNSHandlerConfig) (provider.DNSHandler, error) 
 		if mockZone.DNSName != "" {
 			zoneID := mockZone.ZonePrefix + mockZone.DNSName
 			logger.Infof("Providing mock DNSZone %s[%s]", mockZone.DNSName, zoneID)
-			hostedZone := provider.NewDNSHostedZone(h.ProviderType(), zoneID, mockZone.DNSName, "", []string{}, false)
+			forwardedDomains := []string{}
+			if len(mockZone.ForwardedDomains) > 0 {
+				forwardedDomains = mockZone.ForwardedDomains
+			}
+			hostedZone := provider.NewDNSHostedZone(h.ProviderType(), zoneID, mockZone.DNSName, "", forwardedDomains, false)
 			mock.AddZone(hostedZone)
 		}
 	}

--- a/test/integration/testenv.go
+++ b/test/integration/testenv.go
@@ -58,6 +58,7 @@ const (
 	FailDeleteEntry
 	FailSecondZoneWithSameBaseDomain
 	AlternativeMockName
+	Domain2IsSubdomain
 )
 
 type TestEnv struct {
@@ -203,6 +204,12 @@ func (te *TestEnv) BuildProviderConfig(domain, domain2 string, failOptions ...Fa
 			{ZonePrefix: te.ZonePrefix, DNSName: domain},
 			{ZonePrefix: te.ZonePrefix + "second:", DNSName: domain2},
 		},
+	}
+	for _, opt := range failOptions {
+		switch opt {
+		case Domain2IsSubdomain:
+			input.Zones[0].ForwardedDomains = []string{domain2}
+		}
 	}
 	return te.BuildProviderConfigEx(input, failOptions...)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix bug introduced with #203. If a provider contains two zones and one is a forwarded subdomain of the other, it must not complain about overlapping domains.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
