### PR TITLE
Fix panic if source object referenced by a DNSAnnotation object has no annotations

### DIFF
--- a/pkg/dns/source/dnsinfo.go
+++ b/pkg/dns/source/dnsinfo.go
@@ -108,7 +108,7 @@ func (this *sourceReconciler) enrichAnnotations(logger logger.LogContext, obj re
 	addons := this.annotations.GetInfoFor(obj.ClusterKey())
 	if len(addons) > 0 {
 		obj = obj.DeepCopy()
-		annos := obj.GetAnnotations()
+		annos := getSafeMap(obj.GetAnnotations())
 
 		annotatedNames := utils.StringSet{}
 		annotatedNames.AddAllSplittedSelected(annos[DNS_ANNOTATION], utils.StandardNonEmptyStringElement)
@@ -131,4 +131,11 @@ func (this *sourceReconciler) enrichAnnotations(logger logger.LogContext, obj re
 		obj.SetAnnotations(annos)
 	}
 	return obj
+}
+
+func getSafeMap(m map[string]string) map[string]string {
+	if m == nil {
+		return map[string]string{}
+	}
+	return m
 }

--- a/pkg/dns/source/reconciler.go
+++ b/pkg/dns/source/reconciler.go
@@ -564,10 +564,7 @@ func (this *sourceReconciler) updateEntryFor(logger logger.LogContext, obj resou
 			logger.Infof("ignoring empty targets for entry %s", slave.ObjectName())
 		}
 		if info.IPStack != "" {
-			annots := o.GetAnnotations()
-			if annots == nil {
-				annots = map[string]string{}
-			}
+			annots := getSafeMap(o.GetAnnotations())
 			if annots[dns.AnnotationIPStack] != info.IPStack {
 				annots[dns.AnnotationIPStack] = info.IPStack
 				o.SetAnnotations(annots)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a panic ""assignment to entry in nil map" (assignment to entry in nil map)", if a DNS source object like a service or ingress object has no own annotations, but is referenced by a `DNSAnnotation` object.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fix panic if source object referenced by a DNSAnnotation object has no annotations in its metadata.
```
