### PR TITLE
Improve error handling if remote access server fails

### DIFF
--- a/pkg/dns/provider/controller.go
+++ b/pkg/dns/provider/controller.go
@@ -220,9 +220,9 @@ func Create(c controller.Interface, factory DNSHandlerFactory) (reconcile.Interf
 	}, nil
 }
 
-func (this *reconciler) Setup() {
+func (this *reconciler) Setup() error {
 	this.controller.Infof("*** state Setup ")
-	this.state.Setup()
+	return this.state.Setup()
 }
 
 func (this *reconciler) Start() {

--- a/pkg/dns/provider/state.go
+++ b/pkg/dns/provider/state.go
@@ -229,7 +229,7 @@ func (this *state) Setup() error {
 		}
 		err = this.startRemoteAccessServer(secret)
 		if err != nil {
-			return err
+			return fmt.Errorf("startRemoteAccessServer failed with: %w", err)
 		}
 	}
 
@@ -260,6 +260,7 @@ func (this *state) Setup() error {
 }
 
 func (this *state) startRemoteAccessServer(secret *corev1.Secret) error {
+	this.context.Infof("starting RemoteAccessServer")
 	server, err := embed.StartDNSHandlerServer(this.context, this.config.RemoteAccessConfig)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:
If the remote access server fails on startup, no error was shown because of incomplete error forwarding.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Improve error handling if remote access server startup fails
```
