### PR TITLE
add imagePullSecrets option to deployment

### DIFF
--- a/charts/external-dns-management/templates/deployment.yaml
+++ b/charts/external-dns-management/templates/deployment.yaml
@@ -932,6 +932,10 @@ spec:
         {{- end }}
       {{- end }}
       serviceAccountName: {{ include "external-dns-management.fullname" . }}
+      imagePullSecrets:
+      {{- with .Values.imagePullSecrets }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.gardener.seed.name }}
       priorityClassName: gardener-system-900
       {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
to pull image from private artifactory

**Which issue(s) this PR fixes**:
Fixes # getting error ImagePullBackOff  in dns-manager pod due to status: 401 Unauthorized when pulling image from private artifactory 

**Special notes for your reviewer**:

**Release note**:
NONE
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
