### PR TITLE
switch GCR -> Artifact-Registry

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -14,8 +14,8 @@ external-dns-management:
       publish:
         dockerimages:
           dns-controller-manager:
+            image: europe-docker.pkg.dev/gardener-project/snapshots/dns-controller-manager
             dockerfile: build/Dockerfile
-            image: eu.gcr.io/gardener-project/dns-controller-manager
             inputs:
               repos:
                 source: null
@@ -25,7 +25,8 @@ external-dns-management:
       version:
         inject_effective_version: true
         preprocess: inject-branch-name
-      component_descriptor: ~
+      component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
 
   jobs:
     head-update:
@@ -33,6 +34,8 @@ external-dns-management:
         version:
           preprocess: inject-commit-hash
         component_descriptor:
+          ocm_repository_mappings:
+            - repository: europe-docker.pkg.dev/gardener-project/releases
           retention_policy: 'clean-snapshots'
         draft_release: ~
         draft_release: null
@@ -40,6 +43,9 @@ external-dns-management:
     pull-request:
       traits:
         pull-request: null
+        component_descriptor:
+          ocm_repository_mappings:
+            - repository: europe-docker.pkg.dev/gardener-project/releases
         version:
           preprocess: inject-commit-hash
 
@@ -47,10 +53,16 @@ external-dns-management:
       traits:
         version:
           preprocess: 'finalize'
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
         release:
           nextversion: 'bump_minor'
           next_version_callback: '.ci/prepare_release'
           release_callback: '.ci/prepare_release'
+        publish:
+          dockerimages:
+            dns-controller-manager:
+              image: europe-docker.pkg.dev/gardener-project/releases/dns-controller-manager
         slack:
           default_channel: 'internal_scp_workspace'
           channel_cfgs:
@@ -62,10 +74,16 @@ external-dns-management:
       traits:
         version:
           preprocess: finalize
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
         release:
           nextversion: bump_patch
           next_version_callback: '.ci/prepare_release'
           release_callback: '.ci/prepare_release'
+        publish:
+          dockerimages:
+            dns-controller-manager:
+              image: europe-docker.pkg.dev/gardener-project/releases/dns-controller-manager
         slack:
           channel_cfgs:
             internal_scp_workspace:
@@ -78,6 +96,12 @@ external-dns-management:
         release:
           nextversion: noop
           release_callback: .ci/prepare_release
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
+        publish:
+          dockerimages:
+            dns-controller-manager:
+              image: europe-docker.pkg.dev/gardener-project/releases/dns-controller-manager
         slack:
           channel_cfgs:
             internal_scp_workspace:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-REGISTRY              := eu.gcr.io/gardener-project
+REGISTRY              := europe-docker.pkg.dev/gardener-project/public
 EXECUTABLE            := dns-controller-manager
 PROJECT               := github.com/gardener/external-dns-management
 IMAGE_REPOSITORY      := $(REGISTRY)/dns-controller-manager

--- a/charts/external-dns-management/values.yaml
+++ b/charts/external-dns-management/values.yaml
@@ -4,7 +4,7 @@ fullnameOverride: dns-controller-manager
 replicaCount: 1
 
 image:
-  repository: eu.gcr.io/gardener-project/dns-controller-manager
+  repository: europe-docker.pkg.dev/gardener-project/public/dns-controller-manager
   tag: v0.16.1-master
   pullPolicy: IfNotPresent
 

--- a/hack/.ci/component_descriptor
+++ b/hack/.ci/component_descriptor
@@ -16,7 +16,7 @@ if [[ -f "$repo_root_dir/charts/images.yaml" ]]; then
   # the konnectivity-server is temporary excluded until the component-descriptor for the replica-reloader is released
   component-cli image-vector add --comp-desc ${BASE_DEFINITION_PATH} \
     --image-vector "$repo_root_dir/charts/images.yaml" \
-    --component-prefixes eu.gcr.io/gardener-project/gardener \
+    --component-prefixes europe-docker.pkg.dev/gardener-project \
     --exclude-component-reference konnectivity-server \
     --generic-dependencies hyperkube,kube-apiserver,kube-controller-manager,kube-scheduler,kube-proxy
 fi
@@ -39,14 +39,6 @@ if [[ -d "$repo_root_dir/charts/" ]]; then
       REPOSITORY=${imageAndTag[0]}
       TAG=${imageAndTag[1]}
 
-      gardener="eu.gcr.io/gardener-project/gardener"
-      if [[ "$NAME" == "hyperkube" ]]; then
-        ${ADD_DEPENDENCIES_CMD} --generic-dependencies "{\"name\": \"$NAME\", \"version\": \"$TAG\"}"
-      elif [[ $REPOSITORY =~ "eu.gcr.io/gardener-project/gardener"* ]]; then
-        ${ADD_DEPENDENCIES_CMD} --generic-dependencies "{\"name\": \"$NAME\", \"version\": \"$TAG\"}"
-      else
-        ${ADD_DEPENDENCIES_CMD} --container-image-dependencies "{\"name\": \"${NAME}\", \"image_reference\": \"${REPOSITORY}:${TAG}\", \"version\": \"$TAG\"}"
-      fi
     done < <(echo "$outputFile")
   done
 fi

--- a/hack/get-cd-registry.sh
+++ b/hack/get-cd-registry.sh
@@ -6,4 +6,4 @@
 
 set -e
 
-echo "eu.gcr.io/sap-se-gcr-k8s-private/cnudie/gardener/development"
+echo "europe-docker.pkg.dev/gardener-project/releases"

--- a/hack/get-image-registry.sh
+++ b/hack/get-image-registry.sh
@@ -6,4 +6,4 @@
 
 set -e
 
-echo "eu.gcr.io/gardener-project"
+echo "europe-docker.pkg.dev/gardener-project/public"


### PR DESCRIPTION
GCR has been deprecated [0] in favour of Artifact-Registry.

Thus, change push-targets for OCI-Images:

- europe-docker.pkg.dev/gardener-project/snapshots for snapshots
- europe-docker.pkg.dev/gardener-project/releases for releases
- europe-docker.pkg.dev/gardener-project/public for combined view of snapshots + releases

[0]
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr


**Release note**:

```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.

```
