### PR TITLE
Stricter validation of DNS name for record and metadata record

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 #############      builder       #############
-FROM eu.gcr.io/gardener-project/3rd/golang:1.16.7 AS builder
+FROM eu.gcr.io/gardener-project/3rd/golang:1.16.9 AS builder
 
 WORKDIR /build
 COPY . .

--- a/pkg/dns/dnsset.go
+++ b/pkg/dns/dnsset.go
@@ -111,8 +111,9 @@ const (
 )
 
 type DNSSet struct {
-	Name string
-	Sets RecordSets
+	Name        string
+	UpdateGroup string
+	Sets        RecordSets
 }
 
 func (this *DNSSet) Clone() *DNSSet {

--- a/pkg/dns/mapping.go
+++ b/pkg/dns/mapping.go
@@ -52,19 +52,30 @@ func MapToProvider(rtype string, dnsset *DNSSet, base string) (string, *RecordSe
 			prefix = TxtPrefix
 			dnsset.SetAttr(ATTR_PREFIX, prefix)
 		}
+		metaName := calcMetaRecordDomainName(name, prefix, base)
 		new := *dnsset.Sets[rtype]
 		new.Type = RS_TXT
-		add := ""
-		if strings.HasPrefix(name, "*.") {
-			add = "*."
-			name = name[2:]
-			if name == base {
-				prefix += "-base."
-			}
-		}
-		return add + prefix + name, &new
+		return metaName, &new
 	}
 	return name, rs
+}
+
+func calcMetaRecordDomainName(name, prefix, base string) string {
+	add := ""
+	if strings.HasPrefix(name, "*.") {
+		add = "*."
+		name = name[2:]
+		if name == base {
+			prefix += "-base."
+		}
+	}
+	return add + prefix + name
+}
+
+// CalcMetaRecordDomainNameForValidation returns domain name of metadata TXT DNS record if globally defined prefix is used.
+// As it does not consider the zone, it may be wrong for the zone base domain.
+func CalcMetaRecordDomainNameForValidation(name string) string {
+	return calcMetaRecordDomainName(name, TxtPrefix, "")
 }
 
 func MapFromProvider(dns string, rs *RecordSet) (string, *RecordSet) {

--- a/pkg/dns/provider/changemodel.go
+++ b/pkg/dns/provider/changemodel.go
@@ -243,17 +243,17 @@ func (this *ChangeModel) Setup() error {
 	return err
 }
 
-func (this *ChangeModel) Check(name string, createdAt time.Time, done DoneHandler, targets ...Target) ChangeResult {
-	return this.Exec(false, false, name, createdAt, done, targets...)
+func (this *ChangeModel) Check(name, updateGroup string, createdAt time.Time, done DoneHandler, targets ...Target) ChangeResult {
+	return this.Exec(false, false, name, updateGroup, createdAt, done, targets...)
 }
-func (this *ChangeModel) Apply(name string, createdAt time.Time, done DoneHandler, targets ...Target) ChangeResult {
-	return this.Exec(true, false, name, createdAt, done, targets...)
+func (this *ChangeModel) Apply(name, updateGroup string, createdAt time.Time, done DoneHandler, targets ...Target) ChangeResult {
+	return this.Exec(true, false, name, updateGroup, createdAt, done, targets...)
 }
-func (this *ChangeModel) Delete(name string, createdAt time.Time, done DoneHandler) ChangeResult {
-	return this.Exec(true, true, name, createdAt, done)
+func (this *ChangeModel) Delete(name, updateGroup string, createdAt time.Time, done DoneHandler) ChangeResult {
+	return this.Exec(true, true, name, updateGroup, createdAt, done)
 }
 
-func (this *ChangeModel) Exec(apply bool, delete bool, name string, createdAt time.Time, done DoneHandler, targets ...Target) ChangeResult {
+func (this *ChangeModel) Exec(apply bool, delete bool, name, updateGroup string, createdAt time.Time, done DoneHandler, targets ...Target) ChangeResult {
 	//this.Infof("%s: %v", name, targets)
 	if len(targets) == 0 && !delete {
 		return ChangeResult{}
@@ -279,6 +279,7 @@ func (this *ChangeModel) Exec(apply bool, delete bool, name string, createdAt ti
 	view := this.getProviderView(p)
 	oldset := view.dnssets[name]
 	newset := dns.NewDNSSet(name)
+	newset.UpdateGroup = updateGroup
 	if !delete {
 		this.AddTargets(newset, oldset, p, targets...)
 	}

--- a/pkg/dns/provider/state_zone.go
+++ b/pkg/dns/provider/state_zone.go
@@ -188,9 +188,9 @@ func (this *state) reconcileZone(logger logger.LogContext, req *zoneReconciliati
 		// TODO: err handling
 		var changeResult ChangeResult
 		if e.IsDeleting() {
-			changeResult = changes.Delete(e.DNSName(), e.CreatedAt(), NewStatusUpdate(logger, e, this.GetContext()))
+			changeResult = changes.Delete(e.DNSName(), e.ObjectName().Namespace(), e.CreatedAt(), NewStatusUpdate(logger, e, this.GetContext()))
 		} else {
-			changeResult = changes.Apply(e.DNSName(), e.CreatedAt(), NewStatusUpdate(logger, e, this.GetContext()), e.Targets()...)
+			changeResult = changes.Apply(e.DNSName(), e.ObjectName().Namespace(), e.CreatedAt(), NewStatusUpdate(logger, e, this.GetContext()), e.Targets()...)
 			if changeResult.Error != nil && changeResult.Retry {
 				conflictErr = changeResult.Error
 			}

--- a/pkg/dns/validation.go
+++ b/pkg/dns/validation.go
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *
+ */
+
+package dns
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+func ValidateDomainName(name string) error {
+	check := NormalizeHostname(name)
+	if strings.HasPrefix(check, "_") {
+		// allow "_" prefix, as it is used for DNS challenges of Let's encrypt
+		check = "x" + check[1:]
+	}
+
+	var errs []string
+	if strings.HasPrefix(check, "*.") {
+		errs = validation.IsWildcardDNS1123Subdomain(check)
+	} else {
+		errs = validation.IsDNS1123Subdomain(check)
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("%q is no valid dns name (%v)", name, errs)
+	}
+
+	metaCheck := CalcMetaRecordDomainNameForValidation(check)
+	if strings.HasPrefix(metaCheck, "*.") {
+		errs = validation.IsWildcardDNS1123Subdomain(metaCheck)
+	} else {
+		errs = validation.IsDNS1123Subdomain(metaCheck)
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("metadata record %q of %q is no valid dns name (%v)", metaCheck, name, errs)
+	}
+
+	labels := strings.Split(strings.TrimPrefix(check, "*."), ".")
+	for i, label := range labels {
+		if errs = validation.IsDNS1035Label(label); len(errs) > 0 {
+			return fmt.Errorf("%d. label %q of %q is not valid (%v)", i+1, label, name, errs)
+		}
+	}
+	metaLabels := strings.SplitN(strings.TrimPrefix(metaCheck, "*."), ".", 2)
+	if errs = validation.IsDNS1035Label(metaLabels[0]); len(errs) > 0 {
+		return fmt.Errorf("1. label %q of metadata record of %q is not valid (%v)", metaLabels[0], name, errs)
+	}
+
+	return nil
+}

--- a/pkg/dns/validation_test.go
+++ b/pkg/dns/validation_test.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *
+ */
+
+package dns
+
+import (
+	"fmt"
+	"testing"
+)
+
+const name23 = "ab1234567890-1234567890"
+
+func TestValidation(t *testing.T) {
+	debug := false
+
+	name239 := name23
+	for i := 0; i < 9; i++ {
+		name239 += "." + name23
+	}
+	table := []struct {
+		input string
+		ok    bool
+	}{
+		{"a.b", true},
+		{"a.b.", true},
+		{"*.a", true},
+		{"\\052.a.b", true},
+		{"a-a.a9.a8.a7.a6.a5.a4.a3.a2.a1.a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z", true},
+		{"_a.b", true},
+		{"a123456789012345678901234567890123456789012345678901234567890abc.b", false},   // label too long
+		{"a.a123456789012345678901234567890123456789012345678901234567890abc.b", false}, // label too long
+		{"a12345678901234567890123456789012345678901234567890abcd.b", true},
+		{"a12345678901234567890123456789012345678901234567890abcde.b", false}, // meta data label too long
+		{"abc.a123456789." + name239, false},                                  // name too long
+		{"abcde." + name239, true},                                            // comment-abcde... has 253 chars
+		{"abcdef." + name239, false},                                          // meta data name too long
+	}
+	for _, entry := range table {
+		err := ValidateDomainName(entry.input)
+		if debug && err != nil {
+			fmt.Printf("%v\n", err)
+		}
+		if entry.ok && err != nil {
+			t.Errorf("%s should be ok, but got error %s", entry.input, err)
+		} else if !entry.ok && err == nil {
+			t.Errorf("%s should not be ok, but got no error", entry.input)
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Validation is added for domain labels, which have a limit of 63 characters, and for meta data DNS records.
As the metadata DNS record uses a longer DNS name, its length and first label needs also to match the restrictions (total length <= 253, label <= 63).

Additionally on creating or updating DNS records, the AWS batches are now split per namespace.
Although this results in more requests, it improves robustness, as the failure of a batch is restricted to the changed DNSEntries of the same namespace. It also addresses #220, as the error message of the batch will only be applied to the entries in the same batch, i.e. in the same namespace.

**Which issue(s) this PR fixes**:
Fixes #219
Fixes #220

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Stricter validation of DNS name for record and metadata record (both may have at max 253 chars in total and 63 chars per domain label)
```

```other operator
AWS batches are split per namespace
```

