### PR TITLE
Switch default leader election resource lock to leases

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ Flags:
       --lease-duration duration                                       lease duration
       --lease-name string                                             name for lease object
       --lease-renew-deadline duration                                 lease renew deadline
-      --lease-resource-lock string                                    determines which resource lock to use for leader election, defaults to 'configmapsleases'
+      --lease-resource-lock string                                    determines which resource lock to use for leader election, defaults to 'leases'
       --lease-retry-period duration                                   lease retry period
       --lock-status-check-period duration                             interval for dns lock status checks
   -D, --log-level string                                              logrus log level

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190603021944-12ad9f921c0b
 	github.com/aws/aws-sdk-go v1.38.43
 	github.com/cloudflare/cloudflare-go v0.11.4
-	github.com/gardener/controller-manager-library v0.2.1-0.20211214150939-78d41dea001b
+	github.com/gardener/controller-manager-library v0.2.1-0.20220103153255-cff2a133a1e6
 	github.com/go-openapi/runtime v0.19.15
 	github.com/go-openapi/strfmt v0.19.5
 	github.com/gophercloud/gophercloud v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -219,8 +219,8 @@ github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoD
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/gardener/controller-manager-library v0.2.1-0.20211214150939-78d41dea001b h1:QcAvnYClex0waN6Y0P3CZ4nvfHDk7SJeVLJfc9zoM7w=
-github.com/gardener/controller-manager-library v0.2.1-0.20211214150939-78d41dea001b/go.mod h1:E1Abd/nMB9pbwEiEHPADjsPgbJRJG90WlU28yim2DG4=
+github.com/gardener/controller-manager-library v0.2.1-0.20220103153255-cff2a133a1e6 h1:MqtxlnDxgnBnsPk54xwSVpJlQQ6xO429Z0ep4hYwTwo=
+github.com/gardener/controller-manager-library v0.2.1-0.20220103153255-cff2a133a1e6/go.mod h1:E1Abd/nMB9pbwEiEHPADjsPgbJRJG90WlU28yim2DG4=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/lease/config.go
+++ b/vendor/github.com/gardener/controller-manager-library/pkg/controllermanager/controller/lease/config.go
@@ -25,7 +25,7 @@ type Config struct {
 
 func (this *Config) AddOptionsToSet(set config.OptionSet) {
 	set.AddStringOption(&this.LeaseName, "lease-name", "", "", "name for lease object")
-	set.AddStringOption(&this.LeaseLeaderElectionResourceLock, "lease-resource-lock", "", resourcelock.ConfigMapsLeasesResourceLock, "determines which resource lock to use for leader election, defaults to 'configmapsleases'")
+	set.AddStringOption(&this.LeaseLeaderElectionResourceLock, "lease-resource-lock", "", resourcelock.LeasesResourceLock, "determines which resource lock to use for leader election, defaults to 'leases'")
 	set.AddBoolOption(&this.OmitLease, "omit-lease", "", false, "omit lease for development")
 	set.AddDurationOption(&this.LeaseDuration, "lease-duration", "", 15*time.Second, "lease duration")
 	set.AddDurationOption(&this.LeaseRenewDeadline, "lease-renew-deadline", "", 10*time.Second, "lease renew deadline")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -146,7 +146,7 @@ github.com/form3tech-oss/jwt-go
 # github.com/fsnotify/fsnotify v1.4.9
 ## explicit; go 1.13
 github.com/fsnotify/fsnotify
-# github.com/gardener/controller-manager-library v0.2.1-0.20211214150939-78d41dea001b
+# github.com/gardener/controller-manager-library v0.2.1-0.20220103153255-cff2a133a1e6
 ## explicit; go 1.16
 github.com/gardener/controller-manager-library/hack
 github.com/gardener/controller-manager-library/pkg/certmgmt


### PR DESCRIPTION
**What this PR does / why we need it**:
Switch default leader election resource lock from `configmapsleases` to `leases`

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Switch default leader election resource lock from `configmapsleases` to `leases`
```
