### PR TITLE
Prepare gcr to ar

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,15 +1,48 @@
 external-dns-management:
   base_definition:
+    steps:
+      build:
+        image: golang:1.20.2
+        output_dir: binary
+      check:
+        image: golang:1.20.2
+      integrationtest:
+        image: golang:1.20.2
+      test:
+        image: golang:1.20.2
     traits:
+      publish:
+        dockerimages:
+          dns-controller-manager:
+            dockerfile: build/Dockerfile
+            image: eu.gcr.io/gardener-project/dns-controller-manager
+            inputs:
+              repos:
+                source: null
+              steps:
+                build: null
+            registry: gcr-readwrite
       version:
-        preprocess: 'inject-commit-hash'
+        inject_effective_version: true
+        preprocess: inject-branch-name
       component_descriptor: ~
+
   jobs:
     head-update:
       traits:
-        draft_release: ~
+        version:
+          preprocess: inject-commit-hash
         component_descriptor:
           retention_policy: 'clean-snapshots'
+        draft_release: ~
+        draft_release: null
+
+    pull-request:
+      traits:
+        pull-request: null
+        version:
+          preprocess: inject-commit-hash
+
     release:
       traits:
         version:
@@ -24,6 +57,7 @@ external-dns-management:
             internal_scp_workspace:
               channel_name: 'C9CEBQPGE' #sap-tech-gardener
               slack_cfg_name: 'scp_workspace'
+
     patch-release:
       traits:
         version:
@@ -32,3 +66,23 @@ external-dns-management:
           nextversion: bump_patch
           next_version_callback: '.ci/prepare_release'
           release_callback: '.ci/prepare_release'
+        slack:
+          channel_cfgs:
+            internal_scp_workspace:
+              channel_name: C9CEBQPGE
+              slack_cfg_name: scp_workspace
+          default_channel: internal_scp_workspace
+
+    verbatim-release:
+      traits:
+        release:
+          nextversion: noop
+          release_callback: .ci/prepare_release
+        slack:
+          channel_cfgs:
+            internal_scp_workspace:
+              channel_name: C9CEBQPGE
+              slack_cfg_name: scp_workspace
+          default_channel: internal_scp_workspace
+        version:
+          preprocess: noop

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -7,7 +7,7 @@ external-dns-management:
       check:
         image: golang:1.20.2
       integrationtest:
-        image: golang:1.20.2
+        image: golang:1.21.5
       test:
         image: golang:1.20.2
     traits:

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -2,7 +2,7 @@ external-dns-management:
   base_definition:
     steps:
       build:
-        image: golang:1.20.2
+        image: golang:1.21.5
         output_dir: binary
       check:
         image: golang:1.20.2

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,7 +1,5 @@
 external-dns-management:
-  template: 'default'
   base_definition:
-    repo: ~
     traits:
       version:
         preprocess: 'inject-commit-hash'

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -9,7 +9,7 @@ external-dns-management:
       integrationtest:
         image: golang:1.21.5
       test:
-        image: golang:1.20.2
+        image: golang:1.21.5
     traits:
       publish:
         dockerimages:

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -5,7 +5,7 @@ external-dns-management:
         image: golang:1.21.5
         output_dir: binary
       check:
-        image: golang:1.20.2
+        image: golang:1.21.5
       integrationtest:
         image: golang:1.21.5
       test:


### PR DESCRIPTION
**What this PR does / why we need it**

Refactor .ci/pipeline_definitions in preparations for subsequent switch from GCR -> Artifact-Registry. This change will as a side-effect make managing pipeline-definition slightly less cumbersome.

Accepting this change will have no immediate effect. Therefore, no release-notes are deemed necessary.