### PR TITLE
Don't cleanup entries belonging to provider of equivalent zone

### DIFF
--- a/pkg/dns/provider/interface.go
+++ b/pkg/dns/provider/interface.go
@@ -250,6 +250,7 @@ type DNSProvider interface {
 
 	GetZones() DNSHostedZones
 	IncludesZone(zoneID dns.ZoneID) bool
+	HasEquivalentZone(zoneID dns.ZoneID) bool
 
 	GetZoneState(zone DNSHostedZone) (DNSZoneState, error)
 	ExecuteRequests(logger logger.LogContext, zone DNSHostedZone, state DNSZoneState, requests []*ChangeRequest) error

--- a/pkg/dns/provider/provider.go
+++ b/pkg/dns/provider/provider.go
@@ -600,6 +600,14 @@ func (this *dnsProviderVersion) IncludesZone(zoneID dns.ZoneID) bool {
 	return this.TypeCode() == zoneID.ProviderType && this.included_zones != nil && this.included_zones.Contains(zoneID.ID)
 }
 
+// HasEquivalentZone returns true for same provider specific zone id but different provider type and
+// one zoneid has provider type "remote".
+func (this *dnsProviderVersion) HasEquivalentZone(zoneID dns.ZoneID) bool {
+	return this.TypeCode() != zoneID.ProviderType &&
+		(this.TypeCode() == "remote" || zoneID.ProviderType == "remote") &&
+		this.included_zones != nil && this.included_zones.Contains(zoneID.ID)
+}
+
 func (this *dnsProviderVersion) GetDedicatedDNSAccess() DedicatedDNSAccess {
 	h, _ := this.account.handler.(DedicatedDNSAccess)
 	return h

--- a/pkg/dns/provider/state_zone.go
+++ b/pkg/dns/provider/state_zone.go
@@ -75,7 +75,7 @@ func (this *state) GetZoneReconcilation(logger logger.LogContext, zoneid dns.Zon
 	if now.Before(next) {
 		return next.Sub(now), hasProviders, req
 	}
-	req.entries, req.stale, req.deleting = this.addEntriesForZone(logger, nil, nil, zone)
+	req.entries, req.equivEntries, req.stale, req.deleting = this.addEntriesForZone(logger, nil, nil, zone)
 	req.providers = this.getProvidersForZone(zoneid)
 	req.dnsTicker = this.dnsTicker
 	return 0, hasProviders, req


### PR DESCRIPTION
**What this PR does / why we need it**:
With introduction of a qualified zone id which includes the provider type, DNS entries are only created or updated during zone reconciliation of the zone identified by this qualified zone id.
But for deletion of DNS entries and cleanup of orphan records this separation did not work. After resyncing the zone state DNS records are deleted because the assignment to a provider type is not taken into consideration. If a hosted zone is both accessed directly and remotely ("central DNS proxy"), DNS entries belonging to one of them appear to be orphaned, but are belonging to the other one in fact.
This wrong behaviour is fixed here by excluding DNS entries belonging to such a "equivalent" zone on cleanup. 

**Which issue(s) this PR fixes**:
Fixes #256 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Don't cleanup entries belonging to a provider of  an equivalent zone.
```
