### PR TITLE
[docu] [RFC2136]: server port is optional

### DIFF
--- a/docs/rfc2136/README.md
+++ b/docs/rfc2136/README.md
@@ -62,7 +62,7 @@ metadata:
 type: Opaque
 data:
   # replace '...' with values encoded as base64
-  Server: ... # "<host>:<port>" of the authorive DNS server
+  Server: ... # "<host>[:<port>]" of the authorive DNS server, default port is 53
   TSIGKeyName: ... # key name of the TSIG secret (must end with a dot)
   TSIGSecret: ... # TSIG secret
   Zone: ... # zone (must be fully qualified)

--- a/examples/20-secret-rfc2136-credentials.yaml
+++ b/examples/20-secret-rfc2136-credentials.yaml
@@ -6,7 +6,7 @@ metadata:
 type: Opaque
 data:
   # Replace '...' with values encoded as base64.
-  Server: ... # "<host>:<port>" of the authorive DNS server
+  Server: ... # "<host>[:<port>]" of the authorive DNS server, default port is 53
   TSIGKeyName: ... # key name of the TSIG secret (must end with a dot)
   TSIGSecret: ... # TSIG secret
   Zone: ... # zone (must be fully qualified)


### PR DESCRIPTION
**What this PR does / why we need it**:
Updated documentation of provider type RFC 2136, that port is optional.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
