### PR TITLE
Add annotation to set owner id

### DIFF
--- a/examples/50-ingress-with-dns.yaml
+++ b/examples/50-ingress-with-dns.yaml
@@ -7,6 +7,8 @@ metadata:
     #dns.gardener.cloud/class: garden
     # If you are delegating the certificate management to Gardener, uncomment the following line (see https://gardener.cloud/documentation/guides/administer_shoots/x509_certificates/)
     #cert.gardener.cloud/purpose: managed
+    #dns.gardener.cloud/ttl: "500"
+    #dns.gardener.cloud/owner-id: second
   name: test-ingress
   namespace: default
 spec:

--- a/examples/50-service-with-dns.yaml
+++ b/examples/50-service-with-dns.yaml
@@ -6,6 +6,7 @@ metadata:
     dns.gardener.cloud/ttl: "500"
     # If you are delegating the DNS Management to Gardener, uncomment the following line (see https://gardener.cloud/documentation/guides/administer_shoots/dns_names/)
     #dns.gardener.cloud/class: garden
+    #dns.gardener.cloud/owner-id: second
   name: test-service
   namespace: default
 spec:

--- a/examples/70-dnsannotation.yaml
+++ b/examples/70-dnsannotation.yaml
@@ -14,3 +14,4 @@ spec:
     dns.gardener.cloud/dnsnames: echo2.ringtest.dev.k8s.ondemand.com,echo3.ringtest.dev.k8s.ondemand.com
     # all other annotations are only effective if not set on original object
     #dns.gardener.cloud/ttl: "1000"
+    #dns.gardener.cloud/owner-id: second-owner

--- a/pkg/dns/source/controller.go
+++ b/pkg/dns/source/controller.go
@@ -44,6 +44,7 @@ const TTL_ANNOTATION = dns.ANNOTATION_GROUP + "/ttl"
 const PERIOD_ANNOTATION = dns.ANNOTATION_GROUP + "/cname-lookup-interval"
 const ROUTING_POLICY_ANNOTATION = dns.ANNOTATION_GROUP + "/routing-policy"
 const CLASS_ANNOTATION = dns.CLASS_ANNOTATION
+const OWNER_ID_ANNOTATION = dns.ANNOTATION_GROUP + "/owner-id"
 
 const OPT_CLASS = "dns-class"
 const OPT_TARGET_CLASS = "dns-target-class"

--- a/pkg/dns/source/dnsinfo.go
+++ b/pkg/dns/source/dnsinfo.go
@@ -92,6 +92,12 @@ func (this *sourceReconciler) getDNSInfo(logger logger.LogContext, obj resources
 			}
 		}
 	}
+	if info.OwnerId == nil {
+		a := annos[OWNER_ID_ANNOTATION]
+		if a != "" {
+			info.OwnerId = &a
+		}
+	}
 	if info.Interval == nil {
 		a := annos[PERIOD_ANNOTATION]
 		if a != "" {

--- a/pkg/dns/source/interface.go
+++ b/pkg/dns/source/interface.go
@@ -31,6 +31,7 @@ import (
 
 type DNSInfo struct {
 	Names         dns.DNSNameSet
+	OwnerId       *string
 	TTL           *int64
 	Interval      *int64
 	Targets       utils.StringSet

--- a/pkg/dns/source/reconciler.go
+++ b/pkg/dns/source/reconciler.go
@@ -443,6 +443,8 @@ func (this *sourceReconciler) createEntryFor(logger logger.LogContext, obj resou
 	}
 	if this.state.ownerState.ownerId != "" {
 		entry.Spec.OwnerId = &this.state.ownerState.ownerId
+	} else {
+		entry.Spec.OwnerId = info.OwnerId
 	}
 	entry.Spec.DNSName = name.DNSName
 	this.mapRef(obj, info)
@@ -525,6 +527,8 @@ func (this *sourceReconciler) updateEntryFor(logger logger.LogContext, obj resou
 		var p *string
 		if this.state.ownerState.ownerId != "" {
 			p = &this.state.ownerState.ownerId
+		} else {
+			p = info.OwnerId
 		}
 		mod.AssureStringPtrPtr(&spec.OwnerId, p)
 		mod.AssureInt64PtrPtr(&spec.TTL, info.TTL)

--- a/test/integration/testenv.go
+++ b/test/integration/testenv.go
@@ -514,11 +514,15 @@ func UnwrapOwner(obj resources.Object) *v1alpha1.DNSOwner {
 	return obj.Data().(*v1alpha1.DNSOwner)
 }
 
-func (te *TestEnv) CreateIngressWithAnnotation(name, domainName, fakeExternalIP string, ttl int, routingPolicy *string) (resources.Object, error) {
+func (te *TestEnv) CreateIngressWithAnnotation(name, domainName, fakeExternalIP string, ttl int, routingPolicy *string,
+	additionalAnnotations map[string]string) (resources.Object, error) {
 	setter := func(e *networkingv1.Ingress) {
 		e.Annotations = map[string]string{dnssource.DNS_ANNOTATION: "*", dnssource.TTL_ANNOTATION: fmt.Sprintf("%d", ttl)}
 		if routingPolicy != nil {
 			e.Annotations[dnssource.ROUTING_POLICY_ANNOTATION] = *routingPolicy
+		}
+		for k, v := range additionalAnnotations {
+			e.Annotations[k] = v
 		}
 		e.Spec.Rules = []networkingv1.IngressRule{
 			{


### PR DESCRIPTION
**What this PR does / why we need it**:
Add annotation `dns.gardener.cloud/owner-id` to set owner id for source `Service` and `Ingress` objects.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add annotation `dns.gardener.cloud/owner-id` to set owner id
```
