### PR TITLE
Allow to create DNSEntries for hosted zone base domain

### DIFF
--- a/pkg/dns/mapping.go
+++ b/pkg/dns/mapping.go
@@ -62,7 +62,9 @@ func MapToProvider(rtype string, dnsset *DNSSet, base string) (DNSSetName, *Reco
 
 func calcMetaRecordDomainName(name, prefix, base string) string {
 	add := ""
-	if strings.HasPrefix(name, "*.") {
+	if name == base {
+		prefix += "-base."
+	} else if strings.HasPrefix(name, "*.") {
 		add = "*."
 		name = name[2:]
 		if name == base {

--- a/pkg/dns/mapping_test.go
+++ b/pkg/dns/mapping_test.go
@@ -62,6 +62,7 @@ func TestMapToFromProvider(t *testing.T) {
 		{"*.a.myzone.de", false, "*.comment-a.myzone.de"},
 		{"*.myzone.de", false, "*.comment--base.myzone.de"},
 		{"@.myzone.de", false, "comment----at.myzone.de"},
+		{"myzone.de", false, "comment--base.myzone.de"},
 	}
 
 	rtype := RS_META

--- a/pkg/dns/provider/entry.go
+++ b/pkg/dns/provider/entry.go
@@ -381,9 +381,13 @@ func validate(logger logger.LogContext, state *state, entry *EntryVersion, p *En
 	}
 
 	if p.zonedomain == entry.dnsSetName.DNSName {
-		err = fmt.Errorf("usage of dns name (%s) identical to domain of hosted zone (%s) is not supported",
-			p.zonedomain, p.zoneid)
-		return
+		for _, t := range []string{"azure-dns", "azure-private-dns"} {
+			if p.provider.TypeCode() == t {
+				err = fmt.Errorf("usage of dns name (%s) identical to domain of hosted zone (%s) is not supported. Please use apex prefix '@.'",
+					p.zonedomain, p.zoneid)
+				return
+			}
+		}
 	}
 	if len(effspec.GetTargets()) > 0 && len(effspec.GetText()) > 0 {
 		err = fmt.Errorf("only Text or Targets possible")


### PR DESCRIPTION
**What this PR does / why we need it**:
Creating a `DNSEntry` for the base domain of a hosted zone is now allowed for all providers but `azure-dns` and `azure-private-dns`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Creating a `DNSEntry` for the base domain of a hosted zone is now allowed for all providers but `azure-dns` and `azure-private-dns`.
```
