### PR TITLE
Check for forwarded domains in same account

### DIFF
--- a/pkg/controller/provider/mock/handler.go
+++ b/pkg/controller/provider/mock/handler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"k8s.io/client-go/util/flowcontrol"
@@ -80,7 +81,8 @@ func NewHandler(config *provider.DNSHandlerConfig) (provider.DNSHandler, error) 
 			if len(mockZone.ForwardedDomains) > 0 {
 				forwardedDomains = mockZone.ForwardedDomains
 			}
-			hostedZone := provider.NewDNSHostedZone(h.ProviderType(), zoneID, mockZone.DNSName, "", forwardedDomains, false)
+			isPrivate := strings.Contains(mockZone.ZonePrefix, ":private:")
+			hostedZone := provider.NewDNSHostedZone(h.ProviderType(), zoneID, mockZone.DNSName, "", forwardedDomains, isPrivate)
 			mock.AddZone(hostedZone)
 		}
 	}

--- a/pkg/dns/provider/provider.go
+++ b/pkg/dns/provider/provider.go
@@ -103,11 +103,43 @@ func (this *DNSAccount) Hash() string {
 func (this *DNSAccount) GetZones() (DNSHostedZones, error) {
 	zones, err := this.handler.GetZones()
 	if err == nil {
+		zones = addObviousForwardedDomains(zones)
 		this.Succeeded()
 	} else {
 		this.Failed()
 	}
 	return zones, err
+}
+
+func addObviousForwardedDomains(zones DNSHostedZones) DNSHostedZones {
+	result := make(DNSHostedZones, len(zones))
+	for i, zone := range zones {
+		result[i] = zone
+		if zone.IsPrivate() {
+			continue
+		}
+		changed := false
+		forwarded := zone.ForwardedDomains()
+	otherloop:
+		for j, other := range zones {
+			if i == j || other.IsPrivate() || zone.Domain() == other.Domain() {
+				continue
+			}
+			if Match(zone, other.Domain()) > 0 {
+				for _, domain := range forwarded {
+					if domain == other.Domain() {
+						continue otherloop
+					}
+				}
+				changed = true
+				forwarded = append(forwarded, other.Domain())
+			}
+		}
+		if changed {
+			result[i] = CopyDNSHostedZone(zone, forwarded)
+		}
+	}
+	return result
 }
 
 func (this *DNSAccount) GetZoneState(zone DNSHostedZone) (DNSZoneState, error) {

--- a/test/integration/privateZones_test.go
+++ b/test/integration/privateZones_test.go
@@ -103,11 +103,11 @@ var _ = Describe("PrivateZones", func() {
 		domain := "pr1.mock.xx"
 		setSpec := func(provider *v1alpha1.DNSProvider) {
 			spec := &provider.Spec
-			spec.Zones = &v1alpha1.DNSSelection{Include: []string{"z1:" + domain, "z2" + domain}}
+			spec.Zones = &v1alpha1.DNSSelection{Include: []string{"z1:private:" + domain, "z2:private:" + domain}}
 			spec.Type = "mock-inmemory"
 
 			var zonedata []mock.MockZone
-			for _, prefix := range []string{"z1:", "z2:"} {
+			for _, prefix := range []string{"z1:private:", "z2:private:"} {
 				zonedata = append(zonedata, mock.MockZone{
 					ZonePrefix: prefix,
 					DNSName:    domain,
@@ -130,7 +130,7 @@ var _ = Describe("PrivateZones", func() {
 
 		// should be ok to include only one zone
 		pr, err = testEnv.UpdateProviderSpec(pr, func(spec *v1alpha1.DNSProviderSpec) error {
-			spec.Zones.Include = []string{"z2:pr1.mock.xx"}
+			spec.Zones.Include = []string{"z2:private:pr1.mock.xx"}
 			return nil
 		})
 		Ω(err).Should(BeNil())
@@ -139,11 +139,11 @@ var _ = Describe("PrivateZones", func() {
 		e, err := testEnv.CreateEntry(0, domain)
 		Ω(err).Should(BeNil())
 		testEnv.AwaitEntryReady(e.GetName())
-		err = testEnv.MockInMemoryHasEntryEx(testEnv.Namespace, "z2", e)
+		err = testEnv.MockInMemoryHasEntryEx(testEnv.Namespace, "z2:private:", e)
 		Ω(err).Should(BeNil())
 
 		pr, err = testEnv.UpdateProviderSpec(pr, func(spec *v1alpha1.DNSProviderSpec) error {
-			spec.Zones.Include = []string{"z1:pr1.mock.xx"}
+			spec.Zones.Include = []string{"z1:private:pr1.mock.xx"}
 			return nil
 		})
 		Ω(err).Should(BeNil())
@@ -153,7 +153,7 @@ var _ = Describe("PrivateZones", func() {
 			var data *v1alpha1.DNSProvider
 			pr, data, err = testEnv.GetProvider(pr.GetName())
 			Ω(err).Should(BeNil())
-			if data.Status.Zones.Included[0] == "z1:pr1.mock.xx" {
+			if data.Status.Zones.Included[0] == "z1:private:pr1.mock.xx" {
 				found = true
 				break
 			}
@@ -164,7 +164,7 @@ var _ = Describe("PrivateZones", func() {
 
 		time.Sleep(100 * time.Millisecond)
 		testEnv.AwaitEntryReady(e.GetName())
-		err = testEnv.MockInMemoryHasEntryEx(testEnv.Namespace, "z1", e)
+		err = testEnv.MockInMemoryHasEntryEx(testEnv.Namespace, "z1:private:", e)
 		Ω(err).Should(BeNil())
 
 		err = testEnv.DeleteEntryAndWait(e)
@@ -234,7 +234,7 @@ var _ = Describe("PrivateZones", func() {
 			spec := &provider.Spec
 			spec.Domains = &v1alpha1.DNSSelection{Include: []string{"a.mock.xx"}}
 			spec.Type = "mock-inmemory"
-			spec.ProviderConfig = testEnv.BuildProviderConfig("mock.xx", "a.mock.xx")
+			spec.ProviderConfig = testEnv.BuildProviderConfig("mock.xx", "a.mock.xx", PrivateZones)
 			spec.SecretRef = &corev1.SecretReference{Name: secret.GetName(), Namespace: testEnv.Namespace}
 		}
 
@@ -261,7 +261,7 @@ var _ = Describe("PrivateZones", func() {
 			spec := &provider.Spec
 			spec.Domains = &v1alpha1.DNSSelection{Include: []string{"a.mock.xx"}}
 			spec.Type = "mock-inmemory"
-			spec.ProviderConfig = testEnv.BuildProviderConfig("mock.xx", "mock.xx")
+			spec.ProviderConfig = testEnv.BuildProviderConfig("mock.xx", "mock.xx", PrivateZones)
 			spec.SecretRef = &corev1.SecretReference{Name: secret.GetName(), Namespace: testEnv.Namespace}
 		}
 
@@ -288,7 +288,7 @@ var _ = Describe("PrivateZones", func() {
 			spec := &provider.Spec
 			spec.Domains = &v1alpha1.DNSSelection{Include: []string{"mock.xx"}}
 			spec.Type = "mock-inmemory"
-			spec.ProviderConfig = testEnv.BuildProviderConfig("mock.xx", "sub.mock.xx", Domain2IsSubdomain)
+			spec.ProviderConfig = testEnv.BuildProviderConfig("mock.xx", "sub.mock.xx", Domain2IsSubdomain, PrivateZones)
 			spec.SecretRef = &corev1.SecretReference{Name: secret.GetName(), Namespace: testEnv.Namespace}
 		}
 

--- a/test/integration/testenv.go
+++ b/test/integration/testenv.go
@@ -60,6 +60,7 @@ const (
 	FailSecondZoneWithSameBaseDomain
 	AlternativeMockName
 	Domain2IsSubdomain
+	PrivateZones
 	Quotas4PerMin
 	RemoveAccess
 )
@@ -204,17 +205,21 @@ func (te *TestEnv) CreateSecretEx(secret *corev1.Secret) (resources.Object, erro
 
 func (te *TestEnv) BuildProviderConfig(domain, domain2 string, failOptions ...ProviderTestOption) *runtime.RawExtension {
 	name := te.Namespace
+	prefix2 := ""
 	for _, opt := range failOptions {
 		switch opt {
 		case AlternativeMockName:
 			name = name + "-alt"
+		case PrivateZones:
+			prefix2 = "private:"
 		}
 	}
+
 	input := mock.MockConfig{
 		Name: name,
 		Zones: []mock.MockZone{
-			{ZonePrefix: te.ZonePrefix, DNSName: domain},
-			{ZonePrefix: te.ZonePrefix + "second:", DNSName: domain2},
+			{ZonePrefix: te.ZonePrefix + prefix2, DNSName: domain},
+			{ZonePrefix: te.ZonePrefix + prefix2 + "second:", DNSName: domain2},
 		},
 	}
 	for _, opt := range failOptions {


### PR DESCRIPTION
**What this PR does / why we need it**:
Not all providers return a zone state containing NS records for forwarded zones.
In these cases, the dns-controller-manager has no information about the forwarded zones. In some constellations this can result in `DNSProvider` error states with "overlapping zones".
If the provider returns multiple zones and they are overlapping, the one being a subdomain of the other must be a forwarded domain if both zones are public zones.
This logic is added here.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Check for forwarded domains in same account.
```
