### PR TITLE
[AWS Route53] Create alias AAAA records for load balancers if target domain name has an IPv6 address

### DIFF
--- a/test/functional/config/config.go
+++ b/test/functional/config/config.go
@@ -77,19 +77,20 @@ func PrintConfigEnv() {
 }
 
 type ProviderConfig struct {
-	Name               string                              `json:"name"`
-	Type               string                              `json:"type"`
-	FinalizerType      string                              `json:"finalizerType,omitempty"`
-	Domain             string                              `json:"domain"`
-	ForeignDomain      string                              `json:"foreignDomain,omitempty"`
-	SecretData         string                              `json:"secretData"`
-	Prefix             string                              `json:"prefix"`
-	AliasTarget        string                              `json:"aliasTarget,omitempty"`
-	ZoneID             string                              `json:"zoneID"`
-	PrivateDNS         bool                                `json:"privateDNS,omitempty"`
-	TTL                string                              `json:"ttl,omitempty"`
-	SpecProviderConfig string                              `json:"providerConfig,omitempty"`
-	RoutingPolicySets  map[string]map[string]RoutingPolicy `json:"routingPolicySets,omitempty"`
+	Name                 string                              `json:"name"`
+	Type                 string                              `json:"type"`
+	FinalizerType        string                              `json:"finalizerType,omitempty"`
+	Domain               string                              `json:"domain"`
+	ForeignDomain        string                              `json:"foreignDomain,omitempty"`
+	SecretData           string                              `json:"secretData"`
+	Prefix               string                              `json:"prefix"`
+	AliasTarget          string                              `json:"aliasTarget,omitempty"`
+	AliasTargetDualStack string                              `json:"aliasTargetDualStack,omitempty"`
+	ZoneID               string                              `json:"zoneID"`
+	PrivateDNS           bool                                `json:"privateDNS,omitempty"`
+	TTL                  string                              `json:"ttl,omitempty"`
+	SpecProviderConfig   string                              `json:"providerConfig,omitempty"`
+	RoutingPolicySets    map[string]map[string]RoutingPolicy `json:"routingPolicySets,omitempty"`
 
 	Namespace           string
 	TmpManifestFilename string


### PR DESCRIPTION
**What this PR does / why we need it**:
Loadbalancers on AWS provide the hostname address. If the base domain name of the NLB's hostname is a known AWS region, an alias `A` record is created instead of a `CNAME` record.
If the loadbalancers supports dual-stack, the hostname address has IPv6 addresses, a separate alias `AAAA` record is needed to be usable with IPv6.
For a `DNSEntry` for such targets, a DNS IP lookup is performed on mapping the `CNAME` to alias record(s). If the lookup returns IPv4 and IPv6 addresses on the target hostname, alias records for `A` and `AAAA` are created, respectively.

**Which issue(s) this PR fixes**:
Fixes #340 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
[AWS Route53] Create an additional alias `AAAA` record for load balancers (NLBs) if load balancer target domain name has an IPv6 address.
```
