### PR TITLE
Fix domain name comparison in tryFixChanges

### DIFF
--- a/pkg/controller/provider/aws/execution.go
+++ b/pkg/controller/provider/aws/execution.go
@@ -183,7 +183,7 @@ outer:
 		switch *change.Change.Action {
 		case route53.ChangeActionDelete:
 			for _, m := range submatchNotFound {
-				if m[1] == *change.Change.ResourceRecordSet.Name && m[2] == *change.Change.ResourceRecordSet.Type {
+				if dns.NormalizeHostname(m[1]) == dns.NormalizeHostname(*change.Change.ResourceRecordSet.Name) && m[2] == *change.Change.ResourceRecordSet.Type {
 					this.Infof("Ignoring already deleted record: %s (%s)",
 						*change.Change.ResourceRecordSet.Name, *change.Change.ResourceRecordSet.Type)
 					succeeded = append(succeeded, change)
@@ -192,7 +192,7 @@ outer:
 			}
 		case route53.ChangeActionCreate:
 			for _, m := range submatchExists {
-				if m[1] == *change.Change.ResourceRecordSet.Name && m[2] == *change.Change.ResourceRecordSet.Type {
+				if dns.NormalizeHostname(m[1]) == dns.NormalizeHostname(*change.Change.ResourceRecordSet.Name) && m[2] == *change.Change.ResourceRecordSet.Type {
 					if this.isFetchedRecordSetEqual(change) {
 						this.Infof("Ignoring already created record: %s (%s)",
 							*change.Change.ResourceRecordSet.Name, *change.Change.ResourceRecordSet.Type)
@@ -235,7 +235,7 @@ func (this *Execution) isFetchedRecordSetEqual(change *Change) bool {
 	}
 	crrs := change.Change.ResourceRecordSet
 	orrs := output.ResourceRecordSets[0]
-	if *crrs.Name != *orrs.Name || *crrs.Type != *orrs.Type || !safeCompareInt64(crrs.TTL, orrs.TTL) || len(crrs.ResourceRecords) != len(orrs.ResourceRecords) {
+	if dns.NormalizeHostname(*crrs.Name) != dns.NormalizeHostname(*orrs.Name) || *crrs.Type != *orrs.Type || !safeCompareInt64(crrs.TTL, orrs.TTL) || len(crrs.ResourceRecords) != len(orrs.ResourceRecords) {
 		return false
 	}
 	for i := range crrs.ResourceRecords {


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR #246 does not work for domain names starting with `*.` because of AWS name rewriting.
The domain names are normalised for comparison in this logic.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Ignore already deleted or created changes in AWS Route53 batch for domain names starting with `*.`
```
