### PR TITLE
Avoid restarts on throttling due to failed health checks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go v1.38.43
 	github.com/cloudflare/cloudflare-go v0.11.4
 	github.com/emicklei/go-restful v2.9.6+incompatible // indirect
-	github.com/gardener/controller-manager-library v0.2.1-0.20210921083513-c434afe39381
+	github.com/gardener/controller-manager-library v0.2.1-0.20210924121813-c0a3928cfc8b
 	github.com/go-openapi/runtime v0.19.15
 	github.com/go-openapi/strfmt v0.19.5
 	github.com/gophercloud/gophercloud v0.18.0
@@ -25,6 +25,7 @@ require (
 	go.uber.org/atomic v1.6.0
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	google.golang.org/api v0.20.0
 	k8s.io/api v0.20.6
 	k8s.io/apimachinery v0.20.6

--- a/go.sum
+++ b/go.sum
@@ -183,8 +183,8 @@ github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoD
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/gardener/controller-manager-library v0.2.1-0.20210921083513-c434afe39381 h1:KyvmwaTKN+qwwmx+G1ahQknXVlbROQQBLvAthMW2UxI=
-github.com/gardener/controller-manager-library v0.2.1-0.20210921083513-c434afe39381/go.mod h1:E1Abd/nMB9pbwEiEHPADjsPgbJRJG90WlU28yim2DG4=
+github.com/gardener/controller-manager-library v0.2.1-0.20210924121813-c0a3928cfc8b h1:OQCqe0ePkHtfIye6WO2yWSJvO4A1bv8jMIuBdPryutk=
+github.com/gardener/controller-manager-library v0.2.1-0.20210924121813-c0a3928cfc8b/go.mod h1:E1Abd/nMB9pbwEiEHPADjsPgbJRJG90WlU28yim2DG4=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/pkg/dns/provider/context.go
+++ b/pkg/dns/provider/context.go
@@ -54,6 +54,8 @@ type Context interface {
 	GetPoolPeriod(name string) *time.Duration
 
 	GetCluster(name string) resources.Cluster
+
+	GetPool(name string) controller.Pool
 }
 
 type DefaultContext struct {
@@ -130,4 +132,8 @@ func (this *DefaultContext) GetPoolPeriod(name string) *time.Duration {
 
 func (this *DefaultContext) GetCluster(name string) resources.Cluster {
 	return this.controller.GetCluster(name)
+}
+
+func (this *DefaultContext) GetPool(name string) controller.Pool {
+	return this.controller.GetPool(name)
 }

--- a/pkg/dns/provider/controller.go
+++ b/pkg/dns/provider/controller.go
@@ -52,6 +52,8 @@ const SYNC_ENTRIES = "entries"
 
 const FACTORY_OPTIONS = "factory"
 
+const DNS_POOL = "dns"
+
 var ownerGroupKind = resources.NewGroupKind(api.GroupName, api.DNSOwnerKind)
 var providerGroupKind = resources.NewGroupKind(api.GroupName, api.DNSProviderKind)
 var entryGroupKind = resources.NewGroupKind(api.GroupName, api.DNSEntryKind)
@@ -148,8 +150,8 @@ func DNSController(name string, factory DNSHandlerFactory) controller.Configurat
 		Watches(
 			controller.NewResourceKey(api.GroupName, api.DNSHostedZonePolicyKind),
 		).
-		WorkerPool("dns", 1, 15*time.Minute).CommandMatchers(utils.NewStringGlobMatcher(CMD_HOSTEDZONE_PREFIX+"*")).
-		WorkerPool("statistic", 1, 0).Commands(CMD_STATISTIC).
+		WorkerPool(DNS_POOL, 1, 15*time.Minute).CommandMatchers(utils.NewStringGlobMatcher(CMD_HOSTEDZONE_PREFIX+"*")).
+		WorkerPool("statistic", 2, 0).Commands(CMD_STATISTIC).
 		OptionSource(FACTORY_OPTIONS, FactoryOptionSourceCreator(factory))
 	return cfg
 }
@@ -210,7 +212,6 @@ func (this *reconciler) Setup() {
 }
 
 func (this *reconciler) Start() {
-	this.controller.GetPool("dns").StartTicker()
 	this.state.Start()
 }
 

--- a/pkg/dns/provider/entry.go
+++ b/pkg/dns/provider/entry.go
@@ -711,7 +711,7 @@ func lookupHosts(hostname string) ([]string, []string, error) {
 ///////////////////////////////////////////////////////////////////////////////
 
 type Entry struct {
-	lock       sync.Mutex
+	lock       *dnsutils.TryLock
 	key        string
 	createdAt  time.Time
 	modified   bool
@@ -723,6 +723,7 @@ type Entry struct {
 
 func NewEntry(v *EntryVersion, state *state) *Entry {
 	return &Entry{
+		lock:         dnsutils.NewTryLock(),
 		key:          v.ObjectName().String(),
 		EntryVersion: v,
 		state:        state,

--- a/pkg/dns/provider/state.go
+++ b/pkg/dns/provider/state.go
@@ -57,6 +57,7 @@ type zoneReconciliation struct {
 	dedicated bool
 	deleting  bool
 	fhandler  FinalizerHandler
+	dnsTicker *Ticker
 }
 
 type setup struct {
@@ -138,6 +139,8 @@ type state struct {
 	references *References
 
 	initialized bool
+
+	dnsTicker *Ticker
 }
 
 func NewDNSState(ctx Context, ownerresc resources.Interface, classes *controller.Classes, config Config) *state {
@@ -185,6 +188,7 @@ func (this *state) IsResponsibleFor(logger logger.LogContext, obj resources.Obje
 }
 
 func (this *state) Setup() {
+	this.dnsTicker = NewTicker(this.context.GetPool(DNS_POOL).Tick)
 	this.ownerupd = startOwnerUpdater(this.context, this.ownerresc)
 	processors, err := this.context.GetIntOption(OPT_SETUP)
 	if err != nil || processors <= 0 {

--- a/pkg/dns/provider/state_entry.go
+++ b/pkg/dns/provider/state_entry.go
@@ -270,7 +270,9 @@ func (this *state) EntryPremise(e *dnsutils.DNSEntryObject) (*EntryPremise, erro
 func (this *state) HandleUpdateEntry(logger logger.LogContext, op string, object *dnsutils.DNSEntryObject) reconcile.Status {
 	old := this.GetEntry(object.ObjectName())
 	if old != nil {
-		old.lock.Lock()
+		if !old.lock.TryLockSpinning(200 * time.Millisecond) {
+			return reconcile.RescheduleAfter(logger, 15*time.Second)
+		}
 		defer old.lock.Unlock()
 	}
 

--- a/pkg/dns/provider/state_zone.go
+++ b/pkg/dns/provider/state_zone.go
@@ -75,6 +75,7 @@ func (this *state) GetZoneReconcilation(logger logger.LogContext, zoneid string)
 	}
 	req.entries, req.stale, req.deleting = this.addEntriesForZone(logger, nil, nil, zone)
 	req.providers = this.getProvidersForZone(zoneid)
+	req.dnsTicker = this.dnsTicker
 	return 0, hasProviders, req
 }
 

--- a/pkg/dns/provider/state_zone.go
+++ b/pkg/dns/provider/state_zone.go
@@ -156,7 +156,10 @@ func (this *state) StartZoneReconcilation(logger logger.LogContext, req *zoneRec
 			}
 		}
 		logger.Infof("locking %d entries for zone reconcilation", len(list))
-		list.Lock()
+		if err := list.Lock(); err != nil {
+			logger.Warnf("locking %d entries failed: %s", len(list), err)
+			return false, err
+		}
 		defer func() {
 			logger.Infof("unlocking %d entries", len(list))
 			list.Unlock()

--- a/pkg/dns/provider/ticker.go
+++ b/pkg/dns/provider/ticker.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *
+ */
+
+package provider
+
+import (
+	"time"
+
+	"github.com/gardener/controller-manager-library/pkg/logger"
+)
+
+type Ticker struct {
+	ticker func()
+}
+
+func NewTicker(ticker func()) *Ticker {
+	return &Ticker{ticker: ticker}
+}
+
+func (t *Ticker) TickWhile(log logger.LogContext, f func()) {
+	if t != nil {
+		nextWarn := time.Now().Add(10 * time.Minute)
+		privateTicker := time.NewTicker(30 * time.Second)
+		done := make(chan struct{})
+		go func() {
+			for {
+				select {
+				case <-privateTicker.C:
+					t.ticker()
+					if time.Now().After(nextWarn) {
+						nextWarn = time.Now().Add(10 * time.Minute)
+						log.Warn("operation takes more than 10 minutes")
+					}
+				case <-done:
+					privateTicker.Stop()
+					return
+				}
+			}
+		}()
+		defer close(done)
+	}
+	f()
+}

--- a/pkg/dns/utils/trylock.go
+++ b/pkg/dns/utils/trylock.go
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *
+ */
+
+package utils
+
+import (
+	"context"
+	"time"
+
+	"golang.org/x/sync/semaphore"
+)
+
+// TryLock is a lock supporting both `Lock` and `TryLock` by wrapping a weighted semaphore.
+type TryLock struct {
+	lock *semaphore.Weighted
+	ctx  context.Context
+}
+
+// NewTryLock creates a lock based on a weighted semaphore.
+func NewTryLock() *TryLock {
+	return &TryLock{lock: semaphore.NewWeighted(1), ctx: context.TODO()}
+}
+
+// Lock acquires the lock blocking until resource is available
+func (l *TryLock) Lock() {
+	if err := l.lock.Acquire(l.ctx, 1); err != nil {
+		panic(err)
+	}
+}
+
+// TryLock tries to acquire the resource and returns true if successful.
+func (l *TryLock) TryLock() bool {
+	if !l.lock.TryAcquire(1) {
+		return false
+	}
+	return true
+}
+
+// TryLockSpinning tries to acquire the resource for some time and returns true if successful.
+func (l *TryLock) TryLockSpinning(spinTime time.Duration) bool {
+	end := time.Now().Add(spinTime)
+	waitTime := 200 * time.Microsecond
+	for {
+		if l.TryLock() {
+			return true
+		}
+		delta := end.Sub(time.Now())
+		if waitTime > delta {
+			time.Sleep(delta)
+			return l.TryLock()
+		}
+		time.Sleep(waitTime)
+		waitTime = 11 * waitTime / 10
+	}
+}
+
+// Unlock releases the resource
+func (l *TryLock) Unlock() {
+	l.lock.Release(1)
+}

--- a/pkg/dns/utils/trylock.go
+++ b/pkg/dns/utils/trylock.go
@@ -30,15 +30,25 @@ type TryLock struct {
 }
 
 // NewTryLock creates a lock based on a weighted semaphore.
-func NewTryLock() *TryLock {
-	return &TryLock{lock: semaphore.NewWeighted(1), ctx: context.TODO()}
+func NewTryLock(ctx ...context.Context) *TryLock {
+	var c context.Context
+	switch len(ctx) {
+	case 0:
+		c = context.TODO()
+	case 1:
+		c = ctx[0]
+	default:
+		panic("multiple context not allowed")
+	}
+	return &TryLock{lock: semaphore.NewWeighted(1), ctx: c}
 }
 
 // Lock acquires the lock blocking until resource is available
-func (l *TryLock) Lock() {
+func (l *TryLock) Lock() error {
 	if err := l.lock.Acquire(l.ctx, 1); err != nil {
-		panic(err)
+		return err
 	}
+	return nil
 }
 
 // TryLock tries to acquire the resource and returns true if successful.

--- a/pkg/dns/utils/trylock_test.go
+++ b/pkg/dns/utils/trylock_test.go
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package utils
+
+import (
+	"sync/atomic"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const wait = 20 * time.Microsecond
+const tryLocked = 1000000
+
+var _ = Describe("TryLock", func() {
+	It("deals correctly with lock/unlock", func() {
+		lock := NewTryLock()
+		lock.Lock()
+
+		var counter uint32
+		go func() {
+			atomic.AddUint32(&counter, 1)
+			lock.Lock()
+			atomic.AddUint32(&counter, 2)
+			lock.Unlock()
+		}()
+
+		time.Sleep(wait)
+		Expect(atomic.LoadUint32(&counter)).To(Equal(uint32(1)))
+
+		lock.Unlock()
+		time.Sleep(wait)
+		Expect(atomic.LoadUint32(&counter)).To(Equal(uint32(3)))
+
+		first := lock.TryLockSpinning(wait)
+		Expect(first).To(BeTrue())
+		second := lock.TryLockSpinning(wait)
+		Expect(second).To(BeFalse())
+		lock.Unlock()
+	})
+
+	It("deals correctly with mixture of lock/trylock", func() {
+		lock := NewTryLock()
+		lock.Lock()
+		secondLock := lock.TryLockSpinning(20 * time.Millisecond)
+		Expect(secondLock).To(BeFalse())
+
+		counters := make([]uint64, 3)
+		tryLocker := func(c *uint64) {
+			atomic.StoreUint64(c, 1)
+			for {
+				if lock.TryLock() {
+					atomic.StoreUint64(c, uint64(time.Now().Nanosecond()))
+					time.Sleep(10 * wait)
+					lock.Unlock()
+					return
+				}
+				time.Sleep(wait)
+			}
+		}
+		for i := 0; i < len(counters); i++ {
+			go tryLocker(&counters[i])
+		}
+
+		time.Sleep(wait)
+		for i := 0; i < len(counters); i++ {
+			Expect(atomic.LoadUint64(&counters[i])).To(Equal(uint64(1)))
+		}
+		lock.Unlock()
+
+		time.Sleep(2 * wait)
+		var c2 uint32
+		go func() {
+			atomic.AddUint32(&c2, 1)
+			lock.Lock()
+			atomic.AddUint32(&c2, 2)
+			lock.Unlock()
+		}()
+
+		time.Sleep(20 * wait)
+		Expect(atomic.LoadUint32(&c2)).To(Equal(uint32(3)))
+
+		for i := 0; i < len(counters); i++ {
+			for j := 0; j < len(counters); j++ {
+				if i != j && counters[i] > counters[j] {
+					Expect(counters[i]-counters[j] > uint64((10 * wait).Nanoseconds())).To(BeTrue())
+				}
+			}
+		}
+	})
+})

--- a/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/interface.go
+++ b/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/interface.go
@@ -37,7 +37,7 @@ type Environment interface {
 }
 
 type Pool interface {
-	StartTicker()
+	Tick()
 	EnqueueCommand(name string)
 	EnqueueCommandRateLimited(name string)
 	EnqueueCommandAfter(name string, duration time.Duration)

--- a/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/pool.go
+++ b/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/pool.go
@@ -148,8 +148,8 @@ func (p *pool) Period() time.Duration {
 	return p.period
 }
 
-func (p *pool) StartTicker() {
-	// noop as periodic tick is always activated
+func (p *pool) Tick() {
+	healthz.Tick(p.Key())
 }
 
 func (p *pool) Run() {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -122,7 +122,7 @@ github.com/fatih/color
 github.com/form3tech-oss/jwt-go
 # github.com/fsnotify/fsnotify v1.4.9
 github.com/fsnotify/fsnotify
-# github.com/gardener/controller-manager-library v0.2.1-0.20210921083513-c434afe39381
+# github.com/gardener/controller-manager-library v0.2.1-0.20210924121813-c0a3928cfc8b
 ## explicit
 github.com/gardener/controller-manager-library/hack
 github.com/gardener/controller-manager-library/pkg/certmgmt
@@ -433,6 +433,7 @@ golang.org/x/oauth2/internal
 golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
 # golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+## explicit
 golang.org/x/sync/semaphore
 # golang.org/x/sys v0.0.0-20210303074136-134d130e1a04
 golang.org/x/sys/internal/unsafeheader


### PR DESCRIPTION
**What this PR does / why we need it**:
We have seen reoccurring restarts if the zone reconciliation was taking multiple minutes due to request throttling.
To avoid these restarts, some changes have been introduced:
- TryLock for entry reconciliation and entries are rescheduled if lock cannot be retrieved.
- health ticks are performed during zone reconciliation requests
- second worker for statistics pool

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Avoid restarts on throttling due to failed health checks
```
