### PR TITLE
ignore services with star dnsname

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190603021944-12ad9f921c0b
 	github.com/aws/aws-sdk-go v1.44.173
 	github.com/cloudflare/cloudflare-go v0.11.4
-	github.com/gardener/controller-manager-library v0.2.1-0.20231213134107-496e1a49d791
+	github.com/gardener/controller-manager-library v0.2.1-0.20240214101453-c2ba8556a43a
 	github.com/go-openapi/runtime v0.24.1
 	github.com/go-openapi/strfmt v0.21.2
 	github.com/gophercloud/gophercloud v0.24.0
@@ -120,6 +120,7 @@ require (
 	go.mongodb.org/mongo-driver v1.8.3 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.17.0 // indirect
+	golang.org/x/lint v0.0.0-20190930215403-16217165b5de // indirect
 	golang.org/x/mod v0.13.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -141,8 +141,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
-github.com/gardener/controller-manager-library v0.2.1-0.20231213134107-496e1a49d791 h1:Neqc/RIUyM8sQx3+VgIA+OGA/iOfZ90R5wD67m5mE4k=
-github.com/gardener/controller-manager-library v0.2.1-0.20231213134107-496e1a49d791/go.mod h1:aepVXNhGH90BjVr9IGDACutA2Kqy9/2rqZZuE2FqJMo=
+github.com/gardener/controller-manager-library v0.2.1-0.20240214101453-c2ba8556a43a h1:G01XkSBEO2QERVxPrqiYvDRuc/hRSPmcMngoQvx6S+o=
+github.com/gardener/controller-manager-library v0.2.1-0.20240214101453-c2ba8556a43a/go.mod h1:CeIcbuj7B+dEy2QJlPaMPPqGibnV3MS8stOpDM/6w8s=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
@@ -642,6 +642,8 @@ golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQz
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=
+golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=

--- a/pkg/controller/source/gateways/gatewayapi/handler.go
+++ b/pkg/controller/source/gateways/gatewayapi/handler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	gatewayapisv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapisv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -200,7 +201,7 @@ func newServiceLister(c controller.Interface) (*httprouteLister, error) {
 }
 
 func (l *httprouteLister) ListHTTPRoutes(gateway *resources.ObjectName) ([]resources.ObjectData, error) {
-	objs, err := l.httprouteResources.ListCached(nil)
+	objs, err := l.httprouteResources.List(metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/source/gateways/istio/handler.go
+++ b/pkg/controller/source/gateways/istio/handler.go
@@ -295,7 +295,7 @@ func (s *stdResourceLister) GetIngress(name resources.ObjectName) (resources.Obj
 }
 
 func (s *stdResourceLister) ListVirtualServices(gateway *resources.ObjectName) ([]resources.ObjectData, error) {
-	objs, err := s.virtualServicesResources.ListCached(nil)
+	objs, err := s.virtualServicesResources.List(metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/source/gateways/istio/virtualservicesReconciler.go
+++ b/pkg/controller/source/gateways/istio/virtualservicesReconciler.go
@@ -58,7 +58,7 @@ func (r *virtualservicesReconciler) Delete(logger logger.LogContext, obj resourc
 }
 
 func (r *virtualservicesReconciler) Deleted(logger logger.LogContext, key resources.ClusterObjectKey) reconcile.Status {
-	gateways := r.state.MatchingGatewaysByTargetSource(key.ObjectKey())
+	gateways := r.state.MatchingGatewaysByVirtualService(key.ObjectName())
 	r.state.RemoveVirtualService(key.ObjectName())
 	r.triggerGateways(key.Cluster(), resources.NewObjectNameSetByArray(gateways))
 	return reconcile.Succeeded(logger)

--- a/pkg/controller/source/service/handler.go
+++ b/pkg/controller/source/service/handler.go
@@ -35,6 +35,13 @@ func GetTargets(_ logger.LogContext, obj resources.ObjectData, names dns.DNSName
 		}
 		return nil, fmt.Errorf("service is not of type LoadBalancer")
 	}
+	if len(names) == 1 {
+		for name := range names {
+			if name.DNSName == "*" {
+				return nil, nil
+			}
+		}
+	}
 	ipstack := ""
 	set := utils.StringSet{}
 	for _, i := range svc.Status.LoadBalancer.Ingress {


### PR DESCRIPTION
**What this PR does / why we need it**:
For Gateway API gateways, Istio creates a service of type loadbalancer and copies all annotations from the gateway object. To avoid handling this service as a source object, services with annotation `dns.gardener.cloud/dnsnames='*'` are ignore.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Ignore generated load balancer services of gateways.
```

```bugfix operator
Uncached listing of virtual services and httproutes
```