### PR TITLE
Bump golang version to 1.20.5

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 #############      builder       #############
-FROM golang:1.20.4 AS builder
+FROM golang:1.20.5 AS builder
 
 WORKDIR /build
 COPY . .


### PR DESCRIPTION
**What this PR does / why we need it**:
Update builder image to `golang:1.20.5`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Bump builder image from `golang:1.20.4` to `golang:1.20.5`
```
