### PR TITLE
Increase rsa key size to 3072 bits

### DIFF
--- a/pkg/controller/remoteaccesscertificates/certificate.go
+++ b/pkg/controller/remoteaccesscertificates/certificate.go
@@ -50,7 +50,10 @@ func CreateSubject(commonName string) pkix.Name {
 // CreateCertificate creates a client or server TLS certificate.
 func CreateCertificate(caCert *x509.Certificate, caPrivateKey *rsa.PrivateKey, subject pkix.Name, dnsName string,
 	days int, serialNumber int64, isServer bool) (*CertData, error) {
-	key, _ := rsa.GenerateKey(rand.Reader, 1024)
+	key, err := rsa.GenerateKey(rand.Reader, 3072)
+	if err != nil {
+		return nil, err
+	}
 
 	csrTemplate := x509.CertificateRequest{
 		Subject:            subject,

--- a/pkg/controller/remoteaccesscertificates/controller.go
+++ b/pkg/controller/remoteaccesscertificates/controller.go
@@ -21,7 +21,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/gardener/controller-manager-library/pkg/config"
@@ -124,7 +124,7 @@ func loadClientCA(config *Config) (*x509.Certificate, *rsa.PrivateKey, error) {
 	if config.caCertFile == "" {
 		return nil, nil, fmt.Errorf("missing option %s with CA for client certificates", provider.OPT_REMOTE_ACCESS_CACERT)
 	}
-	pemClientCA, err := ioutil.ReadFile(config.caCertFile)
+	pemClientCA, err := os.ReadFile(config.caCertFile)
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot read client CA: %w", err)
 	}
@@ -136,7 +136,7 @@ func loadClientCA(config *Config) (*x509.Certificate, *rsa.PrivateKey, error) {
 	if config.caKeyFile == "" {
 		return nil, nil, fmt.Errorf("missing option %s with CA key for client certificates", OPT_REMOTE_ACCESS_CAKEY)
 	}
-	keyPem, err := ioutil.ReadFile(config.caKeyFile)
+	keyPem, err := os.ReadFile(config.caKeyFile)
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot read client CA key: %w", err)
 	}

--- a/pkg/server/remote/embed/remoteserver.go
+++ b/pkg/server/remote/embed/remoteserver.go
@@ -19,9 +19,9 @@ package embed
 import (
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
+	"os"
 
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
@@ -57,7 +57,7 @@ func RegisterCreateServerFunc(f CreateServerFunc) {
 
 func loadTLSCredentials(logctx logger.LogContext, cfg *RemoteAccessServerConfig) (credentials.TransportCredentials, error) {
 	// Load certificate of the CA who signed client's certificate
-	pemClientCA, err := ioutil.ReadFile(cfg.CACertFilename)
+	pemClientCA, err := os.ReadFile(cfg.CACertFilename)
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -19,7 +19,6 @@ package integration
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -124,7 +123,7 @@ users:
       client-certificate-data: %s
       client-key-data: %s`
 
-	tmpfile, err := ioutil.TempFile("", "kubeconfig-integration-suite-test")
+	tmpfile, err := os.CreateTemp("", "kubeconfig-integration-suite-test")
 	Expect(err).NotTo(HaveOccurred())
 	_, err = fmt.Fprintf(tmpfile, template, cfg.Host, base64.StdEncoding.EncodeToString(cfg.CAData),
 		base64.StdEncoding.EncodeToString(cfg.CertData), base64.StdEncoding.EncodeToString(cfg.KeyData))


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
3072 bit RSA keys are now used in order to generate TLS certificates.
```
