### PR TITLE
Replace pod on replacing CA cert for remoteaccess

### DIFF
--- a/charts/external-dns-management/templates/deployment.yaml
+++ b/charts/external-dns-management/templates/deployment.yaml
@@ -24,6 +24,9 @@ spec:
         {{- if semverCompare "<1.24-0" .Capabilities.KubeVersion.GitVersion }}
         checksum/psp: {{ include (print $.Template.BasePath "/psp.yaml") . | sha256sum }}
         {{- end }}
+        {{- if (and .Values.remoteaccess.enabled) }}
+        checksum/remote-access-cacert: {{ include (print $.Template.BasePath "/secret-remoteaccess.yaml") . | sha256sum }}
+        {{- end }}
 {{- if .Values.configuration.serverPortHttp }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{- .Values.configuration.serverPortHttp }}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Replace pod on replacing CA cert for remote access

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
