### PR TITLE
Allow to add custom volume mounts to Helm chart for AWS chain of credential providers

### DIFF
--- a/charts/external-dns-management/templates/deployment.yaml
+++ b/charts/external-dns-management/templates/deployment.yaml
@@ -796,16 +796,26 @@ spec:
         {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
-        {{- if .Values.configuration.persistentCache }}
+        {{- if or .Values.configuration.persistentCache .Values.custom.volumeMounts }}
         volumeMounts:
+          {{- if or .Values.configuration.persistentCache }}
           - name: persistent-cache
             mountPath: /persistent-cache
+          {{- end }}
+          {{- if .Values.custom.volumeMounts }}
+          {{- toYaml .Values.custom.volumeMounts | nindent 10 }}
+          {{- end }}
         {{- end }}
-      {{- if .Values.configuration.persistentCache }}
+      {{- if or .Values.configuration.persistentCache .Values.custom.volumes }}
       volumes:
+        {{- if or .Values.configuration.persistentCache }}
         - name: persistent-cache
           persistentVolumeClaim:
             claimName: {{ include "external-dns-management.fullname" . }}
+        {{- end }}
+        {{- if .Values.custom.volumes }}
+        {{- toYaml .Values.custom.volumes | nindent 8 }}
+        {{- end }}
       {{- end }}
       serviceAccountName: {{ include "external-dns-management.fullname" . }}
       priorityClassName: {{ include "external-dns-management.fullname" . }}

--- a/charts/external-dns-management/values.yaml
+++ b/charts/external-dns-management/values.yaml
@@ -302,3 +302,15 @@ gardener:
 security:
   apparmorEnabled: false
   seccompEnabled: false
+
+custom: {}
+# you may want to mount an additional volume if AWS_USE_CREDENTIALS_CHAIN is set
+#custom:
+#  volumes:
+#    - name: token
+#      secret:
+#        defaultMode: 420
+#        secretName: my-token
+#  volumeMounts:
+#    - name: token
+#      mountPath: /token

--- a/docs/aws-route53/README.md
+++ b/docs/aws-route53/README.md
@@ -96,3 +96,6 @@ data:
   # optionally specify the region
   #AWS_REGION: ...
 ```
+
+You may need to mount an additional volume as the AWS client expects environment variable with token path and volume mount with the token file.
+See Helm chart values `custom.volumes` and `custom.volumeMounts`.


### PR DESCRIPTION
**What this PR does / why we need it**:
If a deployment wants to use the AWS chain of credential providers an additional volume mount is needed to provide the token file.

**Which issue(s) this PR fixes**:
Fixes #217 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Allow to add custom volume mounts to Helm chart for AWS chain of credential providers
```
