### PR TITLE
Use current owners in change model

### DIFF
--- a/pkg/dns/dnsset.go
+++ b/pkg/dns/dnsset.go
@@ -16,7 +16,9 @@
 
 package dns
 
-import "github.com/gardener/controller-manager-library/pkg/utils"
+import (
+	"github.com/gardener/controller-manager-library/pkg/utils"
+)
 
 ////////////////////////////////////////////////////////////////////////////////
 // A DNSSet contains Record sets for an DNS name. The name is given without
@@ -50,6 +52,11 @@ import "github.com/gardener/controller-manager-library/pkg/utils"
 // an effective set and dns name for the desired purpose.
 
 type DNSSets map[string]*DNSSet
+
+type Ownership interface {
+	IsResponsibleFor(id string) bool
+	GetIds() utils.StringSet
+}
 
 func (dnssets DNSSets) AddRecordSetFromProvider(dnsname string, rs *RecordSet) {
 	name := NormalizeHostname(dnsname)
@@ -130,14 +137,14 @@ func (this *DNSSet) SetAttr(name string, value string) {
 	}
 }
 
-func (this *DNSSet) IsOwnedBy(owners utils.StringSet) bool {
+func (this *DNSSet) IsOwnedBy(ownership Ownership) bool {
 	o := this.GetAttr(ATTR_OWNER)
-	return o != "" && owners.Contains(o)
+	return o != "" && ownership.IsResponsibleFor(o)
 }
 
-func (this *DNSSet) IsForeign(owners utils.StringSet) bool {
+func (this *DNSSet) IsForeign(ownership Ownership) bool {
 	o := this.GetAttr(ATTR_OWNER)
-	return o != "" && !owners.Contains(o)
+	return o != "" && !ownership.IsResponsibleFor(o)
 }
 
 func (this *DNSSet) GetOwner() string {

--- a/pkg/dns/provider/ownercache.go
+++ b/pkg/dns/provider/ownercache.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/utils"
+	"github.com/gardener/external-dns-management/pkg/dns"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gardener/external-dns-management/pkg/dns/provider/statistic"
@@ -69,6 +70,8 @@ type OwnerCache struct {
 
 	schedule *dnsutils.Schedule
 }
+
+var _ dns.Ownership = &OwnerCache{}
 
 func NewOwnerCache(ctx ProviderCacheContext, config *Config) *OwnerCache {
 	this := &OwnerCache{

--- a/pkg/dns/provider/state.go
+++ b/pkg/dns/provider/state.go
@@ -52,7 +52,7 @@ type zoneReconciliation struct {
 	zone      *dnsHostedZone
 	providers DNSProviders
 	entries   Entries
-	ownerIds  utils.StringSet
+	ownership dns.Ownership
 	stale     DNSNames
 	dedicated bool
 	deleting  bool

--- a/pkg/dns/provider/state_provider.go
+++ b/pkg/dns/provider/state_provider.go
@@ -207,6 +207,7 @@ func (this *state) removeLocalProvider(logger logger.LogContext, obj *dnsutils.D
 						dedicated: false,
 						deleting:  false,
 						fhandler:  this.context,
+						ownership: this.ownerCache,
 					})
 					if !done {
 						return reconcile.Delay(logger, fmt.Errorf("zone reconcilation busy -> delay deletion"))

--- a/pkg/dns/provider/state_zone.go
+++ b/pkg/dns/provider/state_zone.go
@@ -61,7 +61,7 @@ func (this *state) GetZoneReconcilation(logger logger.LogContext, zoneid string)
 	this.lock.RLock()
 	defer this.lock.RUnlock()
 
-	req.ownerIds = this.ownerCache.GetIds()
+	req.ownership = this.ownerCache
 	hasProviders := this.hasProviders()
 	zone := this.zones[zoneid]
 	if zone == nil {
@@ -169,11 +169,10 @@ func (this *state) StartZoneReconcilation(logger logger.LogContext, req *zoneRec
 func (this *state) reconcileZone(logger logger.LogContext, req *zoneReconciliation) error {
 	zoneid := req.zone.Id()
 	req.zone.SetNext(time.Now().Add(this.config.Delay))
-	ownerids := req.ownerIds
 	metrics.ReportZoneEntries(req.zone.ProviderType(), zoneid, len(req.entries), len(req.stale))
 	logger.Infof("reconcile ZONE %s (%s) for %d dns entries (%d stale)", req.zone.Id(), req.zone.Domain(), len(req.entries), len(req.stale))
-	logger.Debugf("    ownerids: %s", ownerids)
-	changes := NewChangeModel(logger, ownerids, req, this.config)
+	logger.Debugf("    ownerids: %s", req.ownership.GetIds())
+	changes := NewChangeModel(logger, req.ownership, req, this.config)
 	err := changes.Setup()
 	if err != nil {
 		req.zone.Failed()


### PR DESCRIPTION
**What this PR does / why we need it**:
If a zone reconciliation takes an extraordinary long time because of request throttling, the DNS owner set used in the change model may be outdated. With this change the owners are always fetched directly from the "owner cache".

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
use owners directly from the owner cache during zone reconciliation to avoid stale information on long throttling
```
