### PR TITLE
Registry k8s-gateways in version v1beta1

### DIFF
--- a/cmd/compound/main.go
+++ b/cmd/compound/main.go
@@ -22,6 +22,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	gatewayapisv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapisv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapisv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	_ "github.com/gardener/external-dns-management/pkg/controller/annotation/annotations"
@@ -70,6 +71,7 @@ func init() {
 	resources.Register(istionetworkingv1alpha3.SchemeBuilder)
 	resources.Register(istionetworkingv1beta1.SchemeBuilder)
 	resources.Register(gatewayapisv1alpha2.SchemeBuilder)
+	resources.Register(gatewayapisv1beta1.SchemeBuilder)
 	resources.Register(gatewayapisv1.SchemeBuilder)
 
 	embed.RegisterCreateServerFunc(remote.CreateServer)

--- a/pkg/controller/source/gateways/gatewayapi/httproutesReconciler.go
+++ b/pkg/controller/source/gateways/gatewayapi/httproutesReconciler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	gatewayapisv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapisv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayapisv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func HTTPRoutesReconciler(c controller.Interface) (reconcile.Interface, error) {
@@ -60,6 +61,17 @@ func extractGatewayNames(route resources.ObjectData) resources.ObjectNameSet {
 	gatewayNames := resources.NewObjectNameSet()
 	switch data := route.(type) {
 	case *gatewayapisv1.HTTPRoute:
+		for _, ref := range data.Spec.ParentRefs {
+			if (ref.Group == nil || string(*ref.Group) == GroupKindGateway.Group) &&
+				(ref.Kind == nil || string(*ref.Kind) == GroupKindGateway.Kind) {
+				namespace := data.Namespace
+				if ref.Namespace != nil {
+					namespace = string(*ref.Namespace)
+				}
+				gatewayNames.Add(resources.NewObjectName(namespace, string(ref.Name)))
+			}
+		}
+	case *gatewayapisv1beta1.HTTPRoute:
 		for _, ref := range data.Spec.ParentRefs {
 			if (ref.Group == nil || string(*ref.Group) == GroupKindGateway.Group) &&
 				(ref.Kind == nil || string(*ref.Kind) == GroupKindGateway.Kind) {


### PR DESCRIPTION
**What this PR does / why we need it**:
The scheme for the apigroup `gateway.networking.k8s.io` version `v1beta1` is missing and could cause that the `dnssources` controller crash on startup with 

```
creating reconciler default failed: gardener/cml/resources/NON_UNIQUE_MAPPING: non unique version mapping for HTTPRoute.gateway.networking.k8s.io
```

This PR fixes the issue.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Registry `gateway.networking.k8s.io` in version v1beta1
```
