### PR TITLE
Fix sporadic panic on starting remote access server.

### DIFF
--- a/pkg/server/remote/server.go
+++ b/pkg/server/remote/server.go
@@ -158,12 +158,12 @@ func (s *server) Login(ctx context.Context, request *common.LoginRequest) (*comm
 		logctx.Warn("Login auth failed")
 		return nil, err
 	}
-	logctx.Info("Login auth successful: %s", commonName)
+	logctx.Infof("Login auth successful: %s", commonName)
 
 	nsState := s.getNamespaceState(request.Namespace, false)
 	if nsState == nil {
 		metrics.ReportRemoteAccessLogins(request.Namespace, request.CliendID, false)
-		logctx.Info("namespace %s not found or no providers available", request.Namespace)
+		logctx.Infof("namespace %s not found or no providers available", request.Namespace)
 		return nil, fmt.Errorf("namespace %s not found or no providers available", request.Namespace)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix sporadic panic on starting remote server.
Fixed also minor wrong logging format.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix sporadic panic on starting remote access server.
```
