### PR TITLE
rfc2136 provider: expect base64 encoded TSIG key

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.10
 	github.com/prometheus/client_golang v1.16.0
-	github.com/spf13/pflag v1.0.5
 	go.uber.org/atomic v1.10.0
 	go.uber.org/automaxprocs v1.4.0
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
@@ -112,6 +111,7 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spf13/cobra v1.7.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	go.mongodb.org/mongo-driver v1.8.3 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.14.0 // indirect

--- a/pkg/controller/provider/rfc2136/execution.go
+++ b/pkg/controller/provider/rfc2136/execution.go
@@ -186,7 +186,7 @@ func (exec *Execution) exchange(records []miekgdns.RR, apply func(*miekgdns.Msg,
 
 	c := &miekgdns.Client{
 		Net:        tcp,
-		TsigSecret: map[string]string{exec.handler.tsigKeyname: exec.handler.tsigSecretBase64},
+		TsigSecret: map[string]string{exec.handler.tsigKeyname: exec.handler.tsigSecret},
 	}
 
 	msg := &miekgdns.Msg{}


### PR DESCRIPTION
**What this PR does / why we need it**:
Usually both tsig key tools generate, and dns servers are configured using the base64 encoded version of the TSIG Key.
This PR reduces complexity by removing base64 encoding during runtime, which removes the need to decode it for the Kubernetes Secret.

This also makes integration with external secret providers easier, as the binary data from the tsig key could be difficult to copy.

**Which issue(s) this PR fixes**:
Fixes #346

**Special notes for your reviewer**:
the diff in go.mod is due to running `go mod tidy`

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking
- target_group:   operator
-->
```breaking operator
rfc2136 provider expects TSIGSecret in base64 encoded format (previously base64 decoded was expected)
```
