### PR TITLE
Update golang to 1.22.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 #############      builder       #############
-FROM golang:1.22.2 AS builder
+FROM golang:1.22.3 AS builder
 
 WORKDIR /build
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Update golang from `1.22.2` to `1.22.3`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update golang from `1.22.2` to `1.22.3`
```
