### PR TITLE
Drop retrieval of forwarded domains to avoid synching unused hosted zones

### DIFF
--- a/pkg/controller/provider/azure-private/handler.go
+++ b/pkg/controller/provider/azure-private/handler.go
@@ -118,7 +118,7 @@ func (h *Handler) getZones(_ provider.ZoneCache) (provider.DNSHostedZones, error
 
 		if zoneID != "" {
 			// ResourceGroup needed for requests to Azure. Remember by adding to Id. Split by calling splitZoneid().
-			hostedZone := provider.NewDNSHostedZone(h.ProviderType(), zoneID, dns.NormalizeHostname(*item.Name), "", []string{}, true)
+			hostedZone := provider.NewDNSHostedZone(h.ProviderType(), zoneID, dns.NormalizeHostname(*item.Name), "", true)
 
 			zones = append(zones, hostedZone)
 		}

--- a/pkg/controller/provider/cloudflare/handler.go
+++ b/pkg/controller/provider/cloudflare/handler.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/gardener/controller-manager-library/pkg/logger"
-	"github.com/gardener/external-dns-management/pkg/dns"
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 	"github.com/gardener/external-dns-management/pkg/dns/provider/raw"
 )
@@ -97,26 +96,7 @@ func (h *Handler) getZones(cache provider.ZoneCache) (provider.DNSHostedZones, e
 	zones := provider.DNSHostedZones{}
 
 	for _, z := range rawZones {
-		forwarded := []string{}
-		f := func(r cloudflare.DNSRecord) (bool, error) {
-			if r.Type == dns.RS_NS {
-				name := r.Name
-				if name != z.Name {
-					forwarded = append(forwarded, name)
-				}
-			}
-			return true, nil
-		}
-		err := h.access.ListRecords(z.ID, f)
-		if err != nil {
-			if checkAccessForbidden(err) {
-				// It is possible to deny access to certain zones in the account
-				// As a result, z zone should not be appended to the hosted zones
-				continue
-			}
-			return nil, err
-		}
-		hostedZone := provider.NewDNSHostedZone(h.ProviderType(), z.ID, z.Name, z.ID, forwarded, false)
+		hostedZone := provider.NewDNSHostedZone(h.ProviderType(), z.ID, z.Name, z.ID, false)
 		zones = append(zones, hostedZone)
 	}
 

--- a/pkg/controller/provider/google/execution_test.go
+++ b/pkg/controller/provider/google/execution_test.go
@@ -586,7 +586,7 @@ func matchGeoItem(location string, targets ...string) geoItem {
 
 func prepareSubmission(reqs []*provider.ChangeRequest, rrsetGetter rrsetGetterFunc) (*googledns.Change, error) {
 	log := logger.NewContext("", "TestEnv")
-	zone := provider.NewDNSHostedZone(TYPE_CODE, "test", "example.org", "", nil, false)
+	zone := provider.NewDNSHostedZone(TYPE_CODE, "test", "example.org", "", false)
 	doneHandler := &testDoneHandler{}
 	exec := NewExecution(log, nil, zone)
 	for _, r := range reqs {

--- a/pkg/controller/provider/infoblox/handler.go
+++ b/pkg/controller/provider/infoblox/handler.go
@@ -201,21 +201,7 @@ func (h *Handler) getZones(cache provider.ZoneCache) (provider.DNSHostedZones, e
 			continue
 		}
 
-		h.config.Metrics.AddZoneRequests(z.Ref, provider.M_LISTRECORDS, 1)
-		var resN []RecordNS
-		objN := ibclient.NewRecordNS(ibclient.RecordNS{})
-		params := ibclient.NewQueryParams(false, map[string]string{"view": *h.infobloxConfig.View, "zone": z.Fqdn})
-		err = h.access.GetObject(objN, "", params, &resN)
-		if filterNotFound(err) != nil {
-			return nil, fmt.Errorf("could not fetch NS records from zone '%s': %s", z.Fqdn, err)
-		}
-		forwarded := []string{}
-		for _, res := range resN {
-			if res.Name != z.Fqdn {
-				forwarded = append(forwarded, res.Name)
-			}
-		}
-		hostedZone := provider.NewDNSHostedZone(h.ProviderType(), z.Ref, dns.NormalizeHostname(z.Fqdn), z.Fqdn, forwarded, false)
+		hostedZone := provider.NewDNSHostedZone(h.ProviderType(), z.Ref, dns.NormalizeHostname(z.Fqdn), z.Fqdn, false)
 		zones = append(zones, hostedZone)
 	}
 	return zones, nil

--- a/pkg/controller/provider/mock/handler.go
+++ b/pkg/controller/provider/mock/handler.go
@@ -39,9 +39,8 @@ type Handler struct {
 }
 
 type MockZone struct {
-	ZonePrefix       string   `json:"zonePrefix"`
-	DNSName          string   `json:"dnsName"`
-	ForwardedDomains []string `json:"forwardedDomains,omitempty"`
+	ZonePrefix string `json:"zonePrefix"`
+	DNSName    string `json:"dnsName"`
 }
 
 type MockConfig struct {
@@ -77,12 +76,8 @@ func NewHandler(config *provider.DNSHandlerConfig) (provider.DNSHandler, error) 
 		if mockZone.DNSName != "" {
 			zoneID := mockZone.ZonePrefix + mockZone.DNSName
 			logger.Infof("Providing mock DNSZone %s[%s]", mockZone.DNSName, zoneID)
-			forwardedDomains := []string{}
-			if len(mockZone.ForwardedDomains) > 0 {
-				forwardedDomains = mockZone.ForwardedDomains
-			}
 			isPrivate := strings.Contains(mockZone.ZonePrefix, ":private:")
-			hostedZone := provider.NewDNSHostedZone(h.ProviderType(), zoneID, mockZone.DNSName, "", forwardedDomains, isPrivate)
+			hostedZone := provider.NewDNSHostedZone(h.ProviderType(), zoneID, mockZone.DNSName, "", isPrivate)
 			mock.AddZone(hostedZone)
 		}
 	}

--- a/pkg/controller/provider/netlify/handler.go
+++ b/pkg/controller/provider/netlify/handler.go
@@ -112,7 +112,7 @@ func (h *Handler) getZones(cache provider.ZoneCache) (provider.DNSHostedZones, e
 			}
 			return nil, err
 		}
-		hostedZone := provider.NewDNSHostedZone(h.ProviderType(), z.ID, z.Name, z.ID, forwarded, false)
+		hostedZone := provider.NewDNSHostedZone(h.ProviderType(), z.ID, z.Name, z.ID, false)
 		zones = append(zones, hostedZone)
 	}
 

--- a/pkg/controller/provider/openstack/handler_test.go
+++ b/pkg/controller/provider/openstack/handler_test.go
@@ -217,15 +217,6 @@ func newPreparedMockHandler(t *testing.T) *Handler {
 			ID:   "z2",
 			Name: "z2.test.",
 		})
-	_, err := h.client.CreateRecordSet("z2", recordsets.CreateOpts{
-		Name:    "excluded.z2.test.",
-		Type:    "NS",
-		TTL:     3600,
-		Records: []string{"ns1.somewhere", "ns2.somewhere"},
-	})
-	if err != nil {
-		t.Errorf("Error on creating mock recordsets: %v", err)
-	}
 	return h
 }
 
@@ -251,9 +242,6 @@ func TestGetZones(t *testing.T) {
 	}
 	if z2.Id().ID != "z2" || z2.Domain() != "z2.test" {
 		t.Errorf("Zone z2 not found: %v", z2)
-	}
-	if len(z2.ForwardedDomains()) != 1 || z2.ForwardedDomains()[0] != "excluded.z2.test" {
-		t.Errorf("Zone z2: unexpected forwarded domains: %v", z2.ForwardedDomains())
 	}
 }
 

--- a/pkg/controller/provider/remote/handler.go
+++ b/pkg/controller/provider/remote/handler.go
@@ -215,7 +215,7 @@ func (h *Handler) getZones(cache provider.ZoneCache) (provider.DNSHostedZones, e
 
 	zones := provider.DNSHostedZones{}
 	for _, z := range remoteZones.Zone {
-		hostedZone := provider.NewDNSHostedZone(h.ProviderType(), z.Id, dns.NormalizeHostname(z.Domain), z.Key, z.ForwardedDomain, z.PrivateZone)
+		hostedZone := provider.NewDNSHostedZone(h.ProviderType(), z.Id, dns.NormalizeHostname(z.Domain), z.Key, z.PrivateZone)
 		zones = append(zones, hostedZone)
 	}
 	return zones, nil

--- a/pkg/controller/provider/rfc2136/handler.go
+++ b/pkg/controller/provider/rfc2136/handler.go
@@ -119,7 +119,7 @@ func (h *Handler) getZones(cache provider.ZoneCache) (provider.DNSHostedZones, e
 	domainName := dns.NormalizeHostname(h.zone)
 	h.config.Metrics.AddGenericRequests(provider.M_LISTZONES, 1)
 	return provider.DNSHostedZones{
-		provider.NewDNSHostedZone(TYPE_CODE, h.zone, domainName, h.zone, nil, false),
+		provider.NewDNSHostedZone(TYPE_CODE, h.zone, domainName, h.zone, false),
 	}, nil
 }
 

--- a/pkg/dns/provider/default.go
+++ b/pkg/dns/provider/default.go
@@ -92,8 +92,8 @@ func Match(zone DNSHostedZone, dnsname string) int {
 	return 0
 }
 
-func NewDNSHostedZone(providerType, id, domain, key string, forwarded []string, isPrivate bool) DNSHostedZone {
-	return &DefaultDNSHostedZone{zoneid: dns.NewZoneID(providerType, id), key: key, domain: domain, forwarded: forwarded, isPrivate: isPrivate}
+func NewDNSHostedZone(providerType, id, domain, key string, isPrivate bool) DNSHostedZone {
+	return &DefaultDNSHostedZone{zoneid: dns.NewZoneID(providerType, id), key: key, domain: domain, isPrivate: isPrivate}
 }
 
 func CopyDNSHostedZone(zone DNSHostedZone, forwardedDomains []string) DNSHostedZone {

--- a/test/integration/privateZones_test.go
+++ b/test/integration/privateZones_test.go
@@ -288,7 +288,7 @@ var _ = Describe("PrivateZones", func() {
 			spec := &provider.Spec
 			spec.Domains = &v1alpha1.DNSSelection{Include: []string{"mock.xx"}}
 			spec.Type = "mock-inmemory"
-			spec.ProviderConfig = testEnv.BuildProviderConfig("mock.xx", "sub.mock.xx", Domain2IsSubdomain, PrivateZones)
+			spec.ProviderConfig = testEnv.BuildProviderConfig("mock.xx", "sub.mock.xx", PrivateZones)
 			spec.SecretRef = &corev1.SecretReference{Name: secret.GetName(), Namespace: testEnv.Namespace}
 		}
 

--- a/test/integration/testenv.go
+++ b/test/integration/testenv.go
@@ -58,7 +58,6 @@ const (
 	FailDeleteEntry
 	FailSecondZoneWithSameBaseDomain
 	AlternativeMockName
-	Domain2IsSubdomain
 	PrivateZones
 	Quotas4PerMin
 	RemoveAccess
@@ -220,12 +219,6 @@ func (te *TestEnv) BuildProviderConfig(domain, domain2 string, failOptions ...Pr
 			{ZonePrefix: te.ZonePrefix + prefix2, DNSName: domain},
 			{ZonePrefix: te.ZonePrefix + prefix2 + "second:", DNSName: domain2},
 		},
-	}
-	for _, opt := range failOptions {
-		switch opt {
-		case Domain2IsSubdomain:
-			input.Zones[0].ForwardedDomains = []string{domain2}
-		}
 	}
 	return te.BuildProviderConfigEx(input, failOptions...)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The providers do not read anymore all accessible hosted zone to find forwarded subdomains defined by `NS` record sets, i.e. subdomains which have another authoritative nameserver. Only forwarded subdomains known by the domain names of accessible hosted zones will be used to select the correct zone for the domain of a `DNSEntry`.
This means if there is a `NS` record set for a subdomain of a hosted zone which is hosted by a foreign nameserver, the DNS records for the `DNSEntry` will still be created in the accessible hosted zone. In this case, a lookup via a public DNS server will not return these newly created DNS records. Before this change, the `DNSEntry` would have shown an error state, as it could not find a suitable `DNSProvider`.

_Example for the changed behaviour:
Let's assume the credentials for a provider allows accessing three public zones: `zone1.example.com`, `zone2.example.com`, and `zone3.example.com`. The zone1 contains a `NS` record for `foo.bar.zone1.example.com` which is hosted on a foreign authoritative nameserver. There is only a `DNSProvider` including the domain `bar.zone1.example.com`.  The dns-controller-manager finds the correct zone `zone1.example.com`. With the new behaviour it only reads the DNS records of zone1. The other zones are ignored as long as no `DNSProvider` want to access them. Formerly, also all records of zone2 and zone3 would have been read periodically to know about the forwarded domains.
Creating a `DNSEntry` for `svc.foo.bar.zone1.example.com` now results in the creation of a DNS record set in the zone `zone1.example.com`,  which will not be found if looked up by a public DNS server, as the DNS record set should have to been placed into the forwarded hosted zone `foo.bar.zone1.example.com`. With the former behaviour, applying this `DNSEntry` would have resulted in an error state without action._

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
`NS` records are not retrieved anymore for all accessible hosted zones to avoid reading all DNS record sets of all hosted zones periodically independently if they are used. Only hosted zones with active `DNSProviders` are synched, but without caring about consequences of `NS` records for subdomains. If there are many large hosted zones accessible for given credentials and there are only  `DNSProviders` using a few of these zones (either by domain or zone include), the period synchronisation of the zone state for all other hosted zones is avoided. This can result in a significant reduction of requests to the provider backend. As a downside of this change, applying a `DNSEntry` for a forwarded subdomain now results in a DNS record set in the parent hosted zone, if the real hosted zone is unknown to the controller. Formerly, applying such a `DNSEnty` resulted in an error state. 
No action is necessary from the users, this is only a "heads up" for the changed behaviour if `NS` records are used for subdomains.
```
