### PR TITLE
No warning event for Services without dnsnames annotation

### DIFF
--- a/pkg/controller/source/service/handler.go
+++ b/pkg/controller/source/service/handler.go
@@ -18,20 +18,22 @@ package service
 
 import (
 	"fmt"
+
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/utils"
-	"github.com/gardener/external-dns-management/pkg/dns/source"
-
 	api "k8s.io/api/core/v1"
 )
 
 // FakeTargetIP provides target for testing without load balancer
 var FakeTargetIP *string
 
-func GetTargets(logger logger.LogContext, obj resources.Object, current *source.DNSCurrentState) (utils.StringSet, utils.StringSet, error) {
+func GetTargets(logger logger.LogContext, obj resources.Object, names utils.StringSet) (utils.StringSet, utils.StringSet, error) {
 	svc := obj.Data().(*api.Service)
 	if svc.Spec.Type != api.ServiceTypeLoadBalancer {
+		if len(names) == 0 {
+			return nil, nil, nil
+		}
 		return nil, nil, fmt.Errorf("service is not of type LoadBalancer")
 	}
 	set := utils.StringSet{}

--- a/pkg/dns/source/defaults.go
+++ b/pkg/dns/source/defaults.go
@@ -17,9 +17,10 @@
 package source
 
 import (
+	"sync"
+
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sync"
 
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile"
 	"github.com/gardener/controller-manager-library/pkg/logger"
@@ -92,7 +93,7 @@ func (this *DefaultDNSSource) CreateDNSFeedback(obj resources.Object) DNSFeedbac
 func (this *DefaultDNSSource) GetDNSInfo(logger logger.LogContext, obj resources.Object, current *DNSCurrentState) (*DNSInfo, error) {
 	info := &DNSInfo{}
 	info.Names = current.AnnotatedNames
-	tgts, txts, err := this.handler(logger, obj, current)
+	tgts, txts, err := this.handler(logger, obj, info.Names)
 	info.Targets = tgts
 	info.Text = txts
 	return info, err

--- a/pkg/dns/source/interface.go
+++ b/pkg/dns/source/interface.go
@@ -64,7 +64,7 @@ type DNSSourceType interface {
 	Create(controller.Interface) (DNSSource, error)
 }
 
-type DNSTargetExtractor func(logger logger.LogContext, obj resources.Object, current *DNSCurrentState) (utils.StringSet, utils.StringSet, error)
+type DNSTargetExtractor func(logger logger.LogContext, obj resources.Object, names utils.StringSet) (utils.StringSet, utils.StringSet, error)
 type DNSSourceCreator func(controller.Interface) (DNSSource, error)
 
 type DNSState struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
The source controller for `Service` reports an event on the source cluster if `spec.type` != `LoadBalancer`, as only this type has targets.
As an unwelcome side effect, all services even without `dns.gardener.cloud/...` annotations report such an event on first reconciliation.
This PR corrects the logic. Services without a `dns.garder.cloud/dnsnames` annotation are not triggering an event anymore.

**Which issue(s) this PR fixes**:
Fixes #223 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
No warning event for Services without dnsnames annotation
```
