### PR TITLE
Support for openstack loadbalancer.openstack.org/hostname annotation

### DIFF
--- a/examples/52-service-with-dns-openstack-proxy.yaml
+++ b/examples/52-service-with-dns-openstack-proxy.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    dns.gardener.cloud/dnsnames: echo.my-dns-domain.com
+    dns.gardener.cloud/ttl: "500"
+    # If you are delegating the DNS Management to Gardener, uncomment the following line (see https://gardener.cloud/documentation/guides/administer_shoots/dns_names/)
+    #dns.gardener.cloud/class: garden
+
+    # expose load balancer with own host name for supporting PROXY protocol (alternative to nip.io suffix)
+    # more details here: https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md#use-proxy-protocol-to-preserve-client-ip
+    loadbalancer.openstack.org/hostname: echo.my-dns-domain.com
+    loadbalancer.openstack.org/proxy-protocol: "true"
+
+  name: test-service
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  sessionAffinity: None
+  type: LoadBalancer


### PR DESCRIPTION
**What this PR does / why we need it**:
Support for PROXY protocol on Openstack (which needs a hostname as ingress).
If the user sets the annotation `loadbalancer.openstack.org/hostname`, the
annotation `loadbalancer.openstack.org/load-balancer-address` contains the IP address.
This address can then be used to create a DNS record for the hostname specified both
in annotation `loadbalancer.openstack.org/hostname` and `dns.gardener.cloud/dnsnames`
see [service-annotations](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md#service-annotations)
Note: `loadbalancer.openstack.org/load-balancer-address` is only available in >= v1.26.1 of the openstack-cloud-controller-manager at the moment.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Support for openstack `loadbalancer.openstack.org/hostname` annotation
```
