### PR TITLE
Adapt `NetworkPolicy`s

### DIFF
--- a/charts/external-dns-management/templates/deployment.yaml
+++ b/charts/external-dns-management/templates/deployment.yaml
@@ -32,6 +32,10 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "external-dns-management.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        networking.gardener.cloud/to-dns: allowed
+        networking.gardener.cloud/to-runtime-apiserver: allowed
+        networking.gardener.cloud/to-public-networks: allowed
+        networking.gardener.cloud/to-private-networks: allowed
     spec:
       hostIPC: false
       hostNetwork: false

--- a/charts/external-dns-management/templates/service-remoteaccess.yaml
+++ b/charts/external-dns-management/templates/service-remoteaccess.yaml
@@ -2,8 +2,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {{- if .Values.remoteaccess.service.annotations }}
   annotations:
+    networking.resources.gardener.cloud/from-world-to-ports: '[{"protocol":"TCP","port":{{ .Values.remoteaccess.port }}}]'
+  {{- if .Values.remoteaccess.service.annotations }}
     {{- toYaml .Values.remoteaccess.service.annotations | nindent 4 }}
   {{- end }}
   name: {{ include "external-dns-management.fullname" . }}-remoteaccess


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security networking
/kind enhancement

**What this PR does / why we need it**:
This PR adapts the `NetworkPolicy`s as following:

- egress traffic to DNS and to the runtime kube-apiserver is allowed
- egress traffic to public and private networks is allowed (to reach DNS provider APIs)
- ingress from world is allowed if remote access is enabled

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The Helm chart is now adapted such that it works well in garden cluster with enabled `NetworkPolicy` protection (default since `gardener/gardener@v1.71` when garden cluster is managed by `gardener-operator`).
```
