### PR TITLE
Allow full qualified domain names in DNSEntry field `spec.DnsName`

### DIFF
--- a/pkg/dns/source/slaves.go
+++ b/pkg/dns/source/slaves.go
@@ -99,7 +99,7 @@ func (this *slaveReconciler) Reconcile(logger logger.LogContext, obj resources.O
 					continue
 				}
 				s := entry.Status()
-				n := entry.Spec().DNSName
+				n := entry.GetDNSName()
 
 				stateCopy := DNSState{DNSEntryStatus: *s, CreationTimestamp: entry.GetCreationTimestamp()}
 				if stateCopy.Provider != nil {
@@ -157,7 +157,7 @@ func (this *slaveReconciler) Delete(logger logger.LogContext, obj resources.Obje
 				if fb == nil {
 					continue
 				}
-				n := entry.Spec().DNSName
+				n := entry.GetDNSName()
 				fb.Deleted(logger, n, "")
 			}
 			this.events.Deleted(logger, k)

--- a/pkg/dns/utils.go
+++ b/pkg/dns/utils.go
@@ -16,21 +16,10 @@
 
 package dns
 
-import (
-	"github.com/gardener/controller-manager-library/pkg/resources"
-	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
-)
-
 func SupportedRecordType(t string) bool {
 	switch t {
 	case RS_CNAME, RS_A, RS_AAAA, RS_TXT:
 		return true
 	}
 	return false
-}
-
-func DNSNameMatcher(dnsname string) resources.ObjectMatcher {
-	return func(o resources.Object) bool {
-		return o.Data().(*api.DNSEntry).Spec.DNSName == dnsname
-	}
 }

--- a/pkg/dns/utils/utils_entry.go
+++ b/pkg/dns/utils/utils_entry.go
@@ -62,7 +62,7 @@ func (this *DNSEntryObject) BaseStatus() *api.DNSBaseStatus {
 }
 
 func (this *DNSEntryObject) GetDNSName() string {
-	return this.DNSEntry().Spec.DNSName
+	return dns.NormalizeHostname(this.DNSEntry().Spec.DNSName)
 }
 func (this *DNSEntryObject) GetSetIdentifier() string {
 	if policy := this.DNSEntry().Spec.RoutingPolicy; policy != nil {

--- a/pkg/dns/utils/utils_lock.go
+++ b/pkg/dns/utils/utils_lock.go
@@ -64,7 +64,7 @@ func (this *DNSLockObject) BaseStatus() *api.DNSBaseStatus {
 }
 
 func (this *DNSLockObject) GetDNSName() string {
-	return this.DNSLock().Spec.DNSName
+	return dns.NormalizeHostname(this.DNSLock().Spec.DNSName)
 }
 
 func (this *DNSLockObject) GetSetIdentifier() string {

--- a/test/integration/entryLivecycle_test.go
+++ b/test/integration/entryLivecycle_test.go
@@ -64,7 +64,7 @@ var _ = Describe("EntryLivecycle", func() {
 
 		defer testEnv.DeleteProviderAndSecret(pr)
 
-		e, err := testEnv.CreateTXTEntry(0, domain)
+		e, err := testEnv.CreateTXTEntry(0, domain+".")
 		Ω(err).Should(BeNil())
 
 		checkProvider(pr)


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow full qualified domain names in DNSEntry `spec.DnsName`, i.e. domain names ending with a dot.

**Which issue(s) this PR fixes**:
Fixes #288

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Allow full qualified domain names in DNSEntry field `spec.DnsName`
```
