### PR TITLE
Validate provider domain includes and excludes for wildcards

### DIFF
--- a/pkg/dns/provider/selection/selection.go
+++ b/pkg/dns/provider/selection/selection.go
@@ -68,6 +68,15 @@ func CalcZoneAndDomainSelection(spec v1alpha1.DNSProviderSpec, allzones []LightD
 		DomainSel:     NewSubSelection(),
 	}
 
+	if err := validateDomains(this.SpecDomainSel.Include, "domains include"); err != nil {
+		this.Error = err.Error()
+		return this
+	}
+	if err := validateDomains(this.SpecDomainSel.Exclude, "domains exclude"); err != nil {
+		this.Error = err.Error()
+		return this
+	}
+
 	var zones []LightDNSHostedZone
 	for _, z := range allzones {
 		if z.Id().ProviderType == spec.Type {
@@ -181,6 +190,15 @@ outer:
 	}
 
 	return this
+}
+
+func validateDomains(domains utils.StringSet, name string) error {
+	for domain := range domains {
+		if strings.HasPrefix(domain, "*.") {
+			return fmt.Errorf("wildcards are not allowed in %s '%s' (hint: remove the wildcard)", name, domain)
+		}
+	}
+	return nil
 }
 
 func PrepareSelection(sel *v1alpha1.DNSSelection) SubSelection {

--- a/pkg/dns/provider/selection/selection_test.go
+++ b/pkg/dns/provider/selection/selection_test.go
@@ -133,6 +133,48 @@ var _ = Describe("Selection", func() {
 		}))
 	})
 
+	It("validates domain includes", func() {
+		spec := v1alpha1.DNSProviderSpec{
+			Type: "test",
+			Domains: &v1alpha1.DNSSelection{
+				Include: []string{"*.a.b"},
+				Exclude: []string{"sub.a.b"},
+			},
+		}
+		result := CalcZoneAndDomainSelection(spec, allzones)
+		Expect(result).To(Equal(SelectionResult{
+			SpecZoneSel: NewSubSelection(),
+			SpecDomainSel: SubSelection{
+				Include: utils.NewStringSet("*.a.b"),
+				Exclude: utils.NewStringSet("sub.a.b"),
+			},
+			ZoneSel:   NewSubSelection(),
+			DomainSel: NewSubSelection(),
+			Error:     "wildcards are not allowed in domains include '*.a.b' (hint: remove the wildcard)",
+		}))
+	})
+
+	It("validates domain excludes", func() {
+		spec := v1alpha1.DNSProviderSpec{
+			Type: "test",
+			Domains: &v1alpha1.DNSSelection{
+				Include: []string{"a.b"},
+				Exclude: []string{"*.sub.a.b"},
+			},
+		}
+		result := CalcZoneAndDomainSelection(spec, allzones)
+		Expect(result).To(Equal(SelectionResult{
+			SpecZoneSel: NewSubSelection(),
+			SpecDomainSel: SubSelection{
+				Include: utils.NewStringSet("a.b"),
+				Exclude: utils.NewStringSet("*.sub.a.b"),
+			},
+			ZoneSel:   NewSubSelection(),
+			DomainSel: NewSubSelection(),
+			Error:     "wildcards are not allowed in domains exclude '*.sub.a.b' (hint: remove the wildcard)",
+		}))
+	})
+
 	It("handles zones exclusion", func() {
 		spec := v1alpha1.DNSProviderSpec{
 			Type: "test",


### PR DESCRIPTION
**What this PR does / why we need it**:
The `DNSProvider` specifies included and excluded domain with the `spec.domains.include` and `spec.domains.exclude` fields.
It is expected, that these are the plain domain names and subsume any subdomains implicitly.
Sometimes users try to define a domain using wildcards, e.g. `*.example.com` instead of `example.com`, which is accepted, but does not work.
With this PR, the include and exclude domains are validated for such forbidden wildcard domains and report a user friendly error.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Validate provider domain includes and excludes for forbidden wildcard domains.
```
