### PR TITLE
Tolerate apex label `@` on domain name validation

### DIFF
--- a/pkg/dns/mapping.go
+++ b/pkg/dns/mapping.go
@@ -68,6 +68,10 @@ func calcMetaRecordDomainName(name, prefix, base string) string {
 		if name == base {
 			prefix += "-base."
 		}
+	} else if strings.HasPrefix(name, "@.") {
+		// special case: allow apex label for Azure
+		name = name[2:]
+		prefix += "---at."
 	}
 	return add + prefix + name
 }
@@ -94,6 +98,9 @@ func MapFromProvider(name DNSSetName, rs *RecordSet) (DNSSetName, *RecordSet) {
 				dns = dns[len(prefix):]
 				if strings.HasPrefix(dns, "-base.") {
 					dns = dns[6:]
+				} else if strings.HasPrefix(dns, "---at.") {
+					dns = dns[6:]
+					add = "@."
 				} else if strings.HasPrefix(dns, ".") {
 					// for backwards compatibility of form *.comment-.basedomain
 					dns = dns[1:]

--- a/pkg/dns/mapping_test.go
+++ b/pkg/dns/mapping_test.go
@@ -61,6 +61,7 @@ func TestMapToFromProvider(t *testing.T) {
 		{"a.myzone.de", true, "mycomment-a.myzone.de"},
 		{"*.a.myzone.de", false, "*.comment-a.myzone.de"},
 		{"*.myzone.de", false, "*.comment--base.myzone.de"},
+		{"@.myzone.de", false, "comment----at.myzone.de"},
 	}
 
 	rtype := RS_META

--- a/pkg/dns/validation.go
+++ b/pkg/dns/validation.go
@@ -33,6 +33,9 @@ func ValidateDomainName(name string) error {
 	var errs []string
 	if strings.HasPrefix(check, "*.") {
 		errs = validation.IsWildcardDNS1123Subdomain(check)
+	} else if strings.HasPrefix(check, "@.") {
+		// special case: allow apex label for Azure
+		errs = validation.IsDNS1123Subdomain(check[2:])
 	} else {
 		errs = validation.IsDNS1123Subdomain(check)
 	}
@@ -53,6 +56,10 @@ func ValidateDomainName(name string) error {
 
 	labels := strings.Split(strings.TrimPrefix(check, "*."), ".")
 	for i, label := range labels {
+		if i == 0 && label == "@" {
+			// special case: allow apex label for Azure
+			continue
+		}
 		if errs = validation.IsDNS1123Label(label); len(errs) > 0 {
 			return fmt.Errorf("%d. label %q of %q is not valid (%v)", i+1, label, name, errs)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Tolerate apex label `@` on domain name validation. 
As validation happens before assigning a `DNSEntry` to a provider, it is silently allowed for all providers, although it is only requested for Azure DNS.

**Which issue(s) this PR fixes**:
Fixes #272 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Tolerate apex label `@` for Azure DNS on domain name validation
```
