### PR TITLE
Update to golang 1.17.8 and alpine 3.15.3

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 #############      builder       #############
-FROM golang:1.17.7 AS builder
+FROM golang:1.17.8 AS builder
 
 WORKDIR /build
 COPY . .
@@ -21,7 +21,7 @@ COPY . .
 RUN make release
 
 ############# base
-FROM alpine:3.15.0 AS base
+FROM alpine:3.15.3 AS base
 
 #############      dns-controller-manager     #############
 FROM base AS dns-controller-manager


### PR DESCRIPTION
What this PR does / why we need it:
Updating to golang version 1.17.8
Updating to alpine 3.15.3

Release note:
Updated dependencies: golang version 1.17.8, alpine 3.15.3

