### PR TITLE
[aws-route53] Create AAAA records with alias target for specific annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ the target cluster. As there can be multiple controllers active on the same clus
 need to set the correct `DNSClass` both for the controller and for the source resource by
 setting the annotation `dns.gardener.cloud/class`. The default value for the `DNSClass` is `gardendns`.
 
-Note that if you delegate the DNS management for shoot resources to Gardener via the 
+**Note**: If you delegate the DNS management for shoot resources to Gardener via the 
 [shoot-dns-service extension](https://github.com/gardener/gardener-extension-shoot-dns-service),
 the correct annotation is `dns.gardener.cloud/class=garden`.
 
@@ -205,7 +205,7 @@ metadata:
     dns.gardener.cloud/dnsnames: echo.my-dns-domain.com
     dns.gardener.cloud/ttl: "500"
     # If you are delegating the DNS Management to Gardener, uncomment the following line (see https://gardener.cloud/documentation/guides/administer_shoots/dns_names/)
-    #`dns.gardener.cloud/class`: garden
+    #dns.gardener.cloud/class: garden
   name: test-service
   namespace: default
 spec:
@@ -217,6 +217,20 @@ spec:
   sessionAffinity: None
   type: LoadBalancer
 ``` 
+
+#### `A` DNS records with alias targets for provider type AWS-Route53 and AWS load balancers
+
+For AWS-Route53 and AWS load balancers, `A` DNS records with alias target are created instead of `CNAME` 
+as an optimisation.
+
+To support dual-stack IP addresses in this case, set one of these annotations:
+
+-  `service.beta.kubernetes.io/aws-load-balancer-ip-address-type=dualstack` (services only)
+- `dns.gardener.cloud/ip-stack=dual-stack` (ingresses, services or dnsentries)
+
+In this case, both `A` and `AAAA` records with alias target records are created.
+
+With annotation `dns.gardener.cloud/ip-stack=ipv6`, only an `AAAA` record with alias target is created.
 
 ## The Model
 

--- a/examples/50-ingress-with-dns.yaml
+++ b/examples/50-ingress-with-dns.yaml
@@ -9,6 +9,7 @@ metadata:
     #cert.gardener.cloud/purpose: managed
     #dns.gardener.cloud/ttl: "500"
     #dns.gardener.cloud/owner-id: second
+    #dns.gardener.cloud/ip-stack: dual-stack     # AWS-route 53 only: enable both A and AAAA alias targets
   name: test-ingress
   namespace: default
 spec:

--- a/examples/50-service-with-dns.yaml
+++ b/examples/50-service-with-dns.yaml
@@ -7,6 +7,8 @@ metadata:
     # If you are delegating the DNS Management to Gardener, uncomment the following line (see https://gardener.cloud/documentation/guides/administer_shoots/dns_names/)
     #dns.gardener.cloud/class: garden
     #dns.gardener.cloud/owner-id: second
+    #service.beta.kubernetes.io/aws-load-balancer-ip-address-type: dualstack   # AWS-route 53 only: enable both A and AAAA alias targets
+    #dns.gardener.cloud/ip-stack: dual-stack                                   # AWS-route 53 only: alternative way to enable A and AAAA alias targets
   name: test-service
   namespace: default
 spec:

--- a/pkg/controller/provider/aws/handler.go
+++ b/pkg/controller/provider/aws/handler.go
@@ -265,7 +265,12 @@ func (h *Handler) executeRequests(logger logger.LogContext, zone provider.DNSHos
 	return exec.submitChanges(h.config.Metrics)
 }
 
-func (h *Handler) MapTargets(targets []provider.Target) []provider.Target {
+func (h *Handler) MapTargets(_ string, targets []provider.Target) []provider.Target {
+	return MapTargets(targets)
+}
+
+// MapTargets maps CNAME records to A/AAAA records for hosted zones used for AWS load balancers.
+func MapTargets(targets []provider.Target) []provider.Target {
 	mapped := make([]provider.Target, 0, len(targets)+1)
 	for _, t := range targets {
 		switch t.GetRecordType() {

--- a/pkg/controller/provider/aws/handler.go
+++ b/pkg/controller/provider/aws/handler.go
@@ -174,6 +174,9 @@ func (h *Handler) getZones(_ provider.ZoneCache) (provider.DNSHostedZones, error
 }
 
 func buildRecordSet(r *route53.ResourceRecordSet) *dns.RecordSet {
+	if rs := buildRecordSetFromAliasTarget(r); rs != nil {
+		return rs
+	}
 	rs := dns.NewRecordSet(aws.StringValue(r.Type), aws.Int64Value(r.TTL), nil)
 	for _, rr := range r.ResourceRecords {
 		rs.Add(&dns.Record{Value: aws.StringValue(rr.Value)})
@@ -190,12 +193,7 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, _ provider.ZoneCache
 
 	aggr := func(r *route53.ResourceRecordSet) {
 		if dns.SupportedRecordType(aws.StringValue(r.Type)) {
-			var rs *dns.RecordSet
-			if isAliasTarget(r) {
-				rs = buildRecordSetFromAliasTarget(r)
-			} else {
-				rs = buildRecordSet(r)
-			}
+			rs := buildRecordSet(r)
 			name := dns.DNSSetName{DNSName: aws.StringValue(r.Name), SetIdentifier: aws.StringValue(r.SetIdentifier)}
 			policy := h.policyContext.extractRoutingPolicy(r)
 			dnssets.AddRecordSetFromProviderEx(name, policy, rs)
@@ -267,14 +265,30 @@ func (h *Handler) executeRequests(logger logger.LogContext, zone provider.DNSHos
 	return exec.submitChanges(h.config.Metrics)
 }
 
-func (h *Handler) MapTarget(t provider.Target) provider.Target {
-	if t.GetRecordType() == dns.RS_CNAME {
-		hostedZone := canonicalHostedZone(t.GetHostName())
-		if hostedZone != "" {
-			return dnsutils.NewTarget(dns.RS_ALIAS, t.GetHostName(), t.GetTTL())
+func (h *Handler) MapTargets(targets []provider.Target) []provider.Target {
+	mapped := make([]provider.Target, 0, len(targets)+1)
+	for _, t := range targets {
+		switch t.GetRecordType() {
+		case dns.RS_CNAME:
+			hostedZone := canonicalHostedZone(t.GetHostName())
+			if hostedZone != "" {
+				switch strings.ToLower(t.GetIPStack()) {
+				case dns.AnnotationValueIPStackIPDualStack:
+					mapped = append(mapped, dnsutils.NewTarget(dns.RS_ALIAS_A, t.GetHostName(), t.GetTTL()))
+					mapped = append(mapped, dnsutils.NewTarget(dns.RS_ALIAS_AAAA, t.GetHostName(), t.GetTTL()))
+				case dns.AnnotationValueIPStackIPv6:
+					mapped = append(mapped, dnsutils.NewTarget(dns.RS_ALIAS_AAAA, t.GetHostName(), t.GetTTL()))
+				default:
+					mapped = append(mapped, dnsutils.NewTarget(dns.RS_ALIAS_A, t.GetHostName(), t.GetTTL()))
+				}
+			} else {
+				mapped = append(mapped, t)
+			}
+		default:
+			mapped = append(mapped, t)
 		}
 	}
-	return t
+	return mapped
 }
 
 // AssociateVPCWithHostedZone associates a VPC with a private hosted zone
@@ -378,12 +392,7 @@ func (h *Handler) GetRecordSet(zone provider.DNSHostedZone, setName dns.DNSSetNa
 	dnssets := dns.DNSSets{}
 	aggr := func(r *route53.ResourceRecordSet) {
 		if dns.SupportedRecordType(aws.StringValue(r.Type)) {
-			var rs *dns.RecordSet
-			if isAliasTarget(r) {
-				rs = buildRecordSetFromAliasTarget(r)
-			} else {
-				rs = buildRecordSet(r)
-			}
+			rs := buildRecordSet(r)
 			routingPolicy := h.policyContext.extractRoutingPolicy(r)
 			dnsSetName := dns.DNSSetName{DNSName: aws.StringValue(r.Name), SetIdentifier: aws.StringValue(r.SetIdentifier)}
 			dnssets.AddRecordSetFromProviderEx(dnsSetName, routingPolicy, rs)

--- a/pkg/controller/source/dnsentry/handler.go
+++ b/pkg/controller/source/dnsentry/handler.go
@@ -67,6 +67,7 @@ func (this *DNSEntrySource) GetDNSInfo(_ logger.LogContext, obj resources.Object
 		TTL:           data.Spec.TTL,
 		Interval:      data.Spec.CNameLookupInterval,
 		RoutingPolicy: data.Spec.RoutingPolicy,
+		IPStack:       obj.GetAnnotation(dns.AnnotationIPStack),
 	}
 	return info, nil
 }

--- a/pkg/controller/source/ingress/handler.go
+++ b/pkg/controller/source/ingress/handler.go
@@ -57,6 +57,7 @@ func (this *IngressSource) GetDNSInfo(_ logger.LogContext, obj resources.Object,
 		return info, fmt.Errorf("annotated dns names %s not declared by ingress", del)
 	}
 	info.Names = dns.NewDNSNameSetFromStringSet(names, current.GetSetIdentifier())
+	info.IPStack = obj.GetAnnotation(dns.AnnotationIPStack)
 	return info, nil
 }
 

--- a/pkg/dns/const.go
+++ b/pkg/dns/const.go
@@ -32,3 +32,13 @@ const (
 )
 
 const OPT_SETUP = "setup"
+
+const (
+	// AnnotationIPStack is an optional annotation for DNSEntries to specify the IP stack.
+	// Values are 'ipv4', 'dual-stack', and 'ipv6'. If not specified, 'ipv4' is assumed.
+	// This annotation is currently only relevant for AWS-Route53 to generate alias target A and/or AAAA records.
+	AnnotationIPStack                 = ANNOTATION_GROUP + "/ip-stack"
+	AnnotationValueIPStackIPv4        = "ipv4"
+	AnnotationValueIPStackIPDualStack = "dual-stack"
+	AnnotationValueIPStackIPv6        = "ipv6"
+)

--- a/pkg/dns/provider/changemodel.go
+++ b/pkg/dns/provider/changemodel.go
@@ -526,11 +526,9 @@ func (this *ChangeModel) ApplySpec(set *dns.DNSSet, base *dns.DNSSet, provider D
 	}
 
 	targetsets := set.Sets
-	for _, t := range spec.Targets() {
-		// use status calculated in entry
-		ttl := t.GetTTL()
-		t = provider.MapTarget(t)
-		AddRecord(targetsets, t.GetRecordType(), t.GetHostName(), ttl)
+	targets := provider.MapTargets(spec.Targets())
+	for _, t := range targets {
+		AddRecord(targetsets, t.GetRecordType(), t.GetHostName(), t.GetTTL())
 	}
 	set.Sets = targetsets
 	return set

--- a/pkg/dns/provider/changemodel.go
+++ b/pkg/dns/provider/changemodel.go
@@ -526,7 +526,7 @@ func (this *ChangeModel) ApplySpec(set *dns.DNSSet, base *dns.DNSSet, provider D
 	}
 
 	targetsets := set.Sets
-	targets := provider.MapTargets(spec.Targets())
+	targets := provider.MapTargets(set.Name.DNSName, spec.Targets())
 	for _, t := range targets {
 		AddRecord(targetsets, t.GetRecordType(), t.GetHostName(), t.GetTTL())
 	}

--- a/pkg/dns/provider/entry.go
+++ b/pkg/dns/provider/entry.go
@@ -118,6 +118,10 @@ func (this *EntryVersion) Kind() string {
 	return this.object.GroupKind().Kind
 }
 
+func (this *EntryVersion) GetAnnotations() map[string]string {
+	return this.object.GetAnnotations()
+}
+
 func (this *EntryVersion) RequiresUpdateFor(e *EntryVersion) (reasons []string, refresh bool) {
 	if this.dnsSetName != e.dnsSetName {
 		reasons = append(reasons, "recordset name changed")

--- a/pkg/dns/provider/interface.go
+++ b/pkg/dns/provider/interface.go
@@ -205,7 +205,7 @@ type DNSHandler interface {
 	GetZoneState(DNSHostedZone) (DNSZoneState, error)
 	ReportZoneStateConflict(zone DNSHostedZone, err error) bool
 	ExecuteRequests(logger logger.LogContext, zone DNSHostedZone, state DNSZoneState, reqs []*ChangeRequest) error
-	MapTarget(t Target) Target
+	MapTargets(targets []Target) []Target
 	Release()
 }
 
@@ -221,8 +221,8 @@ func (this *DefaultDNSHandler) ProviderType() string {
 	return this.providerType
 }
 
-func (this *DefaultDNSHandler) MapTarget(t Target) Target {
-	return t
+func (this *DefaultDNSHandler) MapTargets(targets []Target) []Target {
+	return targets
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -262,7 +262,7 @@ type DNSProvider interface {
 	IsValid() bool
 
 	AccountHash() string
-	MapTarget(t Target) Target
+	MapTargets(targets []Target) []Target
 
 	// ReportZoneStateConflict is used to report a conflict because of stale data.
 	// It returns true if zone data will be updated and a retry may resolve the conflict

--- a/pkg/dns/provider/interface.go
+++ b/pkg/dns/provider/interface.go
@@ -205,7 +205,7 @@ type DNSHandler interface {
 	GetZoneState(DNSHostedZone) (DNSZoneState, error)
 	ReportZoneStateConflict(zone DNSHostedZone, err error) bool
 	ExecuteRequests(logger logger.LogContext, zone DNSHostedZone, state DNSZoneState, reqs []*ChangeRequest) error
-	MapTargets(targets []Target) []Target
+	MapTargets(dnsName string, targets []Target) []Target
 	Release()
 }
 
@@ -221,7 +221,7 @@ func (this *DefaultDNSHandler) ProviderType() string {
 	return this.providerType
 }
 
-func (this *DefaultDNSHandler) MapTargets(targets []Target) []Target {
+func (this *DefaultDNSHandler) MapTargets(_ string, targets []Target) []Target {
 	return targets
 }
 
@@ -262,7 +262,7 @@ type DNSProvider interface {
 	IsValid() bool
 
 	AccountHash() string
-	MapTargets(targets []Target) []Target
+	MapTargets(dnsName string, targets []Target) []Target
 
 	// ReportZoneStateConflict is used to report a conflict because of stale data.
 	// It returns true if zone data will be updated and a retry may resolve the conflict

--- a/pkg/dns/provider/provider.go
+++ b/pkg/dns/provider/provider.go
@@ -161,8 +161,8 @@ func (this *DNSAccount) ExecuteRequests(logger logger.LogContext, zone DNSHosted
 	return this.handler.ExecuteRequests(logger, zone, state, reqs)
 }
 
-func (this *DNSAccount) MapTargets(targets []Target) []Target {
-	return this.handler.MapTargets(targets)
+func (this *DNSAccount) MapTargets(dnsName string, targets []Target) []Target {
+	return this.handler.MapTargets(dnsName, targets)
 }
 
 func (this *DNSAccount) Release() {
@@ -539,8 +539,8 @@ func (this *dnsProviderVersion) MatchZone(dns string) int {
 	return 0
 }
 
-func (this *dnsProviderVersion) MapTargets(targets []Target) []Target {
-	return this.account.MapTargets(targets)
+func (this *dnsProviderVersion) MapTargets(dnsName string, targets []Target) []Target {
+	return this.account.MapTargets(dnsName, targets)
 }
 
 func (this *dnsProviderVersion) setError(modified bool, err error) error {

--- a/pkg/dns/provider/provider.go
+++ b/pkg/dns/provider/provider.go
@@ -161,8 +161,8 @@ func (this *DNSAccount) ExecuteRequests(logger logger.LogContext, zone DNSHosted
 	return this.handler.ExecuteRequests(logger, zone, state, reqs)
 }
 
-func (this *DNSAccount) MapTarget(t Target) Target {
-	return this.handler.MapTarget(t)
+func (this *DNSAccount) MapTargets(targets []Target) []Target {
+	return this.handler.MapTargets(targets)
 }
 
 func (this *DNSAccount) Release() {
@@ -539,8 +539,8 @@ func (this *dnsProviderVersion) MatchZone(dns string) int {
 	return 0
 }
 
-func (this *dnsProviderVersion) MapTarget(t Target) Target {
-	return this.account.MapTarget(t)
+func (this *dnsProviderVersion) MapTargets(targets []Target) []Target {
+	return this.account.MapTargets(targets)
 }
 
 func (this *dnsProviderVersion) setError(modified bool, err error) error {

--- a/pkg/dns/provider/target.go
+++ b/pkg/dns/provider/target.go
@@ -32,7 +32,7 @@ type (
 func NewHostTargetFromEntryVersion(name string, entry *EntryVersion) (Target, error) {
 	ip := net.ParseIP(name)
 	if ip == nil {
-		return dnsutils.NewTarget(dns.RS_CNAME, name, entry.TTL()), nil
+		return dnsutils.NewTargetWithIPStack(dns.RS_CNAME, name, entry.TTL(), entry.GetAnnotations()[dns.AnnotationIPStack]), nil
 	} else if ip.To4() != nil {
 		return dnsutils.NewTarget(dns.RS_A, name, entry.TTL()), nil
 	} else if ip.To16() != nil {

--- a/pkg/dns/records.go
+++ b/pkg/dns/records.go
@@ -22,8 +22,9 @@ import (
 )
 
 const (
-	RS_META  = "META"
-	RS_ALIAS = "ALIAS" // provider specific alias for CNAME record (e.g. AWS alias target)
+	RS_META       = "META"
+	RS_ALIAS_A    = "ALIAS"      // provider specific alias for CNAME record (AWS alias target A)
+	RS_ALIAS_AAAA = "ALIAS_AAAA" // provider specific alias for CNAME record (AWS alias target AAAA)
 )
 
 const (

--- a/pkg/dns/source/defaults.go
+++ b/pkg/dns/source/defaults.go
@@ -96,9 +96,12 @@ func (this *DefaultDNSSource) CreateDNSFeedback(obj resources.Object) DNSFeedbac
 func (this *DefaultDNSSource) GetDNSInfo(logger logger.LogContext, obj resources.Object, current *DNSCurrentState) (*DNSInfo, error) {
 	info := &DNSInfo{}
 	info.Names = dns.NewDNSNameSetFromStringSet(current.AnnotatedNames, current.GetSetIdentifier())
-	tgts, txts, err := this.handler(logger, obj, info.Names)
-	info.Targets = tgts
-	info.Text = txts
+	extraction, err := this.handler(logger, obj, info.Names)
+	if extraction != nil {
+		info.Targets = extraction.Targets
+		info.Text = extraction.Texts
+		info.IPStack = extraction.IPStack
+	}
 	return info, err
 }
 

--- a/pkg/dns/source/interface.go
+++ b/pkg/dns/source/interface.go
@@ -39,6 +39,7 @@ type DNSInfo struct {
 	OrigRef       *v1alpha1.EntryReference
 	TargetRef     *v1alpha1.EntryReference
 	RoutingPolicy *v1alpha1.RoutingPolicy
+	IPStack       string
 }
 
 type DNSFeedback interface {
@@ -67,8 +68,14 @@ type DNSSourceType interface {
 	Create(controller.Interface) (DNSSource, error)
 }
 
+type TargetExtraction struct {
+	Targets utils.StringSet
+	Texts   utils.StringSet
+	IPStack string
+}
+
 type (
-	DNSTargetExtractor func(logger logger.LogContext, obj resources.Object, names dns.DNSNameSet) (targets utils.StringSet, texts utils.StringSet, err error)
+	DNSTargetExtractor func(logger logger.LogContext, obj resources.Object, names dns.DNSNameSet) (*TargetExtraction, error)
 	DNSSourceCreator   func(controller.Interface) (DNSSource, error)
 )
 

--- a/pkg/dns/utils/target.go
+++ b/pkg/dns/utils/target.go
@@ -32,7 +32,8 @@ type Targets []Target
 func (this Targets) Has(target Target) bool {
 	for _, t := range this {
 		if t.GetRecordType() == target.GetRecordType() &&
-			t.GetHostName() == target.GetHostName() {
+			t.GetHostName() == target.GetHostName() &&
+			t.GetIPStack() == target.GetIPStack() {
 			return true
 		}
 	}
@@ -56,12 +57,14 @@ type Target interface {
 	GetRecordType() string
 	GetTTL() int64
 	AsRecord() *dns.Record
+	GetIPStack() string
 }
 
 type target struct {
-	rtype string
-	host  string
-	ttl   int64
+	rtype   string
+	host    string
+	ttl     int64
+	ipstack string
 }
 
 func NewText(t string, ttl int64) Target {
@@ -72,9 +75,14 @@ func NewTarget(ty string, ta string, ttl int64) Target {
 	return &target{rtype: ty, host: ta, ttl: ttl}
 }
 
+func NewTargetWithIPStack(ty string, ta string, ttl int64, ipstack string) Target {
+	return &target{rtype: ty, host: ta, ttl: ttl, ipstack: ipstack}
+}
+
 func (t *target) GetTTL() int64         { return t.ttl }
 func (t *target) GetHostName() string   { return t.host }
 func (t *target) GetRecordType() string { return t.rtype }
+func (t *target) GetIPStack() string    { return t.ipstack }
 
 func (t *target) AsRecord() *dns.Record {
 	return &dns.Record{Value: t.host}

--- a/test/functional/basics.go
+++ b/test/functional/basics.go
@@ -134,6 +134,8 @@ kind: DNSEntry
 metadata:
   name: {{.Prefix}}alias-ds
   namespace: {{.Namespace}}
+  annotations:
+    dns.gardener.cloud/ip-stack: dual-stack
 spec:
   dnsName: {{.Prefix}}alias-ds.{{.Domain}}
   ttl: {{.TTL}}

--- a/test/integration/ingressAnnotation_test.go
+++ b/test/integration/ingressAnnotation_test.go
@@ -32,7 +32,8 @@ var _ = Describe("IngressAnnotation", func() {
 		fakeExternalIP := "1.2.3.4"
 		ingressDomain := "myingress." + domain
 		ttl := 456
-		ingress, err := testEnv.CreateIngressWithAnnotation("myingress", ingressDomain, fakeExternalIP, ttl, nil, nil)
+		ingress, err := testEnv.CreateIngressWithAnnotation("myingress", ingressDomain, fakeExternalIP, ttl, nil,
+			map[string]string{"dns.gardener.cloud/ip-stack": "dual-stack"})
 		Ω(err).ShouldNot(HaveOccurred())
 		routingPolicy := `{"type": "weighted", "setIdentifier": "my-id", "parameters": {"weight": "10"}}`
 		ingress2, err := testEnv.CreateIngressWithAnnotation("mysvc2", ingressDomain, fakeExternalIP, ttl, &routingPolicy, nil)
@@ -53,6 +54,7 @@ var _ = Describe("IngressAnnotation", func() {
 		Ω(entry.Spec.TTL).ShouldNot(BeNil())
 		Ω(*entry.Spec.TTL).Should(Equal(int64(ttl)))
 		Ω(entry.Spec.OwnerId).Should(BeNil())
+		Ω(entry.Annotations["dns.gardener.cloud/ip-stack"]).Should(Equal("dual-stack"))
 
 		entryObj2, err := testEnv.AwaitObjectByOwner("Ingress", ingress2.GetName())
 		entry2 := UnwrapEntry(entryObj2)
@@ -63,6 +65,7 @@ var _ = Describe("IngressAnnotation", func() {
 			SetIdentifier: "my-id",
 			Parameters:    map[string]string{"weight": "10"},
 		}))
+		Ω(entry2.Annotations["dns.gardener.cloud/ip-stack"]).Should(Equal(""))
 
 		entryObj3, err := testEnv.AwaitObjectByOwner("Ingress", ingress3.GetName())
 		Ω(err).ShouldNot(HaveOccurred())

--- a/test/integration/serviceAnnotation_test.go
+++ b/test/integration/serviceAnnotation_test.go
@@ -34,7 +34,8 @@ var _ = Describe("ServiceAnnotation", func() {
 		status := &v1.LoadBalancerIngress{IP: fakeExternalIP}
 		svcDomain := "mysvc." + domain
 		ttl := 456
-		svc, err := testEnv.CreateServiceWithAnnotation("mysvc", svcDomain, status, ttl, nil, nil)
+		svc, err := testEnv.CreateServiceWithAnnotation("mysvc", svcDomain, status, ttl, nil,
+			map[string]string{"service.beta.kubernetes.io/aws-load-balancer-ip-address-type": "dualstack"})
 		Ω(err).ShouldNot(HaveOccurred())
 		routingPolicy := `{"type": "weighted", "setIdentifier": "my-id", "parameters": {"weight": "10"}}`
 		svcDomain2 := "mysvc2." + domain
@@ -70,6 +71,7 @@ var _ = Describe("ServiceAnnotation", func() {
 		Ω(entry.Spec.OwnerId).Should(BeNil())
 		Ω(entry.Spec.TTL).ShouldNot(BeNil())
 		Ω(*entry.Spec.TTL).Should(Equal(int64(ttl)))
+		Ω(entry.Annotations["dns.gardener.cloud/ip-stack"]).Should(Equal("dual-stack"))
 
 		entryObj2, err := testEnv.AwaitObjectByOwner("Service", svc2.GetName())
 		entry2 := UnwrapEntry(entryObj2)


### PR DESCRIPTION
**What this PR does / why we need it**:
With #341, the creation of `AAAA` DNS records with alias target was introduced for `aws-route53` for AWS load balancer targets. If an `AAAA` record was needed was concluded by an DNS lookup of the target load balancer domain name.
As it turned out, using DNS lookup it is not reliable in all circumstances. Therefore the implementation was changed to rely on annotations on the source resources (services, ingresses, dnsentries) only.
Two annotations are supported for dual-stack:
- `service.beta.kubernetes.io/aws-load-balancer-ip-address-type=dualstack` (services only)
- `dns.gardener.cloud/ip-stack=dual-stack` (ingresses, dnsentries, and services)

Ipv6 only is supported with the annotation `dns.gardener.cloud/ip-stack=ipv6`

The PR also fixes the problem with sporadic orphan `AAAA` records, if DNS lookup on creation and deletion returned different results.

**Which issue(s) this PR fixes**:
Fixes #349

**Special notes for your reviewer**:
Replaces implementation based on DNS lookup: #341 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
[aws-route53] Support dual-stack AWS load balancers by creating additional AAAA record with alias target if annotation `service.beta.kubernetes.io/aws-load-balancer-ip-address-type=dualstack` (services only) or `dns.gardener.cloud/ip-stack=dual-stack` (ingresses,dnsentries, and services) is set.
```
