### PR TITLE
Add rfc2136 provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It contains provisioning controllers for creating DNS records in one of the DNS 
   - [_Infoblox_](/docs/infoblox/README.md),
   - [_Netlify DNS_](docs/netlify/README.md),
   - [_remote_](docs/remote/README.md),
+  - [_DNS servers supporting RFC 2136 (DNS Update)_](docs/rfc2136/README.md) *(alpha - not recommended for productive usage)*,
 
 and source controllers for services and ingresses to create DNS entries by annotations.
 

--- a/cmd/compound/main.go
+++ b/cmd/compound/main.go
@@ -41,6 +41,7 @@ import (
 	_ "github.com/gardener/external-dns-management/pkg/controller/provider/netlify"
 	_ "github.com/gardener/external-dns-management/pkg/controller/provider/openstack"
 	_ "github.com/gardener/external-dns-management/pkg/controller/provider/remote"
+	_ "github.com/gardener/external-dns-management/pkg/controller/provider/rfc2136"
 	_ "github.com/gardener/external-dns-management/pkg/controller/remoteaccesscertificates"
 	_ "github.com/gardener/external-dns-management/pkg/controller/replication/dnsprovider"
 	_ "github.com/gardener/external-dns-management/pkg/controller/source/dnsentry"

--- a/cmd/dedicated/main.go
+++ b/cmd/dedicated/main.go
@@ -37,6 +37,7 @@ import (
 	_ "github.com/gardener/external-dns-management/pkg/controller/provider/netlify/controller"
 	_ "github.com/gardener/external-dns-management/pkg/controller/provider/openstack/controller"
 	_ "github.com/gardener/external-dns-management/pkg/controller/provider/remote/controller"
+	_ "github.com/gardener/external-dns-management/pkg/controller/provider/rfc2136/controller"
 	_ "github.com/gardener/external-dns-management/pkg/controller/remoteaccesscertificates"
 	_ "github.com/gardener/external-dns-management/pkg/controller/replication/dnsprovider"
 	_ "github.com/gardener/external-dns-management/pkg/controller/source/dnsentry"

--- a/docs/rfc2136/README.md
+++ b/docs/rfc2136/README.md
@@ -1,0 +1,73 @@
+# RFC2136 DNS Provider (alpha)
+
+This DNS provider allows you to create and manage DNS entries for authoritive DNS server supporting
+dynamic updates with DNS messages following [RFC2136](https://datatracker.ietf.org/doc/html/rfc2136) (DNS Update)
+like [knot-dns](https://www.knot-dns.cz/) or others.
+
+*Note: RFC2136 has no support for hosted zone management, only one single zone can be specified per `DNSProvider`.*
+
+*Note: This provider is in alpha state and it is not recommended to be used in production.*
+
+## DNS Server configuration
+
+The configuration is depending on the DNS server product.
+You need permissions for `update` and `transfer` (AXFR) actions on your zones and a TSIG secret.
+
+Here it is described for the "Knot DNS Server" only.
+
+### Configuration of Knot DNS Server
+
+The `knot.conf` must contain a key which has ACLs for `update` and `transfer` actions.
+
+
+```yaml
+# knot.conf sample configuration excerpt
+
+key:
+  - id: "my-key."
+    algorithm: hmac-sha256
+    secret: ...
+
+acl:
+  - id: "update-acl"
+    address: [ "192.168.0.0/16" ] # replace with your address filter
+    action: update
+    key: "my-key."
+  - id: "transfer-acl"
+    address: [ "192.168.0.0/16" ] # replace with your address filter
+    action: transfer
+    key: "my-key."
+
+zone:
+  - domain: example.com
+    acl: [ "update-acl", "transfer-acl" ]
+```
+
+see also [KNOT DNS Configuration](https://www.knot-dns.cz/docs/3.3/html/configuration.html)
+
+## Required permissions
+
+There are no special permissions for the access tokens.
+
+## Using the TSIG secret and server settings 
+
+Create a `Secret` resource with the following data fields.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rfc2136-credentials
+  namespace: default
+type: Opaque
+data:
+  # replace '...' with values encoded as base64
+  Server: ... # "<host>:<port>" of the authorive DNS server
+  TSIGKeyName: ... # key name of the TSIG secret (must end with a dot)
+  TSIGSecret: ... # TSIG secret
+  Zone: ... # zone (must be fully qualified)
+  # the algorithm is optional. By default 'hmac-sha256' is assumed.
+  #TSIGSecretAlgorithm: ... # TSIG Algorithm Name for Hash-based Message Authentication (HMAC)
+``` 
+
+The field `TSIGSecretAlgorithm` is optional and specifies the TSIG Algorithm Name for Hash-based Message Authentication (HMAC).

--- a/examples/20-secret-rfc2136-credentials.yaml
+++ b/examples/20-secret-rfc2136-credentials.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rfc2136-credentials
+  namespace: default
+type: Opaque
+data:
+  # Replace '...' with values encoded as base64.
+  Server: ... # "<host>:<port>" of the authorive DNS server
+  TSIGKeyName: ... # key name of the TSIG secret (must end with a dot)
+  TSIGSecret: ... # TSIG secret
+  Zone: ... # zone (must be fully qualified)
+  # the algorithm is optional. By default 'hmac-sha256' is assumed.
+  #TSIGSecretAlgorithm: ... # TSIG Algorithm Name for Hash-based Message Authentication (HMAC).

--- a/examples/30-provider-rfc2136.yaml
+++ b/examples/30-provider-rfc2136.yaml
@@ -1,0 +1,12 @@
+apiVersion: dns.gardener.cloud/v1alpha1
+kind: DNSProvider
+metadata:
+  name: rfc2136
+  namespace: default
+spec:
+  type: rfc2136
+  secretRef:
+    name: rfc2136-credentials
+  domains:
+    include:
+    - my.own.domain.com

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.10
 	github.com/prometheus/client_golang v1.16.0
+	github.com/spf13/pflag v1.0.5
 	go.uber.org/atomic v1.10.0
 	go.uber.org/automaxprocs v1.4.0
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
@@ -111,7 +112,6 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spf13/cobra v1.7.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	go.mongodb.org/mongo-driver v1.8.3 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.14.0 // indirect

--- a/pkg/controller/provider/rfc2136/controller/controller.go
+++ b/pkg/controller/provider/rfc2136/controller/controller.go
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *
+ */
+
+package controller
+
+import (
+	"github.com/gardener/external-dns-management/pkg/controller/provider/rfc2136"
+	"github.com/gardener/external-dns-management/pkg/dns/provider"
+)
+
+func init() {
+	provider.DNSController("", rfc2136.Factory).
+		FinalizerDomain("dns.gardener.cloud").
+		MustRegister(provider.CONTROLLER_GROUP_DNS_CONTROLLERS)
+}

--- a/pkg/controller/provider/rfc2136/execution.go
+++ b/pkg/controller/provider/rfc2136/execution.go
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2019 SAP SE or an SAP affiliate company. All rights reserved. exec file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use exec file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *
+ */
+
+package rfc2136
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"time"
+
+	azure "github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2018-05-01/dns"
+	"github.com/gardener/controller-manager-library/pkg/logger"
+	miekgdns "github.com/miekg/dns"
+
+	"github.com/gardener/external-dns-management/pkg/dns"
+	"github.com/gardener/external-dns-management/pkg/dns/provider"
+)
+
+type Change struct {
+	rs   *azure.RecordSet
+	Done provider.DoneHandler
+}
+
+type Execution struct {
+	logger.LogContext
+	handler *Handler
+
+	changes map[string][]*Change
+}
+
+func NewExecution(logger logger.LogContext, h *Handler) *Execution {
+	return &Execution{LogContext: logger, handler: h, changes: map[string][]*Change{}}
+}
+
+func (exec *Execution) buildRecordSet(req *provider.ChangeRequest) ([]miekgdns.RR, []miekgdns.RR, error) {
+	var setName dns.DNSSetName
+	var addset, delset *dns.RecordSet
+
+	domain := dns.NormalizeHostname(exec.handler.zone)
+	if req.Addition != nil {
+		setName, addset = dns.MapToProvider(req.Type, req.Addition, domain)
+	}
+	if req.Deletion != nil {
+		setName, delset = dns.MapToProvider(req.Type, req.Deletion, domain)
+	}
+	if setName.DNSName == "" || (addset.Length() == 0 && delset.Length() == 0) {
+		return nil, nil, nil
+	}
+
+	if setName.SetIdentifier != "" || req.Addition != nil && req.Addition.RoutingPolicy != nil || req.Deletion != nil && req.Deletion.RoutingPolicy != nil {
+		return nil, nil, fmt.Errorf("routing policies not supported for " + TYPE_CODE)
+	}
+
+	var err error
+	var addRRSet, delRRSet []miekgdns.RR
+	if req.Addition != nil {
+		exec.Infof("Desired %s: %s record set %s[%s] with TTL %d: %s", req.Action, addset.Type, setName.DNSName, domain, addset.TTL, addset.RecordString())
+		addRRSet, err = exec.buildMappedRecordSet(setName.DNSName, addset)
+		if err != nil {
+			return nil, nil, err
+		}
+		if req.Deletion != nil {
+			newRecords, updRecords, delRecords := addset.DiffTo(delset)
+			addRecords := append(newRecords, updRecords...)
+			if recreateOnTTLChange {
+				// experience with know-dns: update of TTL needs deletion and insert
+				delRecords = append(delRecords, updRecords...)
+			}
+			addRRSet, err = exec.buildMappedRecordSet(setName.DNSName, &dns.RecordSet{Type: addset.Type, TTL: addset.TTL, Records: addRecords})
+			if err != nil {
+				return nil, nil, err
+			}
+			if len(delRecords) > 0 {
+				delRRSet, err = exec.buildMappedRecordSet(setName.DNSName, &dns.RecordSet{Type: delset.Type, TTL: delset.TTL, Records: delRecords})
+				if err != nil {
+					return nil, nil, err
+				}
+			}
+		}
+	} else {
+		exec.Infof("Desired %s: %s record set %s[%s] with TTL %d: %s", req.Action, delset.Type, setName.DNSName, domain, delset.TTL, delset.RecordString())
+		delRRSet, err = exec.buildMappedRecordSet(setName.DNSName, delset)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return addRRSet, delRRSet, nil
+}
+
+func (exec *Execution) buildMappedRecordSet(name string, rset *dns.RecordSet) ([]miekgdns.RR, error) {
+	var records []miekgdns.RR
+
+	hdr := miekgdns.RR_Header{
+		Name: miekgdns.Fqdn(name),
+		Ttl:  uint32(rset.TTL),
+	}
+	switch rset.Type {
+	case dns.RS_A:
+		hdr.Rrtype = miekgdns.TypeA
+		for _, r := range rset.Records {
+			ip := net.ParseIP(r.Value)
+			if ip == nil {
+				return nil, fmt.Errorf("invalid IP address: %s", r.Value)
+			}
+			if ip.To4() == nil {
+				return nil, fmt.Errorf("not an IPv4 address: %s", r.Value)
+			}
+			records = append(records, &miekgdns.A{Hdr: hdr, A: ip.To4()})
+		}
+		return records, nil
+	case dns.RS_AAAA:
+		hdr.Rrtype = miekgdns.TypeAAAA
+		for _, r := range rset.Records {
+			ip := net.ParseIP(r.Value)
+			if ip == nil {
+				return nil, fmt.Errorf("invalid IP address: %s", r.Value)
+			}
+			if ip.To16() == nil {
+				return nil, fmt.Errorf("not an IPv6 address: %s", r.Value)
+			}
+			records = append(records, &miekgdns.AAAA{Hdr: hdr, AAAA: ip.To16()})
+		}
+		return records, nil
+	case dns.RS_CNAME:
+		hdr.Rrtype = miekgdns.TypeCNAME
+		for _, r := range rset.Records {
+			records = append(records, &miekgdns.CNAME{Hdr: hdr, Target: miekgdns.Fqdn(r.Value)})
+		}
+		return records, nil
+	case dns.RS_TXT:
+		hdr.Rrtype = miekgdns.TypeTXT
+		txtRecord := &miekgdns.TXT{Hdr: hdr}
+		for _, r := range rset.Records {
+			unquoted, err := strconv.Unquote(r.Value)
+			if err != nil {
+				unquoted = r.Value
+			}
+			txtRecord.Txt = append(txtRecord.Txt, unquoted)
+		}
+		records = append(records, txtRecord)
+		return records, nil
+	default:
+		return nil, fmt.Errorf("unexpected record type: %s", rset.Type)
+	}
+}
+
+func (exec *Execution) apply(inserts, deletes []miekgdns.RR, metrics provider.Metrics) error {
+	if len(deletes) != 0 {
+		if err := exec.delete(deletes, metrics); err != nil {
+			return err
+		}
+	}
+	if len(inserts) != 0 {
+		if err := exec.insert(inserts, metrics); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (exec *Execution) insert(records []miekgdns.RR, metrics provider.Metrics) error {
+	return exec.exchange(records, func(msg *miekgdns.Msg, rrs []miekgdns.RR) { msg.Insert(rrs) }, provider.M_UPDATERECORDS, metrics)
+}
+
+func (exec *Execution) delete(records []miekgdns.RR, metrics provider.Metrics) error {
+	return exec.exchange(records, func(msg *miekgdns.Msg, rrs []miekgdns.RR) { msg.Remove(rrs) }, provider.M_DELETERECORDS, metrics)
+}
+
+func (exec *Execution) exchange(records []miekgdns.RR, apply func(*miekgdns.Msg, []miekgdns.RR), requestType string, metrics provider.Metrics) error {
+	exec.handler.config.RateLimiter.Accept()
+
+	c := &miekgdns.Client{
+		Net:        tcp,
+		TsigSecret: map[string]string{exec.handler.tsigKeyname: exec.handler.tsigSecretBase64},
+	}
+
+	msg := &miekgdns.Msg{}
+	msg.SetUpdate(exec.handler.zone)
+	msg.SetTsig(exec.handler.tsigKeyname, exec.handler.tsigAlgorithm, clockSkew, time.Now().Unix())
+
+	apply(msg, records)
+
+	retMsg, _, err := c.Exchange(msg, exec.handler.nameserver) // your DNS server
+	metrics.AddZoneRequests(exec.handler.zone, requestType, 1)
+	if err != nil {
+		return err
+	}
+
+	if retMsg.Rcode != miekgdns.RcodeSuccess {
+		return fmt.Errorf("DNS server returned error code on %s: %d", requestType, retMsg.Rcode)
+	}
+	return nil
+}

--- a/pkg/controller/provider/rfc2136/factory.go
+++ b/pkg/controller/provider/rfc2136/factory.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *
+ */
+
+package rfc2136
+
+import (
+	"github.com/gardener/external-dns-management/pkg/controller/provider/compound"
+	"github.com/gardener/external-dns-management/pkg/dns/provider"
+)
+
+const TYPE_CODE = "rfc2136"
+
+var rateLimiterDefaults = provider.RateLimiterOptions{
+	Enabled: true,
+	QPS:     50,
+	Burst:   10,
+}
+
+var Factory = provider.NewDNSHandlerFactory(TYPE_CODE, NewHandler).
+	SetGenericFactoryOptionDefaults(provider.GenericFactoryOptionDefaults.SetRateLimiterOptions(rateLimiterDefaults))
+
+func init() {
+	compound.MustRegister(Factory)
+}

--- a/pkg/controller/provider/rfc2136/handler.go
+++ b/pkg/controller/provider/rfc2136/handler.go
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2019 SAP SE or an SAP affiliate company. All rights reserved. h file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *
+ */
+
+package rfc2136
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gardener/controller-manager-library/pkg/logger"
+	"github.com/gardener/external-dns-management/pkg/dns"
+	"github.com/gardener/external-dns-management/pkg/dns/provider"
+	"github.com/gardener/external-dns-management/pkg/dns/provider/raw"
+	miekgdns "github.com/miekg/dns"
+)
+
+const (
+	// maximum time DNS client can be off from server for an update to succeed
+	clockSkew = 300
+	tcp       = "tcp"
+	// recreateOnTTLChange specifies if changing TTL of a recordset needs deletion and insert of recordset
+	recreateOnTTLChange = true
+)
+
+type Handler struct {
+	provider.DefaultDNSHandler
+	config provider.DNSHandlerConfig
+	cache  provider.ZoneCache
+	ctx    context.Context
+
+	nameserver       string
+	zone             string
+	tsigKeyname      string
+	tsigSecretBase64 string
+	tsigAlgorithm    string
+}
+
+var _ provider.DNSHandler = &Handler{}
+
+// tsigAlgs are the supported TSIG algorithms
+var tsigAlgs = []string{miekgdns.HmacSHA1, miekgdns.HmacSHA224, miekgdns.HmacSHA256, miekgdns.HmacSHA384, miekgdns.HmacSHA512}
+
+func NewHandler(c *provider.DNSHandlerConfig) (provider.DNSHandler, error) {
+	h := &Handler{
+		DefaultDNSHandler: provider.NewDefaultDNSHandler(TYPE_CODE),
+		config:            *c,
+	}
+
+	h.ctx = c.Context
+
+	server, err := c.GetRequiredProperty("Server")
+	if err != nil {
+		return nil, err
+	}
+	if !strings.Contains(server, ":") {
+		server += ":53"
+	}
+	h.nameserver = server
+
+	zone, err := c.GetRequiredProperty("Zone")
+	if err != nil {
+		return nil, err
+	}
+	if zone != miekgdns.CanonicalName(zone) {
+		return nil, fmt.Errorf("zone must be given in canonical form: '%s' instead of '%s'", miekgdns.CanonicalName(zone), h.zone)
+	}
+	h.zone = zone
+
+	keyname, err := c.GetRequiredProperty("TSIGKeyName")
+	if err != nil {
+		return nil, err
+	}
+	if keyname != miekgdns.Fqdn(keyname) {
+		return nil, fmt.Errorf("TSIGKeyName must end with '.'")
+	}
+	h.tsigKeyname = miekgdns.Fqdn(keyname)
+
+	secret, err := c.GetRequiredProperty("TSIGSecret")
+	if err != nil {
+		return nil, err
+	}
+	h.tsigSecretBase64 = base64.StdEncoding.EncodeToString([]byte(secret))
+
+	h.tsigAlgorithm, err = findTsigAlgorithm(c.GetProperty("TSIGSecretAlgorithm"))
+
+	h.cache, err = c.ZoneCacheFactory.CreateZoneCache(provider.CacheZoneState, c.Metrics, h.getZones, h.getZoneState)
+	if err != nil {
+		return nil, err
+	}
+
+	return h, nil
+}
+
+func (h *Handler) Release() {
+	h.cache.Release()
+}
+
+func (h *Handler) GetZones() (provider.DNSHostedZones, error) {
+	return h.cache.GetZones()
+}
+
+func (h *Handler) getZones(cache provider.ZoneCache) (provider.DNSHostedZones, error) {
+	domainName := dns.NormalizeHostname(h.zone)
+	h.config.Metrics.AddGenericRequests(provider.M_LISTZONES, 1)
+	return provider.DNSHostedZones{
+		provider.NewDNSHostedZone(TYPE_CODE, h.zone, domainName, h.zone, nil, false),
+	}, nil
+}
+
+func (h *Handler) GetZoneState(zone provider.DNSHostedZone) (provider.DNSZoneState, error) {
+	return h.cache.GetZoneState(zone)
+}
+
+func (h *Handler) getZoneState(zone provider.DNSHostedZone, cache provider.ZoneCache) (provider.DNSZoneState, error) {
+	dnssets := dns.DNSSets{}
+
+	if zone.Id().ID != h.zone {
+		return nil, fmt.Errorf("Handler supports only zone %s", h.zone)
+	}
+
+	msg := &miekgdns.Msg{}
+	msg.SetAxfr(h.zone)
+	msg.SetTsig(h.tsigKeyname, h.tsigAlgorithm, clockSkew, time.Now().Unix())
+
+	h.config.RateLimiter.Accept()
+	t := &miekgdns.Transfer{
+		TsigSecret: map[string]string{h.tsigKeyname: h.tsigSecretBase64},
+	}
+	env, err := t.In(msg, h.nameserver)
+	if err != nil {
+		return nil, fmt.Errorf("axfr request failed: %w", err)
+	}
+
+	for e := range env {
+		h.config.Metrics.AddZoneRequests(zone.Id().ID, provider.M_LISTRECORDS, 1)
+		if e.Error != nil {
+			if e.Error == miekgdns.ErrSoa {
+				return nil, fmt.Errorf("AXFR error: unexpected response received from the server")
+			} else {
+				return nil, fmt.Errorf("AXFR error: %v", e.Error)
+			}
+		}
+
+		var (
+			lastRS   *dns.RecordSet
+			lastName string
+			lastType uint16
+		)
+		for _, rr := range e.RR {
+			fullName := dns.NormalizeHostname(rr.Header().Name)
+			if lastRS != nil && (fullName != lastName || lastType != rr.Header().Rrtype) {
+				dnssets.AddRecordSetFromProvider(lastName, lastRS)
+				lastRS = nil
+			}
+			var (
+				currentRType  string
+				currentRecord *dns.Record
+			)
+			switch rr.Header().Rrtype {
+			case miekgdns.TypeA:
+				currentRType = dns.RS_A
+				currentRecord = &dns.Record{Value: rr.(*miekgdns.A).A.String()}
+			case miekgdns.TypeAAAA:
+				currentRType = dns.RS_AAAA
+				currentRecord = &dns.Record{Value: rr.(*miekgdns.AAAA).AAAA.String()}
+			case miekgdns.TypeCNAME:
+				currentRType = dns.RS_CNAME
+				currentRecord = &dns.Record{Value: rr.(*miekgdns.CNAME).Target}
+			case miekgdns.TypeTXT:
+				txt := rr.(*miekgdns.TXT).Txt
+				records := make([]*dns.Record, len(txt))
+				for i, t := range txt {
+					records[i] = &dns.Record{Value: raw.EnsureQuotedText(t)}
+				}
+				dnssets.AddRecordSetFromProvider(fullName, dns.NewRecordSet(dns.RS_TXT, int64(rr.Header().Ttl), records))
+			default:
+			}
+			lastName = fullName
+			lastType = rr.Header().Rrtype
+			if currentRecord != nil {
+				if lastRS != nil {
+					lastRS.Records = append(lastRS.Records, currentRecord)
+				} else {
+					lastRS = dns.NewRecordSet(currentRType, int64(rr.Header().Ttl), []*dns.Record{currentRecord})
+				}
+			}
+		}
+		if lastRS != nil {
+			dnssets.AddRecordSetFromProvider(lastName, lastRS)
+		}
+	}
+
+	return provider.NewDNSZoneState(dnssets), nil
+}
+
+func (h *Handler) ReportZoneStateConflict(zone provider.DNSHostedZone, err error) bool {
+	return h.cache.ReportZoneStateConflict(zone, err)
+}
+
+func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
+	err := h.executeRequests(logger, zone, state, reqs)
+	h.cache.ApplyRequests(logger, err, zone, reqs)
+	return err
+}
+
+func (h *Handler) executeRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
+	exec := NewExecution(logger, h)
+
+	var succeeded, failed int
+	for _, r := range reqs {
+		inserts, deletes, err := exec.buildRecordSet(r)
+		if err != nil {
+			if r.Done != nil {
+				r.Done.SetInvalid(err)
+			}
+			continue
+		}
+
+		err = exec.apply(inserts, deletes, h.config.Metrics)
+		if err != nil {
+			failed++
+			logger.Infof("Apply failed with %s", err.Error())
+			if r.Done != nil {
+				r.Done.Failed(err)
+			}
+		} else {
+			succeeded++
+			if r.Done != nil {
+				r.Done.Succeeded()
+			}
+		}
+	}
+
+	if succeeded > 0 {
+		logger.Infof("Succeeded updates for records in zone %s: %d", zone.Id(), succeeded)
+	}
+	if failed > 0 {
+		logger.Infof("Failed updates for records in zone %s: %d", zone.Id(), failed)
+		return fmt.Errorf("%d changes failed", failed)
+	}
+
+	return nil
+}
+
+func findTsigAlgorithm(alg string) (string, error) {
+	if alg == "" {
+		return miekgdns.HmacSHA256, nil
+	}
+
+	fqdnAlg := miekgdns.Fqdn(alg)
+	for _, a := range tsigAlgs {
+		if fqdnAlg == a {
+			return fqdnAlg, nil
+		}
+	}
+	return "", fmt.Errorf("invalid TSIG secret algorithm: %s (supported: %s)", alg, strings.ReplaceAll(strings.Join(tsigAlgs, ","), ".", ""))
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
A provider for authorive DNS servers supporting DNS Update [RFC2136](https://datatracker.ietf.org/doc/html/rfc2136) has been added.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The `rfc2136` provider for authorive DNS servers supporting DNS Update [RFC2136](https://datatracker.ietf.org/doc/html/rfc2136) has been added.
```
