### PR TITLE
Delete cached dnsactivations on deleting dnsowner

### DIFF
--- a/pkg/dns/provider/controller.go
+++ b/pkg/dns/provider/controller.go
@@ -254,7 +254,7 @@ func (this *reconciler) Reconcile(logger logger.LogContext, obj resources.Object
 		if this.state.IsResponsibleFor(logger, obj) {
 			return this.state.UpdateOwner(logger, dnsutils.DNSOwner(obj), false)
 		} else {
-			return this.state.OwnerDeleted(logger, obj.Key())
+			return this.state.OwnerDeleted(logger, obj.ClusterKey())
 		}
 	case obj.IsA(&api.DNSProvider{}):
 		if this.state.IsResponsibleFor(logger, obj) {
@@ -309,7 +309,7 @@ func (this *reconciler) Deleted(logger logger.LogContext, key resources.ClusterO
 	logger.Debugf("deleted %s", key)
 	switch key.GroupKind() {
 	case ownerGroupKind:
-		return this.state.OwnerDeleted(logger, key.ObjectKey())
+		return this.state.OwnerDeleted(logger, key)
 	case providerGroupKind:
 		return this.state.ProviderDeleted(logger, key.ObjectKey())
 	case entryGroupKind:

--- a/pkg/dns/provider/ownercache.go
+++ b/pkg/dns/provider/ownercache.go
@@ -220,9 +220,10 @@ func (this *OwnerCache) _updateOwnerData(cachekey OwnerName, key dnsutils.Schedu
 	return changeset, this.ownerids.KeySet()
 }
 
-func (this *OwnerCache) DeleteOwner(key resources.ObjectKey) (changeset utils.StringSet, activeset utils.StringSet) {
+func (this *OwnerCache) DeleteOwner(key resources.ClusterObjectKey) (changeset utils.StringSet, activeset utils.StringSet) {
 	this.lock.Lock()
 	defer this.lock.Unlock()
+	delete(this.dnsactivations, key)
 	changeset = utils.StringSet{}
 	cachekey := OwnerName(key.Name())
 	old, ok := this.owners[cachekey]

--- a/pkg/dns/provider/ownercache_test.go
+++ b/pkg/dns/provider/ownercache_test.go
@@ -83,9 +83,10 @@ var _ = ginkgo.Describe("Owner cache", func() {
 	config := &Config{
 		Ident: ident,
 	}
-	key1 := resources.NewKey(resources.NewGroupKind("", "test"), "test", "o1")
+	resources.NewClusterObjectKeySet()
+	key1 := resources.NewClusterKeyForObject("test-cluster", resources.NewKey(resources.NewGroupKind("", "test"), "test", "o1"))
 	name1 := OwnerName(key1.Name())
-	key2 := resources.NewKey(resources.NewGroupKind("", "test"), "test", "o2")
+	key2 := resources.NewClusterKeyForObject("test-cluster", resources.NewKey(resources.NewGroupKind("", "test"), "test", "o2"))
 	name2 := OwnerName(key2.Name())
 
 	var cache *TestOwnerCacheContext

--- a/pkg/dns/provider/state_owner.go
+++ b/pkg/dns/provider/state_owner.go
@@ -100,7 +100,7 @@ func (this *state) UpdateOwner(logger logger.LogContext, owner *dnsutils.DNSOwne
 	return reconcile.Succeeded(logger)
 }
 
-func (this *state) OwnerDeleted(logger logger.LogContext, key resources.ObjectKey) reconcile.Status {
+func (this *state) OwnerDeleted(logger logger.LogContext, key resources.ClusterObjectKey) reconcile.Status {
 	this.lock.Lock()
 	changed, active := this.ownerCache.DeleteOwner(key)
 	this.lock.Unlock()

--- a/pkg/server/remote/conversion/conversion_test.go
+++ b/pkg/server/remote/conversion/conversion_test.go
@@ -66,12 +66,12 @@ func TestMarshalChangeRequest(t *testing.T) {
 	for _, item := range table {
 		remote, err := MarshalChangeRequest(item.request)
 		if err != nil {
-			t.Errorf("MarshalChangeRequest failed: %v", err)
+			t.Errorf("MarshalChangeRequest failed: %s", err)
 			continue
 		}
 		copy, err := UnmarshalChangeRequest(remote, nil)
 		if err != nil {
-			t.Errorf("UnmarshalChangeRequest failed: %v", err)
+			t.Errorf("UnmarshalChangeRequest failed: %s", err)
 			continue
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix to delete the cached DNS activations on deleting the corresponding `DNSOwner` object.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Delete cached dnsactivations on deleting `DNSOwner` object.
```
