### PR TITLE
Fixing the link to the Gardener contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please refer to the [Gardener contributor guide](https://github.com/gardener/documentation/blob/master/CONTRIBUTING.md).
+Please refer to the [Gardener contributor guide](https://gardener.cloud/docs/contribute/).


### PR DESCRIPTION
The old link was broken. I assume it should now point to `gardener.cloud`.