### PR TITLE
Allow domain labels starting with a digit

### DIFF
--- a/pkg/dns/validation.go
+++ b/pkg/dns/validation.go
@@ -53,12 +53,12 @@ func ValidateDomainName(name string) error {
 
 	labels := strings.Split(strings.TrimPrefix(check, "*."), ".")
 	for i, label := range labels {
-		if errs = validation.IsDNS1035Label(label); len(errs) > 0 {
+		if errs = validation.IsDNS1123Label(label); len(errs) > 0 {
 			return fmt.Errorf("%d. label %q of %q is not valid (%v)", i+1, label, name, errs)
 		}
 	}
 	metaLabels := strings.SplitN(strings.TrimPrefix(metaCheck, "*."), ".", 2)
-	if errs = validation.IsDNS1035Label(metaLabels[0]); len(errs) > 0 {
+	if errs = validation.IsDNS1123Label(metaLabels[0]); len(errs) > 0 {
 		return fmt.Errorf("1. label %q of metadata record of %q is not valid (%v)", metaLabels[0], name, errs)
 	}
 

--- a/pkg/dns/validation_test.go
+++ b/pkg/dns/validation_test.go
@@ -40,6 +40,7 @@ func TestValidation(t *testing.T) {
 		{"\\052.a.b", true},
 		{"a-a.a9.a8.a7.a6.a5.a4.a3.a2.a1.a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z", true},
 		{"_a.b", true},
+		{"1.2-3.b", true},
 		{"a123456789012345678901234567890123456789012345678901234567890abc.b", false},   // label too long
 		{"a.a123456789012345678901234567890123456789012345678901234567890abc.b", false}, // label too long
 		{"a12345678901234567890123456789012345678901234567890abcd.b", true},


### PR DESCRIPTION
**What this PR does / why we need it**:
With PR #221 a stricter check of domain names and labels has been introduced.
Domain labels are now checked according to RFC 1035 which disallows labels longer than 63 characters and/or starting with a digit.
As we allow shoot cluster names starting with a digit character in Gardener, with the current default domain name schema no DNSEntries for such subdomains can be created anymore.
It also seems that this restriction from RFC 1035 is not enforced in the Internet, as you can even register domains starting with digits.
We have also not seen any DNS provider which rejects domain names containing domain labels starting with a digit.

Further research found that with [RFC 1123, section 2.1](https://datatracker.ietf.org/doc/html/rfc1123#section-2.1), the restriction was relaxed:

> One aspect of host name syntax is hereby changed: the
      restriction on the first character is relaxed to allow either a
      letter or a digit.  Host software MUST support this more liberal
      syntax.

Therefore this check is relaxed with this PR to allow domain labels starting with a digit again.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Allow domain labels starting with a digit again (was disallowed with PR#221 in v0.11.0)
```
