### PR TITLE
Update builder image to golang:1.20.2

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 #############      builder       #############
-FROM golang:1.20.1 AS builder
+FROM golang:1.20.2 AS builder
 
 WORKDIR /build
 COPY . .


### PR DESCRIPTION
**What this PR does / why we need it**:
Update builder image to golang:1.20.2

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
bump builder image `golang` from `1.20.1` to `1.20.2`
```
