### PR TITLE
Update Cloudflare README.md to remove information about base64-encoding

### DIFF
--- a/docs/cloudflare/README.md
+++ b/docs/cloudflare/README.md
@@ -1,6 +1,6 @@
 # Cloudflare DNS Provider
 
-This DNS provider allows you to create and manage DNS entries in Cloudlfare. 
+This DNS provider allows you to create and manage DNS entries in Clouldflare. 
 
 ## Generate API Tokens
 

--- a/docs/cloudflare/README.md
+++ b/docs/cloudflare/README.md
@@ -18,6 +18,7 @@ all zones. Optionally you can exclude certain zones.
 
 ![API token creation](api-token-creation.png)
 
+Generate the token and keep this key safe as it won't be shown again.
 ## Using the API Token
 
 Use the token in a `Secret` resource with the `metadata.name` to be 

--- a/docs/cloudflare/README.md
+++ b/docs/cloudflare/README.md
@@ -18,20 +18,10 @@ all zones. Optionally you can exclude certain zones.
 
 ![API token creation](api-token-creation.png)
 
-Generate the token and keep this key safe as it won't be shown again.
-
-Then base64 encode the token. For eg. if the generated token in `1234567890123456`, use
-
-```bash
-$ echo -n '1234567890123456789' | base64
-```
-
-to get the base64 encoded token. In this eg. this would be `MTIzNDU2Nzg5MDEyMzQ1Njc4OQ==`.
-
 ## Using the API Token
 
-Use the base64 encoded token in a `Secret` resource with the `metadata.name` to be 
-`cloudflare-credentials` and `data.CLOUDFLARE_API_TOKEN` to be the base64 encoded token.
+Use the token in a `Secret` resource with the `metadata.name` to be 
+`cloudflare-credentials` and `data.CLOUDFLARE_API_TOKEN` to be the token.
 
 ```yaml
 apiVersion: v1
@@ -41,7 +31,7 @@ metadata:
   namespace: default
 type: Opaque
 data:
-  CLOUDFLARE_API_TOKEN: MTIzNDU2Nzg5MDEyMzQ1Njc4OQ==
+  CLOUDFLARE_API_TOKEN: 1234567890123456789
 ``` 
 
 ## Troubleshooting
@@ -49,4 +39,3 @@ data:
 * If you get a permission error communicating with Cloudflare, be sure the domain name 
   being registered does not exceed your plan limits. Hierarchical domains are not
   supported on the free plan as of this writing.
-  

--- a/docs/cloudflare/README.md
+++ b/docs/cloudflare/README.md
@@ -31,7 +31,7 @@ metadata:
   name: cloudflare-credentials
   namespace: default
 type: Opaque
-data:
+stringData:
   CLOUDFLARE_API_TOKEN: 1234567890123456789
 ``` 
 

--- a/docs/cloudflare/README.md
+++ b/docs/cloudflare/README.md
@@ -1,6 +1,6 @@
 # Cloudflare DNS Provider
 
-This DNS provider allows you to create and manage DNS entries in Clouldflare. 
+This DNS provider allows you to create and manage DNS entries in Cloudflare. 
 
 ## Generate API Tokens
 


### PR DESCRIPTION
**What this PR does / why we need it**: The documentation for the secret is wrong and those following it will not be able to set up external DNS management for Cloudflare.

**Which issue(s) this PR fixes**:
Fixes #360

**Special notes for your reviewer**: I fixed a typo as well. Also, I want to be sure my issue #360 is validated prior to merging this to ensure I don't screw things up.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
Revised Cloudflare External DNS Management document to no longer recommend base64 encoding of the token in the secret.
```
