### PR TITLE
Allow more CNAME targets

### DIFF
--- a/pkg/dns/dnsset.go
+++ b/pkg/dns/dnsset.go
@@ -119,7 +119,6 @@ func (dnssets DNSSets) GetOwners() utils.StringSet {
 const (
 	ATTR_OWNER  = "owner"
 	ATTR_PREFIX = "prefix"
-	ATTR_CNAMES = "cnames"
 	ATTR_KIND   = "kind"
 
 	ATTR_TIMESTAMP = "ts"

--- a/pkg/dns/provider/entry.go
+++ b/pkg/dns/provider/entry.go
@@ -43,6 +43,9 @@ import (
 
 const MSG_PRESERVED = "errorneous entry preserved in provider"
 
+// maxCNAMETargets is the maximum number of CNAME targets. It is restricted, as it needs regular DNS lookups.
+const maxCNAMETargets = 25
+
 type EntryPremise struct {
 	ptypes   utils.StringSet
 	ptype    string
@@ -774,8 +777,8 @@ func normalizeTargets(logger logger.LogContext, object dnsutils.DNSSpecification
 	}
 
 	result := make(Targets, 0, len(targets))
-	if len(targets) > 11 {
-		w := fmt.Sprintf("too many CNAME targets: %d", len(targets))
+	if len(targets) > maxCNAMETargets {
+		w := fmt.Sprintf("too many CNAME targets: %d (maximum allowed: %d)", len(targets), maxCNAMETargets)
 		logger.Warn(w)
 		object.Event(corev1.EventTypeWarning, "dnslookup restriction", w)
 		return result, true, false


### PR DESCRIPTION

**What this PR does / why we need it**:
For some special use cases in the community, more `CNAME` targets are needed. Instead of 11 there can be up to 25 targets which are implicitly converted to `A` or `AAAA` records.
As these need regular DNS lookups, we still need to restrict the total number for security reasons.

Moreover, obsolete/unused code was removed from the change model. The conversation from multiple `CNAME` targets to `A` and `AAAA` records already happens on setting up the entry version. 

**Which issue(s) this PR fixes**:
Fixes #283 and #284

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Allow more CNAME targets
```
