### PR TITLE
Introduce qualified zone id to avoid clashes on migrating to remote provider.

### DIFF
--- a/pkg/controller/provider/alicloud/access.go
+++ b/pkg/controller/provider/alicloud/access.go
@@ -144,7 +144,7 @@ func (this *access) CreateRecord(r raw.Record, zone provider.DNSHostedZone) erro
 	req.Type = a.Type
 	req.TTL = requests.NewInteger(a.TTL)
 	req.Value = a.Value
-	this.metrics.AddZoneRequests(zone.Id(), provider.M_UPDATERECORDS, 1)
+	this.metrics.AddZoneRequests(zone.Id().ID, provider.M_UPDATERECORDS, 1)
 	this.rateLimiter.Accept()
 	_, err := this.client.AddDomainRecord(req)
 	return err
@@ -158,7 +158,7 @@ func (this *access) UpdateRecord(r raw.Record, zone provider.DNSHostedZone) erro
 	req.Type = a.Type
 	req.TTL = requests.NewInteger(a.TTL)
 	req.Value = a.Value
-	this.metrics.AddZoneRequests(zone.Id(), provider.M_UPDATERECORDS, 1)
+	this.metrics.AddZoneRequests(zone.Id().ID, provider.M_UPDATERECORDS, 1)
 	this.rateLimiter.Accept()
 	_, err := this.client.UpdateDomainRecord(req)
 	return err
@@ -167,7 +167,7 @@ func (this *access) UpdateRecord(r raw.Record, zone provider.DNSHostedZone) erro
 func (this *access) DeleteRecord(r raw.Record, zone provider.DNSHostedZone) error {
 	req := alidns.CreateDeleteDomainRecordRequest()
 	req.RecordId = r.GetId()
-	this.metrics.AddZoneRequests(zone.Id(), provider.M_UPDATERECORDS, 1)
+	this.metrics.AddZoneRequests(zone.Id().ID, provider.M_UPDATERECORDS, 1)
 	this.rateLimiter.Accept()
 	_, err := this.client.DeleteDomainRecord(req)
 	return err
@@ -189,7 +189,7 @@ func (this *access) GetRecordSet(dnsName, rtype string, zone provider.DNSHostedZ
 		return true, nil
 	}
 
-	err := this.listRecords(zone.Id(), zone.Domain(), consume, requestModifier)
+	err := this.listRecords(zone.Id().ID, zone.Domain(), consume, requestModifier)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/provider/alicloud/handler.go
+++ b/pkg/controller/provider/alicloud/handler.go
@@ -136,7 +136,7 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, cache provider.ZoneC
 		//fmt.Printf("**** found %s %s: %s\n", a.GetType(), a.GetDNSName(), a.GetValue() )
 		return true, nil
 	}
-	err := h.access.ListRecords(zone.Id(), zone.Key(), f)
+	err := h.access.ListRecords(zone.Id().ID, zone.Key(), f)
 	if err != nil {
 		return nil, perrs.WrapAsHandlerError(err, "list records failed")
 	}

--- a/pkg/controller/provider/aws/execution.go
+++ b/pkg/controller/provider/aws/execution.go
@@ -120,13 +120,13 @@ func (this *Execution) submitChanges(metrics provider.Metrics) error {
 		}
 
 		params := &route53.ChangeResourceRecordSetsInput{
-			HostedZoneId: aws.String(this.zone.Id()),
+			HostedZoneId: aws.String(this.zone.Id().ID),
 			ChangeBatch: &route53.ChangeBatch{
 				Changes: mapChanges(changes),
 			},
 		}
 
-		metrics.AddZoneRequests(this.zone.Id(), provider.M_UPDATERECORDS, 1)
+		metrics.AddZoneRequests(this.zone.Id().ID, provider.M_UPDATERECORDS, 1)
 		this.rateLimiter.Accept()
 		var succeededChanges, failedChanges []*Change
 		_, err := this.r53.ChangeResourceRecordSets(params)
@@ -207,7 +207,7 @@ outer:
 
 	if len(unclear) > 0 {
 		params := &route53.ChangeResourceRecordSetsInput{
-			HostedZoneId: aws.String(this.zone.Id()),
+			HostedZoneId: aws.String(this.zone.Id().ID),
 			ChangeBatch: &route53.ChangeBatch{
 				Changes: mapChanges(unclear),
 			},
@@ -224,7 +224,7 @@ outer:
 
 func (this *Execution) isFetchedRecordSetEqual(change *Change) bool {
 	output, err := this.r53.ListResourceRecordSets(&route53.ListResourceRecordSetsInput{
-		HostedZoneId:          aws.String(this.zone.Id()),
+		HostedZoneId:          aws.String(this.zone.Id().ID),
 		MaxItems:              aws.String("1"),
 		StartRecordIdentifier: nil,
 		StartRecordName:       change.Change.ResourceRecordSet.Name,

--- a/pkg/controller/provider/azure-private/handler.go
+++ b/pkg/controller/provider/azure-private/handler.go
@@ -129,10 +129,10 @@ func (h *Handler) GetZoneState(zone provider.DNSHostedZone) (provider.DNSZoneSta
 func (h *Handler) getZoneState(zone provider.DNSHostedZone, cache provider.ZoneCache) (provider.DNSZoneState, error) {
 	dnssets := dns.DNSSets{}
 
-	resourceGroup, zoneName := utils.SplitZoneID(zone.Id())
+	resourceGroup, zoneName := utils.SplitZoneID(zone.Id().ID)
 	h.config.RateLimiter.Accept()
 	results, err := h.recordsClient.ListComplete(h.ctx, resourceGroup, zoneName, nil, "")
-	h.config.Metrics.AddZoneRequests(zone.Id(), provider.M_LISTRECORDS, 1)
+	h.config.Metrics.AddZoneRequests(zone.Id().ID, provider.M_LISTRECORDS, 1)
 	if err != nil {
 		return nil, perrs.WrapfAsHandlerError(err, "Listing DNS zone state for zone %s failed", zoneName)
 	}
@@ -173,7 +173,7 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, cache provider.ZoneC
 	}
 	pages := count / 100
 	if pages > 0 {
-		h.config.Metrics.AddZoneRequests(zone.Id(), provider.M_PLISTRECORDS, count/100)
+		h.config.Metrics.AddZoneRequests(zone.Id().ID, provider.M_PLISTRECORDS, count/100)
 	}
 	return provider.NewDNSZoneState(dnssets), nil
 }
@@ -189,7 +189,7 @@ func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHos
 }
 
 func (h *Handler) executeRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
-	resourceGroup, zoneName := utils.SplitZoneID(zone.Id())
+	resourceGroup, zoneName := utils.SplitZoneID(zone.Id().ID)
 	exec := NewExecution(logger, h, resourceGroup, zoneName)
 
 	var succeeded, failed int

--- a/pkg/controller/provider/azure/handler.go
+++ b/pkg/controller/provider/azure/handler.go
@@ -154,10 +154,10 @@ func (h *Handler) GetZoneState(zone provider.DNSHostedZone) (provider.DNSZoneSta
 func (h *Handler) getZoneState(zone provider.DNSHostedZone, cache provider.ZoneCache) (provider.DNSZoneState, error) {
 	dnssets := dns.DNSSets{}
 
-	resourceGroup, zoneName := utils.SplitZoneID(zone.Id())
+	resourceGroup, zoneName := utils.SplitZoneID(zone.Id().ID)
 	h.config.RateLimiter.Accept()
 	results, err := h.recordsClient.ListAllByDNSZoneComplete(h.ctx, resourceGroup, zoneName, nil, "")
-	h.config.Metrics.AddZoneRequests(zone.Id(), provider.M_LISTRECORDS, 1)
+	h.config.Metrics.AddZoneRequests(zone.Id().ID, provider.M_LISTRECORDS, 1)
 	if err != nil {
 		return nil, perrs.WrapfAsHandlerError(err, "Listing DNS zone state for zone %s failed", zoneName)
 	}
@@ -198,7 +198,7 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, cache provider.ZoneC
 	}
 	pages := count / 100
 	if pages > 0 {
-		h.config.Metrics.AddZoneRequests(zone.Id(), provider.M_PLISTRECORDS, count/100)
+		h.config.Metrics.AddZoneRequests(zone.Id().ID, provider.M_PLISTRECORDS, count/100)
 	}
 	return provider.NewDNSZoneState(dnssets), nil
 }
@@ -214,7 +214,7 @@ func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHos
 }
 
 func (h *Handler) executeRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
-	resourceGroup, zoneName := utils.SplitZoneID(zone.Id())
+	resourceGroup, zoneName := utils.SplitZoneID(zone.Id().ID)
 	exec := NewExecution(logger, h, resourceGroup, zoneName)
 
 	var succeeded, failed int

--- a/pkg/controller/provider/cloudflare/access.go
+++ b/pkg/controller/provider/cloudflare/access.go
@@ -91,7 +91,7 @@ func (this *access) CreateRecord(r raw.Record, zone provider.DNSHostedZone) erro
 		TTL:     ttl,
 		ZoneID:  a.ZoneID,
 	}
-	this.metrics.AddZoneRequests(zone.Id(), provider.M_CREATERECORDS, 1)
+	this.metrics.AddZoneRequests(zone.Id().ID, provider.M_CREATERECORDS, 1)
 	this.rateLimiter.Accept()
 	_, err := this.CreateDNSRecord(a.ZoneID, dnsRecord)
 	return err
@@ -108,7 +108,7 @@ func (this *access) UpdateRecord(r raw.Record, zone provider.DNSHostedZone) erro
 		TTL:     ttl,
 		ZoneID:  a.ZoneID,
 	}
-	this.metrics.AddZoneRequests(zone.Id(), provider.M_UPDATERECORDS, 1)
+	this.metrics.AddZoneRequests(zone.Id().ID, provider.M_UPDATERECORDS, 1)
 	this.rateLimiter.Accept()
 	err := this.UpdateDNSRecord(a.ZoneID, r.GetId(), dnsRecord)
 	return err
@@ -116,7 +116,7 @@ func (this *access) UpdateRecord(r raw.Record, zone provider.DNSHostedZone) erro
 
 func (this *access) DeleteRecord(r raw.Record, zone provider.DNSHostedZone) error {
 	a := r.(*Record)
-	this.metrics.AddZoneRequests(zone.Id(), provider.M_DELETERECORDS, 1)
+	this.metrics.AddZoneRequests(zone.Id().ID, provider.M_DELETERECORDS, 1)
 	this.rateLimiter.Accept()
 	err := this.DeleteDNSRecord(a.ZoneID, r.GetId())
 	return err
@@ -128,7 +128,7 @@ func (this *access) NewRecord(fqdn, rtype, value string, zone provider.DNSHosted
 		Name:    fqdn,
 		Content: value,
 		TTL:     int(ttl),
-		ZoneID:  zone.Id(),
+		ZoneID:  zone.Id().ID,
 	})
 }
 
@@ -140,7 +140,7 @@ func (this *access) GetRecordSet(dnsName, rtype string, zone provider.DNSHostedZ
 		return true, nil
 	}
 
-	err := this.listRecords(zone.Id(), consume, cloudflare.DNSRecord{Type: rtype, Name: dnsName})
+	err := this.listRecords(zone.Id().ID, consume, cloudflare.DNSRecord{Type: rtype, Name: dnsName})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/provider/cloudflare/handler.go
+++ b/pkg/controller/provider/cloudflare/handler.go
@@ -135,7 +135,7 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, cache provider.ZoneC
 		state.AddRecord(a)
 		return true, nil
 	}
-	err := h.access.ListRecords(zone.Key(), f)
+	err := h.access.ListRecords(zone.Id().ID, f)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/provider/google/execution.go
+++ b/pkg/controller/provider/google/execution.go
@@ -94,9 +94,9 @@ func (this *Execution) submitChanges(metrics provider.Metrics) error {
 		this.Infof("desired change: Addition %s %s: %s", c.Name, c.Type, utils.Strings(c.Rrdatas...))
 	}
 
-	metrics.AddZoneRequests(this.zone.Id(), provider.M_UPDATERECORDS, 1)
+	metrics.AddZoneRequests(this.zone.Id().ID, provider.M_UPDATERECORDS, 1)
 	this.handler.config.RateLimiter.Accept()
-	projectID, zoneName := SplitZoneID(this.zone.Id())
+	projectID, zoneName := SplitZoneID(this.zone.Id().ID)
 	if _, err := this.handler.service.Changes.Create(projectID, zoneName, this.change).Do(); err != nil {
 		this.Error(err)
 		for _, d := range this.done {

--- a/pkg/controller/provider/google/handler.go
+++ b/pkg/controller/provider/google/handler.go
@@ -160,12 +160,12 @@ func (h *Handler) handleRecordSets(zone provider.DNSHostedZone, f func(r *google
 				}
 			}
 		}
-		h.config.Metrics.AddZoneRequests(zone.Id(), rt, 1)
+		h.config.Metrics.AddZoneRequests(zone.Id().ID, rt, 1)
 		rt = provider.M_PLISTRECORDS
 		return nil
 	}
 	h.config.RateLimiter.Accept()
-	projectID, zoneName := SplitZoneID(zone.Id())
+	projectID, zoneName := SplitZoneID(zone.Id().ID)
 	err := h.service.ResourceRecordSets.List(projectID, zoneName).Pages(h.ctx, aggr)
 	return forwarded, err
 }

--- a/pkg/controller/provider/infoblox/access.go
+++ b/pkg/controller/provider/infoblox/access.go
@@ -49,19 +49,19 @@ func NewAccess(client ibclient.IBConnector, view string, metrics provider.Metric
 }
 
 func (this *access) CreateRecord(r raw.Record, zone provider.DNSHostedZone) error {
-	this.metrics.AddZoneRequests(zone.Id(), provider.M_CREATERECORDS, 1)
+	this.metrics.AddZoneRequests(zone.Id().ID, provider.M_CREATERECORDS, 1)
 	_, err := this.CreateObject(r.(ibclient.IBObject))
 	return err
 }
 
 func (this *access) UpdateRecord(r raw.Record, zone provider.DNSHostedZone) error {
-	this.metrics.AddZoneRequests(zone.Id(), provider.M_CREATERECORDS, 1)
+	this.metrics.AddZoneRequests(zone.Id().ID, provider.M_CREATERECORDS, 1)
 	_, err := this.UpdateObject(r.(Record).PrepareUpdate().(ibclient.IBObject), r.GetId())
 	return err
 }
 
 func (this *access) DeleteRecord(r raw.Record, zone provider.DNSHostedZone) error {
-	this.metrics.AddZoneRequests(zone.Id(), provider.M_DELETERECORDS, 1)
+	this.metrics.AddZoneRequests(zone.Id().ID, provider.M_DELETERECORDS, 1)
 	_, err := this.DeleteObject(r.GetId())
 	return err
 }
@@ -103,7 +103,7 @@ func (this *access) NewRecord(fqdn string, rtype string, value string, zone prov
 }
 
 func (this *access) GetRecordSet(dnsName, rtype string, zone provider.DNSHostedZone) (raw.RecordSet, error) {
-	this.metrics.AddZoneRequests(zone.Id(), provider.M_LISTRECORDS, 1)
+	this.metrics.AddZoneRequests(zone.Id().ID, provider.M_LISTRECORDS, 1)
 	c := this.IBConnector.(*ibclient.Connector)
 
 	if rtype != dns.RS_TXT {

--- a/pkg/controller/provider/infoblox/handler.go
+++ b/pkg/controller/provider/infoblox/handler.go
@@ -222,7 +222,7 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, cache provider.ZoneC
 	state := raw.NewState()
 	rt := provider.M_LISTRECORDS
 
-	h.config.Metrics.AddZoneRequests(zone.Id(), rt, 1)
+	h.config.Metrics.AddZoneRequests(zone.Id().ID, rt, 1)
 	var resA []RecordA
 	objA := ibclient.NewEmptyRecordA()
 	objA.Zone = zone.Key()
@@ -235,7 +235,7 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, cache provider.ZoneC
 		state.AddRecord((&res).Copy())
 	}
 
-	h.config.Metrics.AddZoneRequests(zone.Id(), rt, 1)
+	h.config.Metrics.AddZoneRequests(zone.Id().ID, rt, 1)
 	var resAAAA []RecordAAAA
 	objAAAA := ibclient.NewEmptyRecordAAAA()
 	objAAAA.Zone = zone.Key()
@@ -248,7 +248,7 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, cache provider.ZoneC
 		state.AddRecord((&res).Copy())
 	}
 
-	h.config.Metrics.AddZoneRequests(zone.Id(), rt, 1)
+	h.config.Metrics.AddZoneRequests(zone.Id().ID, rt, 1)
 	var resC []RecordCNAME
 	objC := ibclient.NewEmptyRecordCNAME()
 	objC.Zone = zone.Key()
@@ -261,7 +261,7 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, cache provider.ZoneC
 		state.AddRecord((&res).Copy())
 	}
 
-	h.config.Metrics.AddZoneRequests(zone.Id(), rt, 1)
+	h.config.Metrics.AddZoneRequests(zone.Id().ID, rt, 1)
 	var resT []RecordTXT
 	objT := ibclient.NewRecordTXT(
 		ibclient.RecordTXT{

--- a/pkg/controller/provider/netlify/access.go
+++ b/pkg/controller/provider/netlify/access.go
@@ -98,7 +98,7 @@ func (this *access) CreateRecord(r raw.Record, zone provider.DNSHostedZone) erro
 		Value:    r.GetValue(),
 		TTL:      int64(ttl),
 	}
-	this.metrics.AddZoneRequests(zone.Id(), provider.M_CREATERECORDS, 1)
+	this.metrics.AddZoneRequests(zone.Id().ID, provider.M_CREATERECORDS, 1)
 	this.rateLimiter.Accept()
 	createParams := operations.NewCreateDNSRecordParams()
 	createParams.SetZoneID(a.DNSZoneID)
@@ -122,7 +122,7 @@ func (this *access) DeleteRecord(r raw.Record, zone provider.DNSHostedZone) erro
 	deleteParams := operations.NewDeleteDNSRecordParams()
 	deleteParams.SetZoneID(a.DNSZoneID)
 	deleteParams.SetDNSRecordID(a.ID)
-	this.metrics.AddZoneRequests(zone.Id(), provider.M_DELETERECORDS, 1)
+	this.metrics.AddZoneRequests(zone.Id().ID, provider.M_DELETERECORDS, 1)
 	this.rateLimiter.Accept()
 	_, err := this.client.DeleteDNSRecord(deleteParams, this.authInfo)
 	return err
@@ -134,7 +134,7 @@ func (this *access) NewRecord(fqdn, rtype, value string, zone provider.DNSHosted
 		Hostname:  fqdn,
 		Value:     value,
 		TTL:       int64(ttl),
-		DNSZoneID: zone.Id(),
+		DNSZoneID: zone.Id().ID,
 	})
 }
 
@@ -149,7 +149,7 @@ func (this *access) GetRecordSet(dnsName, rtype string, zone provider.DNSHostedZ
 	}
 
 	// no filtering provided by API, we have to list complete zone and filter
-	err := this.ListRecords(zone.Id(), consume)
+	err := this.ListRecords(zone.Id().ID, consume)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/provider/openstack/execution.go
+++ b/pkg/controller/provider/openstack/execution.go
@@ -109,7 +109,7 @@ func (exec *Execution) create(rset *recordsets.RecordSet) error {
 		Records: rset.Records,
 	}
 	exec.handler.config.RateLimiter.Accept()
-	_, err := exec.handler.client.CreateRecordSet(exec.zone.Id(), opts)
+	_, err := exec.handler.client.CreateRecordSet(exec.zone.Id().ID, opts)
 	return err
 }
 
@@ -120,7 +120,7 @@ func (exec *Execution) lookupRecordSetID(rset *recordsets.RecordSet) (string, er
 		return nil
 	}
 	exec.handler.config.RateLimiter.Accept()
-	err := exec.handler.client.ForEachRecordSetFilterByTypeAndName(exec.zone.Id(), rset.Type, dns.AlignHostname(rset.Name), handler)
+	err := exec.handler.client.ForEachRecordSetFilterByTypeAndName(exec.zone.Id().ID, rset.Type, dns.AlignHostname(rset.Name), handler)
 	if err != nil {
 		return "", fmt.Errorf("RecordSet lookup for %s %s failed with: %s", rset.Type, rset.Name, err)
 	}
@@ -141,7 +141,7 @@ func (exec *Execution) update(rset *recordsets.RecordSet) error {
 		Records: rset.Records,
 	}
 	exec.handler.config.RateLimiter.Accept()
-	err = exec.handler.client.UpdateRecordSet(exec.zone.Id(), recordSetID, opts)
+	err = exec.handler.client.UpdateRecordSet(exec.zone.Id().ID, recordSetID, opts)
 	return err
 }
 
@@ -151,6 +151,6 @@ func (exec *Execution) delete(rset *recordsets.RecordSet) error {
 		return err
 	}
 	exec.handler.config.RateLimiter.Accept()
-	err = exec.handler.client.DeleteRecordSet(exec.zone.Id(), recordSetID)
+	err = exec.handler.client.DeleteRecordSet(exec.zone.Id().ID, recordSetID)
 	return err
 }

--- a/pkg/controller/provider/openstack/handler.go
+++ b/pkg/controller/provider/openstack/handler.go
@@ -222,7 +222,7 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, cache provider.ZoneC
 	}
 
 	h.config.RateLimiter.Accept()
-	if err := h.client.ForEachRecordSet(zone.Id(), recordSetHandler); err != nil {
+	if err := h.client.ForEachRecordSet(zone.Id().ID, recordSetHandler); err != nil {
 		return nil, fmt.Errorf("Listing DNS zones failed for %s. Details: %s", zone.Id(), err.Error())
 	}
 

--- a/pkg/controller/provider/openstack/handler_test.go
+++ b/pkg/controller/provider/openstack/handler_test.go
@@ -43,10 +43,6 @@ type testzone struct {
 
 var _ provider.DNSHostedZone = &testzone{}
 
-func (tz *testzone) ProviderType() string {
-	return "test"
-}
-
 func (tz *testzone) buildNextId() string {
 	d := fmt.Sprintf("rs-%04d", tz.nextID)
 	tz.nextID++
@@ -57,8 +53,8 @@ func (tz *testzone) Key() string {
 	return tz.zone.ID
 }
 
-func (tz *testzone) Id() string {
-	return tz.zone.ID
+func (tz *testzone) Id() dns.ZoneID {
+	return dns.NewZoneID("test", tz.zone.ID)
 }
 
 func (tz *testzone) Domain() string {
@@ -243,17 +239,17 @@ func TestGetZones(t *testing.T) {
 		t.Errorf("Excepted 2 zones, but got %d", len(hostedZones))
 	}
 	sort.Slice(hostedZones, func(i, j int) bool {
-		return strings.Compare(hostedZones[i].Id(), hostedZones[j].Id()) < 0
+		return strings.Compare(hostedZones[i].Id().ID, hostedZones[j].Id().ID) < 0
 	})
 	z1 := hostedZones[0]
 	z2 := hostedZones[1]
-	if z1.Id() != "z1" || z1.Domain() != "z1.test" {
+	if z1.Id().ID != "z1" || z1.Domain() != "z1.test" {
 		t.Errorf("Zone z1 not found: %v", z1)
 	}
 	if len(z1.ForwardedDomains()) != 0 {
 		t.Errorf("Zone z1: unexpected forwarded domains: %v", z1.ForwardedDomains())
 	}
-	if z2.Id() != "z2" || z2.Domain() != "z2.test" {
+	if z2.Id().ID != "z2" || z2.Domain() != "z2.test" {
 		t.Errorf("Zone z2 not found: %v", z2)
 	}
 	if len(z2.ForwardedDomains()) != 1 || z2.ForwardedDomains()[0] != "excluded.z2.test" {

--- a/pkg/controller/provider/remote/handler.go
+++ b/pkg/controller/provider/remote/handler.go
@@ -234,8 +234,8 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, cache provider.ZoneC
 	err := h.retryOnInvalidTokenError(ctx, func(token string) error {
 		var err error
 		h.config.RateLimiter.Accept()
-		remoteState, err = h.client.GetZoneState(ctx, &common.GetZoneStateRequest{Token: token, Zoneid: zone.Id()})
-		h.config.Metrics.AddZoneRequests(zone.Id(), provider.M_LISTRECORDS, 1)
+		remoteState, err = h.client.GetZoneState(ctx, &common.GetZoneStateRequest{Token: token, Zoneid: zone.Id().ID})
+		h.config.Metrics.AddZoneRequests(zone.Id().ID, provider.M_LISTRECORDS, 1)
 		return err
 	})
 	if err != nil {
@@ -274,9 +274,9 @@ func (h *Handler) executeRequests(logger logger.LogContext, zone provider.DNSHos
 
 		switch change.Action {
 		case common.ChangeRequest_CREATE | common.ChangeRequest_UPDATE:
-			h.config.Metrics.AddZoneRequests(zone.Id(), provider.M_UPDATERECORDS, 1)
+			h.config.Metrics.AddZoneRequests(zone.Id().ID, provider.M_UPDATERECORDS, 1)
 		case common.ChangeRequest_DELETE:
-			h.config.Metrics.AddZoneRequests(zone.Id(), provider.M_DELETERECORDS, 1)
+			h.config.Metrics.AddZoneRequests(zone.Id().ID, provider.M_DELETERECORDS, 1)
 		}
 	}
 
@@ -286,7 +286,7 @@ func (h *Handler) executeRequests(logger logger.LogContext, zone provider.DNSHos
 		h.config.RateLimiter.Accept()
 		executeRequest := &common.ExecuteRequest{
 			Token:         token,
-			Zoneid:        zone.Id(),
+			Zoneid:        zone.Id().ID,
 			ChangeRequest: changeRequests,
 		}
 		response, err = h.client.Execute(ctx, executeRequest)

--- a/pkg/dns/provider/controller.go
+++ b/pkg/dns/provider/controller.go
@@ -240,8 +240,8 @@ func (this *reconciler) Command(logger logger.LogContext, cmd string) reconcile.
 		this.state.UpdateOwnerCounts(logger)
 	default:
 		zoneid := this.state.DecodeZoneCommand(cmd)
-		if zoneid != "" {
-			return this.state.ReconcileZone(logger, zoneid)
+		if zoneid != nil {
+			return this.state.ReconcileZone(logger, *zoneid)
 		}
 		logger.Infof("got unhandled command %q", cmd)
 	}

--- a/pkg/dns/provider/default.go
+++ b/pkg/dns/provider/default.go
@@ -46,27 +46,22 @@ func (this *DefaultDNSZoneState) Clone() DNSZoneState {
 ////////////////////////////////////////////////////////////////////////////////
 
 type DefaultDNSHostedZone struct {
-	providerType string   // provider type
-	id           string   // identifying id for provider api
-	domain       string   // base domain for zone
-	forwarded    []string // forwarded sub domains
-	key          string   // internal key used by provider (not used by this lib)
-	isPrivate    bool     // indicates a private zone
+	zoneid    dns.ZoneID // qualified zone id
+	domain    string     // base domain for zone
+	forwarded []string   // forwarded sub domains
+	key       string     // internal key used by provider (not used by this lib)
+	isPrivate bool       // indicates a private zone
 }
 
 func (this *DefaultDNSHostedZone) Key() string {
 	if this.key != "" {
 		return this.key
 	}
-	return this.id
+	return this.zoneid.ID
 }
 
-func (this *DefaultDNSHostedZone) ProviderType() string {
-	return this.providerType
-}
-
-func (this *DefaultDNSHostedZone) Id() string {
-	return this.id
+func (this *DefaultDNSHostedZone) Id() dns.ZoneID {
+	return this.zoneid
 }
 
 func (this *DefaultDNSHostedZone) Domain() string {
@@ -97,11 +92,11 @@ func Match(zone DNSHostedZone, dnsname string) int {
 	return 0
 }
 
-func NewDNSHostedZone(ptype string, id, domain, key string, forwarded []string, isPrivate bool) DNSHostedZone {
-	return &DefaultDNSHostedZone{providerType: ptype, id: id, key: key, domain: domain, forwarded: forwarded, isPrivate: isPrivate}
+func NewDNSHostedZone(providerType, id, domain, key string, forwarded []string, isPrivate bool) DNSHostedZone {
+	return &DefaultDNSHostedZone{zoneid: dns.NewZoneID(providerType, id), key: key, domain: domain, forwarded: forwarded, isPrivate: isPrivate}
 }
 
 func CopyDNSHostedZone(zone DNSHostedZone, forwardedDomains []string) DNSHostedZone {
-	return &DefaultDNSHostedZone{providerType: zone.ProviderType(), id: zone.Id(), key: zone.Key(),
+	return &DefaultDNSHostedZone{zoneid: zone.Id(), key: zone.Key(),
 		domain: zone.Domain(), forwarded: forwardedDomains, isPrivate: zone.IsPrivate()}
 }

--- a/pkg/dns/provider/interface.go
+++ b/pkg/dns/provider/interface.go
@@ -131,9 +131,8 @@ func NewConfigForController(c controller.Interface, factory DNSHandlerFactory) (
 }
 
 type DNSHostedZone interface {
-	ProviderType() string
 	Key() string
-	Id() string
+	Id() dns.ZoneID
 	Domain() string
 	ForwardedDomains() []string
 	Match(dnsname string) int
@@ -192,8 +191,8 @@ const (
 )
 
 type Metrics interface {
-	AddGenericRequests(request_type string, n int)
-	AddZoneRequests(zoneID, request_type string, n int)
+	AddGenericRequests(requestType string, n int)
+	AddZoneRequests(zoneID, requestType string, n int)
 }
 
 type Finalizers interface {
@@ -250,7 +249,7 @@ type DNSProvider interface {
 	DefaultTTL() int64
 
 	GetZones() DNSHostedZones
-	IncludesZone(zoneID string) bool
+	IncludesZone(zoneID dns.ZoneID) bool
 
 	GetZoneState(zone DNSHostedZone) (DNSZoneState, error)
 	ExecuteRequests(logger logger.LogContext, zone DNSHostedZone, state DNSZoneState, requests []*ChangeRequest) error

--- a/pkg/dns/provider/selection/selection_test.go
+++ b/pkg/dns/provider/selection/selection_test.go
@@ -17,6 +17,7 @@
 package selection_test
 
 import (
+	"github.com/gardener/external-dns-management/pkg/dns"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -28,38 +29,38 @@ import (
 )
 
 type lightDNSHostedZone struct {
-	id               string
+	id               dns.ZoneID
 	domain           string
 	forwardedDomains []string
 }
 
-func (z *lightDNSHostedZone) Id() string                 { return z.id }
+func (z *lightDNSHostedZone) Id() dns.ZoneID             { return z.id }
 func (z *lightDNSHostedZone) Domain() string             { return z.domain }
 func (z *lightDNSHostedZone) ForwardedDomains() []string { return z.forwardedDomains }
 
 var _ = Describe("Selection", func() {
 	zab := &lightDNSHostedZone{
-		id:               "ZAB",
+		id:               dns.NewZoneID("test", "ZAB"),
 		domain:           "a.b",
 		forwardedDomains: []string{"c.a.b", "d.a.b"},
 	}
 	zab2 := &lightDNSHostedZone{
-		id:               "ZAB2",
+		id:               dns.NewZoneID("test", "ZAB2"),
 		domain:           "a.b",
 		forwardedDomains: []string{},
 	}
 	zcab := &lightDNSHostedZone{
-		id:               "ZCAB",
+		id:               dns.NewZoneID("test", "ZCAB"),
 		domain:           "c.a.b",
 		forwardedDomains: nil,
 	}
 	zfab := &lightDNSHostedZone{
-		id:               "ZFAB",
+		id:               dns.NewZoneID("test", "ZFAB"),
 		domain:           "f.a.b",
 		forwardedDomains: nil,
 	}
 	zop := &lightDNSHostedZone{
-		id:               "ZOP",
+		id:               dns.NewZoneID("test", "ZOP"),
 		domain:           "o.p",
 		forwardedDomains: nil,
 	}
@@ -67,7 +68,9 @@ var _ = Describe("Selection", func() {
 	allzones := []LightDNSHostedZone{zab, zcab, zop}
 
 	It("uses all zones if no spec given", func() {
-		spec := v1alpha1.DNSProviderSpec{}
+		spec := v1alpha1.DNSProviderSpec{
+			Type: "test",
+		}
 		result := CalcZoneAndDomainSelection(spec, allzones)
 		Expect(result).To(Equal(SelectionResult{
 			Zones:         allzones,
@@ -86,6 +89,7 @@ var _ = Describe("Selection", func() {
 
 	It("deals with uppercase domain selection and final dot", func() {
 		spec := v1alpha1.DNSProviderSpec{
+			Type: "test",
 			Domains: &v1alpha1.DNSSelection{
 				Include: []string{"A.b."},
 				Exclude: []string{"O.P."},
@@ -111,7 +115,9 @@ var _ = Describe("Selection", func() {
 	})
 
 	It("handles no zones", func() {
-		spec := v1alpha1.DNSProviderSpec{}
+		spec := v1alpha1.DNSProviderSpec{
+			Type: "test",
+		}
 		result := CalcZoneAndDomainSelection(spec, nozones)
 		Expect(result).To(Equal(SelectionResult{
 			Zones:         nil,
@@ -131,6 +137,7 @@ var _ = Describe("Selection", func() {
 
 	It("handles zones exclusion", func() {
 		spec := v1alpha1.DNSProviderSpec{
+			Type: "test",
 			Zones: &v1alpha1.DNSSelection{
 				Include: nil,
 				Exclude: []string{"ZOP", "ZAB"},
@@ -157,6 +164,7 @@ var _ = Describe("Selection", func() {
 
 	It("handles zones inclusion", func() {
 		spec := v1alpha1.DNSProviderSpec{
+			Type: "test",
 			Zones: &v1alpha1.DNSSelection{
 				Include: []string{"ZAB"},
 				Exclude: []string{"ZOP"},
@@ -183,6 +191,7 @@ var _ = Describe("Selection", func() {
 
 	It("handles simple domain inclusion", func() {
 		spec := v1alpha1.DNSProviderSpec{
+			Type: "test",
 			Domains: &v1alpha1.DNSSelection{
 				Include: []string{"a.b"},
 				Exclude: nil,
@@ -209,6 +218,7 @@ var _ = Describe("Selection", func() {
 
 	It("handles domain inclusion with exclusion of domain of sub hosted zone", func() {
 		spec := v1alpha1.DNSProviderSpec{
+			Type: "test",
 			Domains: &v1alpha1.DNSSelection{
 				Include: []string{"a.b"},
 				Exclude: []string{"c.a.b"},
@@ -235,6 +245,7 @@ var _ = Describe("Selection", func() {
 
 	It("handles complex domain inclusion", func() {
 		spec := v1alpha1.DNSProviderSpec{
+			Type: "test",
 			Domains: &v1alpha1.DNSSelection{
 				Include: []string{"c.a.b", "x.o.p"},
 				Exclude: []string{"d.a.b", "e.a.b", "y.x.o.p"},
@@ -264,6 +275,7 @@ var _ = Describe("Selection", func() {
 
 	It("handles foreign domain inclusion", func() {
 		spec := v1alpha1.DNSProviderSpec{
+			Type: "test",
 			Domains: &v1alpha1.DNSSelection{
 				Include: []string{"y.z"},
 				Exclude: nil,
@@ -294,6 +306,7 @@ var _ = Describe("Selection", func() {
 
 	It("matches duplicate zones with same base domain by domain inclusion", func() {
 		spec := v1alpha1.DNSProviderSpec{
+			Type: "test",
 			Domains: &v1alpha1.DNSSelection{
 				Include: []string{"f.a.b"},
 				Exclude: nil,
@@ -320,6 +333,7 @@ var _ = Describe("Selection", func() {
 
 	It("matches duplicate zones with overlapping base domain by domain inclusion", func() {
 		spec := v1alpha1.DNSProviderSpec{
+			Type: "test",
 			Domains: &v1alpha1.DNSSelection{
 				Include: []string{"d.f.a.b"},
 				Exclude: nil,

--- a/pkg/dns/provider/utils.go
+++ b/pkg/dns/provider/utils.go
@@ -22,19 +22,20 @@ import (
 
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/gardener/external-dns-management/pkg/dns"
 )
 
 type NullMetrics struct{}
 
 var _ Metrics = &NullMetrics{}
 
-func (m *NullMetrics) AddGenericRequests(request_type string, n int) {
+func (m *NullMetrics) AddGenericRequests(requestType string, n int) {
 }
 
-func (m *NullMetrics) AddZoneRequests(zon, request_type string, n int) {
+func (m *NullMetrics) AddZoneRequests(zoneid, requestType string, n int) {
 }
 
-func copyZones(src map[string]*dnsHostedZone) dnsHostedZones {
+func copyZones(src map[dns.ZoneID]*dnsHostedZone) dnsHostedZones {
 	dst := dnsHostedZones{}
 	for k, v := range src {
 		dst[k] = v

--- a/pkg/dns/provider/zone.go
+++ b/pkg/dns/provider/zone.go
@@ -23,10 +23,11 @@ import (
 
 	"github.com/gardener/controller-manager-library/pkg/utils"
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/gardener/external-dns-management/pkg/dns"
 	dnsutils "github.com/gardener/external-dns-management/pkg/dns/utils"
 )
 
-type dnsHostedZones map[string]*dnsHostedZone
+type dnsHostedZones map[dns.ZoneID]*dnsHostedZone
 
 type dnsHostedZone struct {
 	*dnsutils.RateLimiter
@@ -75,11 +76,7 @@ func (this *dnsHostedZone) getZone() DNSHostedZone {
 	return this.zone
 }
 
-func (this *dnsHostedZone) ProviderType() string {
-	return this.getZone().ProviderType()
-}
-
-func (this *dnsHostedZone) Id() string {
+func (this *dnsHostedZone) Id() dns.ZoneID {
 	return this.getZone().Id()
 }
 

--- a/pkg/dns/zoneid.go
+++ b/pkg/dns/zoneid.go
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *
+ */
+
+package dns
+
+type ZoneID struct {
+	ProviderType string
+	ID           string
+}
+
+func NewZoneID(providerType, zoneid string) ZoneID {
+	return ZoneID{ProviderType: providerType, ID: zoneid}
+}
+
+func (z ZoneID) String() string {
+	return z.ProviderType + "/" + z.ID
+}
+
+func (z ZoneID) IsEmpty() bool {
+	return len(z.ProviderType)+len(z.ID) == 0
+}

--- a/pkg/server/remote/conversion/conversion_test.go
+++ b/pkg/server/remote/conversion/conversion_test.go
@@ -66,12 +66,12 @@ func TestMarshalChangeRequest(t *testing.T) {
 	for _, item := range table {
 		remote, err := MarshalChangeRequest(item.request)
 		if err != nil {
-			t.Errorf("MarshalChangeRequest failed: %v", err)
+			t.Errorf("MarshalChangeRequest failed: %s", err)
 			continue
 		}
 		copy, err := UnmarshalChangeRequest(remote, nil)
 		if err != nil {
-			t.Errorf("UnmarshalChangeRequest failed: %v", err)
+			t.Errorf("UnmarshalChangeRequest failed: %s", err)
 			continue
 		}
 

--- a/pkg/server/remote/server.go
+++ b/pkg/server/remote/server.go
@@ -238,8 +238,8 @@ func (s *server) getZones(nsState *namespaceState, logctx logger.LogContext) (*c
 	result := &common.Zones{}
 	for _, zone := range zones {
 		z := &common.Zone{
-			Id:              zone.Id(),
-			ProviderType:    zone.ProviderType(),
+			Id:              zone.Id().ID,
+			ProviderType:    zone.Id().ProviderType,
 			Key:             zone.Key(),
 			Domain:          zone.Domain(),
 			ForwardedDomain: zone.ForwardedDomains(),

--- a/pkg/server/remote/state.go
+++ b/pkg/server/remote/state.go
@@ -118,7 +118,7 @@ func (s *namespaceState) _refreshZones() {
 	for _, hstate := range s.handlers {
 		zones := hstate.getCachedZones()
 		for _, zone := range zones {
-			s.zones[zone.Id()] = zonehandler{
+			s.zones[zone.Id().ID] = zonehandler{
 				zone:    zone,
 				handler: hstate,
 			}

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -20,8 +20,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/gardener/controller-manager-library/pkg/resources"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	networkingv1 "k8s.io/api/networking/v1"
 
 	_ "github.com/gardener/external-dns-management/pkg/controller/provider/compound/controller"
 	_ "github.com/gardener/external-dns-management/pkg/controller/provider/mock"
@@ -39,6 +41,8 @@ var testCerts *certFileAndSecret
 
 func TestIntegration(t *testing.T) {
 	RegisterFailHandler(Fail)
+
+	resources.Register(networkingv1.SchemeBuilder)
 
 	RunSpecs(t, "Integration Suite")
 }

--- a/test/integration/testenv.go
+++ b/test/integration/testenv.go
@@ -40,7 +40,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	corev1 "k8s.io/api/core/v1"
-	networking "k8s.io/api/networking/v1beta1"
+	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
@@ -782,7 +782,7 @@ func (te *TestEnv) MockInMemoryGetDNSSetEx(name, zonePrefix, dnsName string) (*d
 		return nil, nil
 	}
 	for _, zone := range testMock.GetZones() {
-		if strings.HasPrefix(zone.Id(), zonePrefix) && zone.Match(dnsName) > 0 {
+		if strings.HasPrefix(zone.Id().ID, zonePrefix) && zone.Match(dnsName) > 0 {
 			state, err := testMock.CloneZoneState(zone)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:
For managing internal state, the zone id as given by the provider is used as key.
This may lead to clashes. If remote providers are introduced gradually (i.e. by migrating DNSProviders from the direct provider to the remote provider per namespace), such clashes occur easily. In such a case there are multiple providers with the same zoneid and zone reconciliation is executed for both at the same time. Only one of them is used for applying changes, but the changes are only reflected in one zone state cache.
This leads to repeated update requests until the other zone state is synchronised by the periodical sync.
 
To avoid such situations, the internal state now uses qualified zone ids which include the provider type.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Introduce qualified zone id to avoid clashes on migrating to remote provider.
```
