### PR TITLE
Merge dnsnames annotations from multiple DNSAnnotation objects

### DIFF
--- a/pkg/dns/const.go
+++ b/pkg/dns/const.go
@@ -29,6 +29,7 @@ const (
 	CLASS_ANNOTATION            = ANNOTATION_GROUP + "/class"
 	REALM_ANNOTATION            = ANNOTATION_GROUP + "/realms"
 	NOT_RATE_LIMITED_ANNOTATION = ANNOTATION_GROUP + "/not-rate-limited"
+	DNS_ANNOTATION              = ANNOTATION_GROUP + "/dnsnames"
 )
 
 const OPT_SETUP = "setup"

--- a/pkg/dns/source/controller.go
+++ b/pkg/dns/source/controller.go
@@ -43,7 +43,7 @@ const (
 )
 
 const (
-	DNS_ANNOTATION            = dns.ANNOTATION_GROUP + "/dnsnames"
+	DNS_ANNOTATION            = dns.DNS_ANNOTATION
 	TTL_ANNOTATION            = dns.ANNOTATION_GROUP + "/ttl"
 	PERIOD_ANNOTATION         = dns.ANNOTATION_GROUP + "/cname-lookup-interval"
 	ROUTING_POLICY_ANNOTATION = dns.ANNOTATION_GROUP + "/routing-policy"

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -75,7 +75,7 @@ var _ = BeforeSuite(func() {
 	args := []string{
 		"--kubeconfig", kubeconfigFile,
 		"--identifier", "integrationtest",
-		"--controllers", "dnscontrollers,dnssources",
+		"--controllers", "dnscontrollers,dnssources,annotation",
 		"--remote-access-port", "50051",
 		"--remote-access-cacert", testCerts.caCert,
 		"--remote-access-server-secret-name", testCerts.secretName,


### PR DESCRIPTION
**What this PR does / why we need it**:
DNS "source" object, such as Service or Ingress, can be annotated in two ways: directly or through `DNSAnnotation` resources.
With the current behaviour, if multiple DNSAnnotation resources reference the same source object and use the same annotation key, only the value from the most recent DNSAnnotation resource will be used. This was implemented as a kind of conflict resolution, but is not optimal for the `dns.gardener.cloud/dnsnames` annotation.

This proposed change ensures that all `dns.gardener.cloud/dnsnames` from all sources, particularly from multiple DNSAnnotation resources, are combined and applied. This means that instead of only considering the most recent DNSAnnotation, all of them will now be considered.

**Which issue(s) this PR fixes**:
Fixes #351 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Merge `dns.gardener.cloud/dnsnames` annotations from multiple DNSAnnotation objects.
```
