### PR TITLE
Bump golang to 1.21.6

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -2,14 +2,14 @@ external-dns-management:
   base_definition:
     steps:
       build:
-        image: golang:1.21.5
+        image: golang:1.21.6
         output_dir: binary
       check:
-        image: golang:1.21.5
+        image: golang:1.21.6
       integrationtest:
-        image: golang:1.21.5
+        image: golang:1.21.6
       test:
-        image: golang:1.21.5
+        image: golang:1.21.6
     traits:
       publish:
         dockerimages:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 #############      builder       #############
-FROM golang:1.21.5 AS builder
+FROM golang:1.21.6 AS builder
 
 WORKDIR /build
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps golang from 1.21.5 to 1.21.6.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
**Release note**:
```other operator
Bumps golang from 1.21.5 to 1.21.6.
```
