### PR TITLE
Keep stale entries untouched if last valid providers is removed

### DIFF
--- a/pkg/dns/provider/entry.go
+++ b/pkg/dns/provider/entry.go
@@ -442,7 +442,7 @@ func validateOwner(_ logger.LogContext, state *state, entry *EntryVersion) error
 	return nil
 }
 
-func (this *EntryVersion) Setup(logger logger.LogContext, state *state, p *EntryPremise, op string, err error, config Config, _ *Entry) reconcile.Status {
+func (this *EntryVersion) Setup(logger logger.LogContext, state *state, p *EntryPremise, op string, err error, config Config) reconcile.Status {
 	hello := dnsutils.NewLogMessage("%s ENTRY: %s, zoneid: %s, handler: %s, provider: %s, ref %+v", op, this.Object().BaseStatus().State, p.zoneid, p.ptype, Provider(p.provider), this.Object().GetReference())
 
 	this.valid = false

--- a/pkg/dns/provider/state_provider.go
+++ b/pkg/dns/provider/state_provider.go
@@ -247,14 +247,17 @@ func (this *state) removeLocalProvider(logger logger.LogContext, obj *dnsutils.D
 				providers := this.getProvidersForZone(zoneid)
 				if len(providers) == 1 {
 					// if this is the last provider for this zone
-					// it must be cleanuped before the provider is gone
+					// it must be cleaned up before the provider is gone
 					logger.Infof("provider is exclusively handling zone %q -> cleanup", zoneid)
+
+					// collect stale entries to keep them untouched
+					_, _, stale, _ := this.addEntriesForZone(logger, nil, nil, z)
 
 					done, err := this.StartZoneReconcilation(logger, &zoneReconciliation{
 						zone:      z,
 						providers: providers,
 						entries:   Entries{},
-						stale:     nil,
+						stale:     stale,
 						dedicated: false,
 						deleting:  false,
 						fhandler:  this.context,

--- a/pkg/dns/provider/state_zone.go
+++ b/pkg/dns/provider/state_zone.go
@@ -25,12 +25,6 @@ import (
 // state handling for zone reconcilation
 ////////////////////////////////////////////////////////////////////////////////
 
-func (this *state) TriggerHostedZone(zoneid dns.ZoneID) {
-	this.lock.Lock()
-	defer this.lock.Unlock()
-	this.triggerHostedZone(zoneid)
-}
-
 func (this *state) TriggerHostedZonesByChangedOwners(logger logger.LogContext, changed utils.StringSet) {
 	this.lock.Lock()
 	defer this.lock.Unlock()

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -26,6 +26,7 @@ import (
 	_ "github.com/gardener/external-dns-management/pkg/controller/source/gateways/istio"
 	_ "github.com/gardener/external-dns-management/pkg/controller/source/ingress"
 	_ "github.com/gardener/external-dns-management/pkg/controller/source/service"
+	_ "github.com/gardener/external-dns-management/pkg/server/pprof"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
@@ -76,6 +77,8 @@ var _ = BeforeSuite(func() {
 		"--remote-access-cacert", testCerts.caCert,
 		"--remote-access-server-secret-name", testCerts.secretName,
 		"--omit-lease",
+		"--enable-profiling",
+		"--server-port-http", "8080",
 		"--reschedule-delay", "15s",
 		"--lock-status-check-period", "5s",
 		"--pool.size", "10",


### PR DESCRIPTION
**What this PR does / why we need it**:
Under certain conditions the DNS records for stale `DNSEntries` could be deleted with the current behaviour:
Assume this sequence of events:
1. There are several providers for the same zone in various namespaces using the same credentials.
2. For some reason the credentials become invalid.
3. All providers go to state 'Error', and related 'DNSEntries' to state 'Stale'.
4. Now the secret for one provider is fixed, and this provider is back to state `Ready`.
5. The ready provider is deleted.
6. As it is the last usable provider, a zone reconciliation is started to cleanup orphan DNS records. As a side-effect all DNS records belonging the stale `DNSEntries` from other providers with invalid state are deleted, too.

To avoid this situation, the cleanup zone reconciliation in this case now considers all stale `DNSEntries` and keeps them untouched.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
8. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Keep stale entries of other providers of the same zone untouched if all providers but one have invalid credentials and last valid provider is removed.
```
