### PR TITLE
Background processing for address lookups of CNAME replacements

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ To install the <b>DNS controller manager</b> in your Kubernetes cluster, follow 
    ```
 
 For more examples about the custom resources and the annotations for services and ingresses
-see the `examples` directory.
+see the [examples](examples/) directory and [translation of `DNSEntries` examples](docs/usage/dnsentry_translation.md)
 
 ### Automatic creation of DNS entries for services and ingresses
 

--- a/charts/external-dns-management/templates/crds.yaml
+++ b/charts/external-dns-management/templates/crds.yaml
@@ -101,7 +101,8 @@ spec:
             properties:
               cnameLookupInterval:
                 description: lookup interval for CNAMEs that must be resolved to IP
-                  addresses
+                  addresses. Only used if `resolveTargetsToAddresses` is set to true
+                  or targets consists of multiple domain names.
                 format: int64
                 type: integer
               dnsName:
@@ -122,6 +123,12 @@ spec:
                 required:
                 - name
                 type: object
+              resolveTargetsToAddresses:
+                description: enables translation of a target domain name in the resolved
+                  IPv4 and IPv6 addresses. If enabled, `A` and/or `AAAA` records are
+                  created instead of a `CNAME` record. If the target list contains
+                  multiple targets, it is enabled implicitly.
+                type: boolean
               routingPolicy:
                 description: optional routing policy
                 properties:
@@ -162,6 +169,11 @@ spec:
             type: object
           status:
             properties:
+              cnameLookupInterval:
+                description: effective lookup interval for CNAMEs that must be resolved
+                  to IP addresses
+                format: int64
+                type: integer
               lastUpdateTime:
                 description: lastUpdateTime contains the timestamp of the last status
                   update

--- a/docs/usage/dnsentry_status.md
+++ b/docs/usage/dnsentry_status.md
@@ -4,15 +4,16 @@ This document provides an overview of the status section of a DNSEntry resource.
 
 ### Fields
 
-| Field name           | Description                                                                                                        |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `state`              | Indicates the state of the DNSEntry. Details see below.                                                            |
-| `lastUpdateTime`     | Timestamp for when the status was updated. Usually changes when any relevant status field like `state`, `message`, `provider`, or `targets` is updated. |
-| `message`            | Human-readable message indicating details about the last status transition.                                        |
-| `provider`           | Shows the DNS provider assigned to this entry.                                                                     |
-| `providerType`       | Shows the DNS provider type assigned to this entry.                                                                |
-| `targets`            | Shows the stored targets or text of the DNS record in the backend service.                                         |
-| `ttl`                | Shows the stored TTL value of the DNS record in the backend service.                                               |
+| Field name             | Description                                                                                                                                             |
+|------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `state`                | Indicates the state of the DNSEntry. Details see below.                                                                                                 |
+| `cnameLookupInterval`  | Shows effective lookup interval for targets domain names to be resolved to IP addresses. Only provided if lookups are active for this entry.            |
+| `lastUpdateTime`       | Timestamp for when the status was updated. Usually changes when any relevant status field like `state`, `message`, `provider`, or `targets` is updated. |
+| `message`              | Human-readable message indicating details about the last status transition.                                                                             |
+| `provider`             | Shows the DNS provider assigned to this entry.                                                                                                          |
+| `providerType`         | Shows the DNS provider type assigned to this entry.                                                                                                     |
+| `targets`              | Shows the stored targets or text of the DNS record in the backend service.                                                                              |
+| `ttl`                  | Shows the stored TTL value of the DNS record in the backend service.                                                                                    |
 
 Currently the available states are:
 

--- a/docs/usage/dnsentry_translation.md
+++ b/docs/usage/dnsentry_translation.md
@@ -1,0 +1,185 @@
+# DNSEntry Translation into DNS records
+
+## Creating `A` and/or `AAAA` records
+
+To create an `A` and/or `AAAA` DNS records, the spec of the `DNSEntry` must contains a list of IP addresses as targets.
+
+Example:
+```yaml
+apiVersion: dns.gardener.cloud/v1alpha1
+kind: DNSEntry
+metadata:
+  name: myentry-a
+  namespace: default
+spec:
+  dnsName: "myentry-a.my-own-domain.com"
+  targets:
+  - 1.2.3.4
+  - 1.2.3.5
+  - 2abc:1234:5678::42
+  ttl: 600 # optional to set TTL
+```
+
+Two DNS records are created, as can be checked with nslookup:
+```bash
+$ nslookup -type=A myentry-a.my-own-domain.com
+...
+Non-authoritative answer:
+Name:	myentry-a.my-own-domain.com
+Address: 1.2.3.4
+Name:	myentry-a.my-own-domain.com
+Address: 1.2.3.5
+
+$ nslookup -type=AAAA myentry-a.my-own-domain.com
+...
+Non-authoritative answer:
+myentry-a.dnstest.my-own-domain.com	has AAAA address 2abc:1234:5678::42
+```
+
+## Creating a `CNAME` record
+
+To create a `CNAME` DNS record, the target list of the `DNSEntry` must contain exactly one domain name.
+
+Example:
+```yaml
+apiVersion: dns.gardener.cloud/v1alpha1
+kind: DNSEntry
+metadata:
+  name: myentry-cname
+  namespace: default
+spec:
+  dnsName: "myentry-cname.my-own-domain.com"
+  targets:
+  - mytarget.my-own-domain.com
+  ttl: 600 # optional to set TTL
+```
+
+A `CNAME` DNS record is created as expected:
+```bash
+$ nslookup -type=CNAME myentry-cname.my-own-domain.com
+...
+Non-authoritative answer:
+myentry-cname.my-own-domain.com	canonical name = mytarget.my-own-domain.com.
+```
+
+## Creating `TXT` record
+
+To create a `TXT` DNS record, the texts list of the `DNSEntry` contains the text values.
+
+Example:
+```yaml
+apiVersion: dns.gardener.cloud/v1alpha1
+kind: DNSEntry
+metadata:
+  name: myentry-txt
+  namespace: default
+spec:
+  dnsName: "myentry-txt.my-own-domain.com"
+  text:
+  - "first value"
+  - "second value"
+  ttl: 600 # optional to set TTL
+```
+
+`TXT` DNS records are created as expected:
+```bash
+$ nslookup -type=TXT myentry-txt.my-own-domain.com
+...
+Non-authoritative answer:
+  myentry-txt.my-own-domain.com	text = "first value"
+  myentry-txt.my-own-domain.com	text = "second value"
+```
+
+## Creating `A`/`AAAA` records for multiple domain names 
+
+This is a feature to provide a `CNAME` like behaviour for multiple domain names.
+The `.spec.targets` list of the `DNSEntry` contains multiple DNS names in this case.
+These names are looked up periodically and resolved into their IPv6 an IPv4 addresses.
+
+Example:
+```yaml
+apiVersion: dns.gardener.cloud/v1alpha1
+kind: DNSEntry
+metadata:
+  name: myentry-multi-cname
+  namespace: default
+spec:
+  dnsName: "myentry-multi-cname.my-own-domain.com"
+  targets:
+  - wikipedia.org
+  - wikipedia.de
+  ttl: 600 # optional to set TTL
+  cnameLookupInterval: 200 # optional to specify lookup internal to resolve the DNS names
+```
+
+As `wikipedia.org` resolves to `185.15.59.224` and `2a02:ec80:300:ed1a::1` and
+`wikipedia.de` to `49.13.55.174` and `2a01:4f8:c012:3f0a::1` (at time of running this example),
+you will get these `A` and `AAAA` DNS records:
+```bash
+$ nslookup -type=A myentry-multi-cname.my-own-domain.com
+...
+Non-authoritative answer:
+Name:	myentry-multi-cname.my-own-domain.com
+Address: 185.15.59.224
+Name:	myentry-multi-cname.my-own-domain.com
+Address: 49.13.55.174
+
+$ nslookup -type=AAAA myentry-multi-cname.my-own-domain.com
+...
+Non-authoritative answer:
+myentry-multi-cname.my-own-domain.com	has AAAA address 2a02:ec80:300:ed1a::1
+myentry-multi-cname.my-own-domain.com	has AAAA address 2a01:4f8:c012:3f0a::1
+```
+
+> [!NOTE] 
+> Using this feature creates reoccuring work load on the dns-controller-manager as the target domain names
+> need to be looked up periodically. If the target addressed have changed, the addresses in the created `A`/`AAAA` records
+> will be updated automatically. As two more steps are involved, some additional time is needed until your DNS clients will 
+> see such changes in comparison with setting the addresses directly as targets.
+> The scheduled DNS lookups happen roughly at the set intervals, but timing depends on cluster load and upstream DNS responsiveness.
+> Also be aware that this feature can only be used for domain names visible to the dns-controller-manager.
+
+## Creating `A`/`AAAA` records for single domain name
+
+This is a special feature to avoid a `CNAME` record and resolving the domain name into addresses.
+The `.spec.targets` list of the `DNSEntry` contains a single DNS name in this case.
+These name is looked up periodically and resolved into its current IPv6 an IPv4 addresses.
+
+Example:
+```yaml
+apiVersion: dns.gardener.cloud/v1alpha1
+kind: DNSEntry
+metadata:
+  name: myentry-no-cname
+  namespace: default
+spec:
+  dnsName: "myentry-no-cname.my-own-domain.com"
+  targets:
+  - wikipedia.org
+  resolveTargetsToAddresses: true # this field is needed to distinguish from CNAME record creation
+  ttl: 600 # optional to set TTL
+  cnameLookupInterval: 200 # optional to specify lookup internal to resolve the DNS names
+```
+
+As `wikipedia.org` resolves to `185.15.59.224` and `2a02:ec80:300:ed1a::1` (at time of running this example),
+you will get these `A` and `AAAA` DNS records:
+```bash
+$  nslookup -type=A myentry-no-cname.my-own-domain.com
+...
+Non-authoritative answer:
+Name:	myentry-no-cname.my-own-domain.com
+Address: 185.15.59.224
+
+$ nslookup -type=AAAA myentry-no-cname.my-own-domain.com
+...
+Non-authoritative answer:
+myentry-no-cname.my-own-domain.com	has AAAA address 2a02:ec80:300:ed1a::1
+```
+
+> [!NOTE]
+> Using this feature creates reoccuring work load on the dns-controller-manager as the target domain names
+> need to be looked up periodically. If the target addressed have changed, the addresses in the created `A`/`AAAA` records
+> will be updated automatically. As two more steps are involved, some additional time is needed until your DNS clients will
+> see such changes in comparison with setting the addresses directly as targets.
+> The scheduled DNS lookups happen roughly at the set intervals, but timing depends on cluster load and upstream DNS responsiveness.
+> Also be aware that this feature can only be used for domain names visible to the dns-controller-manager.

--- a/examples/43-entry-resolve-to-addresses.yaml
+++ b/examples/43-entry-resolve-to-addresses.yaml
@@ -1,0 +1,15 @@
+apiVersion: dns.gardener.cloud/v1alpha1
+kind: DNSEntry
+metadata:
+  annotations:
+    # If you are delegating the DNS management to Gardener, uncomment the following line (see https://gardener.cloud/documentation/guides/administer_shoots/dns_names/)
+    #dns.gardener.cloud/class: garden
+  name: resolve-to-a
+  namespace: default
+spec:
+  dnsName: my.domain-name.example.com
+  ttl: 600
+  cnameLookupInterval: 30
+  resolveTargetsToAddresses: true # if this flag is set, the target name will be resolved and A/AAAA records will be created instead of an CNAME.
+  targets:
+  - my.domain-name.example.com

--- a/examples/50-ingress-with-dns.yaml
+++ b/examples/50-ingress-with-dns.yaml
@@ -10,6 +10,7 @@ metadata:
     #dns.gardener.cloud/ttl: "500"
     #dns.gardener.cloud/owner-id: second
     #dns.gardener.cloud/ip-stack: dual-stack     # AWS-route 53 only: enable both A and AAAA alias targets
+    #dns.gardener.cloud/resolve-targets-to-addresses: "true"
   name: test-ingress
   namespace: default
 spec:

--- a/examples/50-service-with-dns.yaml
+++ b/examples/50-service-with-dns.yaml
@@ -9,6 +9,7 @@ metadata:
     #dns.gardener.cloud/owner-id: second
     #service.beta.kubernetes.io/aws-load-balancer-ip-address-type: dualstack   # AWS-route 53 only: enable both A and AAAA alias targets
     #dns.gardener.cloud/ip-stack: dual-stack                                   # AWS-route 53 only: alternative way to enable A and AAAA alias targets
+    #dns.gardener.cloud/resolve-targets-to-addresses: "true"
   name: test-service
   namespace: default
 spec:

--- a/pkg/apis/dns/crds/dns.gardener.cloud_dnsentries.yaml
+++ b/pkg/apis/dns/crds/dns.gardener.cloud_dnsentries.yaml
@@ -95,7 +95,8 @@ spec:
             properties:
               cnameLookupInterval:
                 description: lookup interval for CNAMEs that must be resolved to IP
-                  addresses
+                  addresses. Only used if `resolveTargetsToAddresses` is set to true
+                  or targets consists of multiple domain names.
                 format: int64
                 type: integer
               dnsName:
@@ -116,6 +117,12 @@ spec:
                 required:
                 - name
                 type: object
+              resolveTargetsToAddresses:
+                description: enables translation of a target domain name in the resolved
+                  IPv4 and IPv6 addresses. If enabled, `A` and/or `AAAA` records are
+                  created instead of a `CNAME` record. If the target list contains
+                  multiple targets, it is enabled implicitly.
+                type: boolean
               routingPolicy:
                 description: optional routing policy
                 properties:
@@ -156,6 +163,11 @@ spec:
             type: object
           status:
             properties:
+              cnameLookupInterval:
+                description: effective lookup interval for CNAMEs that must be resolved
+                  to IP addresses
+                format: int64
+                type: integer
               lastUpdateTime:
                 description: lastUpdateTime contains the timestamp of the last status
                   update

--- a/pkg/apis/dns/crds/zz_generated_crds.go
+++ b/pkg/apis/dns/crds/zz_generated_crds.go
@@ -214,7 +214,8 @@ spec:
             properties:
               cnameLookupInterval:
                 description: lookup interval for CNAMEs that must be resolved to IP
-                  addresses
+                  addresses. Only used if ` + "`" + `resolveTargetsToAddresses` + "`" + ` is set to true
+                  or targets consists of multiple domain names.
                 format: int64
                 type: integer
               dnsName:
@@ -235,6 +236,12 @@ spec:
                 required:
                 - name
                 type: object
+              resolveTargetsToAddresses:
+                description: enables translation of a target domain name in the resolved
+                  IPv4 and IPv6 addresses. If enabled, ` + "`" + `A` + "`" + ` and/or ` + "`" + `AAAA` + "`" + ` records are
+                  created instead of a ` + "`" + `CNAME` + "`" + ` record. If the target list contains
+                  multiple targets, it is enabled implicitly.
+                type: boolean
               routingPolicy:
                 description: optional routing policy
                 properties:
@@ -275,6 +282,11 @@ spec:
             type: object
           status:
             properties:
+              cnameLookupInterval:
+                description: effective lookup interval for CNAMEs that must be resolved
+                  to IP addresses
+                format: int64
+                type: integer
               lastUpdateTime:
                 description: lastUpdateTime contains the timestamp of the last status
                   update

--- a/pkg/apis/dns/v1alpha1/dnsentry.go
+++ b/pkg/apis/dns/v1alpha1/dnsentry.go
@@ -58,9 +58,15 @@ type DNSEntrySpec struct {
 	// time to live for records in external DNS system
 	// +optional
 	TTL *int64 `json:"ttl,omitempty"`
-	// lookup interval for CNAMEs that must be resolved to IP addresses
+	// lookup interval for CNAMEs that must be resolved to IP addresses.
+	// Only used if `resolveTargetsToAddresses` is set to true or targets consists of multiple domain names.
 	// +optional
 	CNameLookupInterval *int64 `json:"cnameLookupInterval,omitempty"`
+	// enables translation of a target domain name in the resolved IPv4 and IPv6 addresses.
+	// If enabled, `A` and/or `AAAA` records are created instead of a `CNAME` record.
+	// If the target list contains multiple targets, it is enabled implicitly.
+	// +optional
+	ResolveTargetsToAddresses *bool `json:"resolveTargetsToAddresses,omitempty"`
 	// text records, either text or targets must be specified
 	// +optional
 	Text []string `json:"text,omitempty"`
@@ -80,6 +86,9 @@ type DNSEntryStatus struct {
 	// effective routing policy
 	// +optional
 	RoutingPolicy *RoutingPolicy `json:"routingPolicy,omitempty"`
+	// effective lookup interval for CNAMEs that must be resolved to IP addresses
+	// +optional
+	CNameLookupInterval *int64 `json:"cnameLookupInterval,omitempty"`
 }
 
 type DNSBaseStatus struct {

--- a/pkg/apis/dns/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/dns/v1alpha1/zz_generated.deepcopy.go
@@ -265,6 +265,11 @@ func (in *DNSEntrySpec) DeepCopyInto(out *DNSEntrySpec) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.ResolveTargetsToAddresses != nil {
+		in, out := &in.ResolveTargetsToAddresses, &out.ResolveTargetsToAddresses
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Text != nil {
 		in, out := &in.Text, &out.Text
 		*out = make([]string, len(*in))
@@ -306,6 +311,11 @@ func (in *DNSEntryStatus) DeepCopyInto(out *DNSEntryStatus) {
 		in, out := &in.RoutingPolicy, &out.RoutingPolicy
 		*out = new(RoutingPolicy)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.CNameLookupInterval != nil {
+		in, out := &in.CNameLookupInterval, &out.CNameLookupInterval
+		*out = new(int64)
+		**out = **in
 	}
 	return
 }

--- a/pkg/controller/source/dnsentry/handler.go
+++ b/pkg/controller/source/dnsentry/handler.go
@@ -46,14 +46,15 @@ func (this *DNSEntrySource) GetDNSInfo(_ logger.LogContext, obj resources.Object
 	name := dnsutils.DNSSetName(entry)
 
 	info := &source.DNSInfo{
-		Names:         dns.NewDNSNameSet(name),
-		Targets:       utils.NewStringSetByArray(entry.Spec.Targets),
-		Text:          utils.NewStringSetByArray(entry.Spec.Text),
-		OrigRef:       entry.Spec.Reference,
-		TTL:           entry.Spec.TTL,
-		Interval:      entry.Spec.CNameLookupInterval,
-		RoutingPolicy: entry.Spec.RoutingPolicy,
-		IPStack:       entry.Annotations[dns.AnnotationIPStack],
+		Names:                     dns.NewDNSNameSet(name),
+		Targets:                   utils.NewStringSetByArray(entry.Spec.Targets),
+		Text:                      utils.NewStringSetByArray(entry.Spec.Text),
+		OrigRef:                   entry.Spec.Reference,
+		TTL:                       entry.Spec.TTL,
+		Interval:                  entry.Spec.CNameLookupInterval,
+		RoutingPolicy:             entry.Spec.RoutingPolicy,
+		IPStack:                   entry.Annotations[dns.AnnotationIPStack],
+		ResolveTargetsToAddresses: entry.Spec.ResolveTargetsToAddresses,
 	}
 	return info, nil
 }

--- a/pkg/controller/source/gateways/gatewayapi/handler.go
+++ b/pkg/controller/source/gateways/gatewayapi/handler.go
@@ -82,6 +82,9 @@ func (s *gatewaySource) GetDNSInfo(_ logger.LogContext, obj resources.ObjectData
 	}
 	info.Names = dns.NewDNSNameSetFromStringSet(names, current.GetSetIdentifier())
 	info.Targets = s.getTargets(obj)
+	if v := obj.GetAnnotations()[source.RESOLVE_TARGETS_TO_ADDRS_ANNOTATION]; v != "" {
+		info.ResolveTargetsToAddresses = ptr.To(v == "true")
+	}
 	return info, nil
 }
 

--- a/pkg/controller/source/gateways/istio/handler.go
+++ b/pkg/controller/source/gateways/istio/handler.go
@@ -97,6 +97,9 @@ func (s *gatewaySource) GetDNSInfo(logger logger.LogContext, obj resources.Objec
 	}
 	info.Names = dns.NewDNSNameSetFromStringSet(names, current.GetSetIdentifier())
 	info.Targets = s.getTargets(logger, info.Names, obj)
+	if v := obj.GetAnnotations()[source.RESOLVE_TARGETS_TO_ADDRS_ANNOTATION]; v != "" {
+		info.ResolveTargetsToAddresses = ptr.To(v == "true")
+	}
 	return info, nil
 }
 

--- a/pkg/controller/source/ingress/handler.go
+++ b/pkg/controller/source/ingress/handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gardener/external-dns-management/pkg/dns/source"
 	networkingv1 "k8s.io/api/networking/v1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	"k8s.io/utils/ptr"
 )
 
 type IngressSource struct {
@@ -46,6 +47,9 @@ func (this *IngressSource) GetDNSInfo(_ logger.LogContext, obj resources.ObjectD
 	}
 	info.Names = dns.NewDNSNameSetFromStringSet(names, current.GetSetIdentifier())
 	info.IPStack = obj.GetAnnotations()[dns.AnnotationIPStack]
+	if v := obj.GetAnnotations()[source.RESOLVE_TARGETS_TO_ADDRS_ANNOTATION]; v != "" {
+		info.ResolveTargetsToAddresses = ptr.To(v == "true")
+	}
 	return info, nil
 }
 

--- a/pkg/dns/provider/lookupprocessor.go
+++ b/pkg/dns/provider/lookupprocessor.go
@@ -1,0 +1,380 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package provider
+
+import (
+	"container/heap"
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/gardener/controller-manager-library/pkg/logger"
+	"github.com/gardener/controller-manager-library/pkg/resources"
+	"github.com/gardener/external-dns-management/pkg/server/metrics"
+	"go.uber.org/atomic"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const maxConcurrentLookupsPerJob = 4
+
+// lookupHost allows to override the default lookup function for testing purposes
+var lookupHost func(string) ([]net.IP, error) = net.LookupIP
+
+type lookupJob struct {
+	objectName resources.ObjectName
+
+	lock             sync.Mutex
+	oldLookupResults lookupAllResults
+	scheduledAt      time.Time
+	interval         time.Duration
+
+	running atomic.Bool
+}
+
+func (j *lookupJob) updateWithLock(newResults lookupAllResults, interval time.Duration) bool {
+	j.lock.Lock()
+	defer j.lock.Unlock()
+	j.interval = interval
+	j.scheduledAt = time.Now().Add(interval)
+	return j.updateLookupResult(newResults)
+}
+
+// update updates lookup results and returns if resolved IP addresses have changed.
+func (j *lookupJob) updateLookupResult(newResults lookupAllResults) bool {
+	changed := !j.oldLookupResults.allIPAddrs.Equal(newResults.allIPAddrs)
+	j.oldLookupResults = newResults
+	return changed
+}
+
+type lookupQueue []*lookupJob
+
+var _ heap.Interface = &lookupQueue{}
+
+func (q lookupQueue) Len() int {
+	return len(q)
+}
+
+func (q lookupQueue) Less(i, j int) bool {
+	return q[i].scheduledAt.Before(q[j].scheduledAt)
+}
+
+func (q lookupQueue) Swap(i, j int) {
+	tmp := q[i]
+	q[i] = q[j]
+	q[j] = tmp
+}
+
+func (q *lookupQueue) Push(x any) {
+	job := x.(*lookupJob)
+	*q = append(*q, job)
+}
+
+func (q *lookupQueue) Pop() any {
+	old := *q
+	n := len(old)
+	x := old[n-1]
+	*q = old[0 : n-1]
+	return x
+}
+
+type enqueuer interface {
+	EnqueueKey(key resources.ClusterObjectKey) error
+}
+
+type lookupMetrics interface {
+	IncrSkipped()
+	IncrHostnameLookups(name resources.ObjectName, hosts, errorCount int, duration time.Duration)
+	ReportCurrentJobCount(count int)
+	IncrLookupChanged(name resources.ObjectName)
+	RemoveJob(name resources.ObjectName)
+}
+
+type defaultLookupMetrics struct{}
+
+var _ lookupMetrics = &defaultLookupMetrics{}
+
+func (d defaultLookupMetrics) IncrSkipped() {
+	metrics.ReportLookupProcessorIncrSkipped()
+}
+
+func (d defaultLookupMetrics) IncrHostnameLookups(name resources.ObjectName, hosts, errorCount int, duration time.Duration) {
+	metrics.ReportLookupProcessorIncrHostnameLookups(name, hosts, errorCount, duration)
+}
+
+func (d defaultLookupMetrics) ReportCurrentJobCount(count int) {
+	metrics.ReportLookupProcessorJobs(count)
+}
+
+func (d defaultLookupMetrics) IncrLookupChanged(name resources.ObjectName) {
+	metrics.ReportLookupProcessorIncrLookupChanged(name)
+}
+
+func (d defaultLookupMetrics) RemoveJob(name resources.ObjectName) {
+	metrics.ReportRemovedJob(name)
+}
+
+type lookupProcessor struct {
+	lock           sync.Mutex
+	logger         logger.LogContext
+	checkPeriod    time.Duration
+	concurrentJobs int
+	slots          chan struct{}
+	queue          lookupQueue
+	cluster        string
+	enqueuer       enqueuer
+	running        atomic.Bool
+	skipped        atomic.Int64
+	metrics        lookupMetrics
+}
+
+func newLookupProcessor(
+	logger logger.LogContext,
+	enqueuer enqueuer,
+	concurrentJobs int,
+	checkPeriod time.Duration,
+	cluster string,
+	metrics lookupMetrics,
+) *lookupProcessor {
+	return &lookupProcessor{
+		logger:         logger,
+		checkPeriod:    checkPeriod,
+		concurrentJobs: concurrentJobs,
+		slots:          make(chan struct{}, concurrentJobs),
+		queue:          lookupQueue{},
+		cluster:        cluster,
+		enqueuer:       enqueuer,
+		metrics:        metrics,
+	}
+}
+
+// Upsert inserts or updates a lookup job for the given object name.
+func (p *lookupProcessor) Upsert(name resources.ObjectName, results lookupAllResults, interval time.Duration) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.incrHostnameLookups(name, results)
+
+	idx := p.find(name)
+	if idx >= 0 {
+		changed := p.queue[idx].updateWithLock(results, interval)
+		heap.Fix(&p.queue, idx)
+		if changed {
+			p.enqueueKey(name)
+		}
+		return
+	}
+
+	job := &lookupJob{
+		scheduledAt:      time.Now().Add(interval),
+		objectName:       name,
+		interval:         interval,
+		oldLookupResults: results,
+	}
+	heap.Push(&p.queue, job)
+	p.metrics.ReportCurrentJobCount(len(p.queue))
+}
+
+// Delete removes the lookup job for the given object name.
+func (p *lookupProcessor) Delete(name resources.ObjectName) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	idx := p.find(name)
+	if idx == -1 {
+		return
+	}
+	heap.Remove(&p.queue, idx)
+	p.metrics.RemoveJob(name)
+	p.metrics.ReportCurrentJobCount(len(p.queue))
+}
+
+func (p *lookupProcessor) Run(ctx context.Context) {
+	p.running.Store(true)
+	defer p.running.Store(false)
+	p.logger.Infof("starting lookup processor with %d slots", p.concurrentJobs)
+
+	nextCheck := p.checkPeriod
+	for {
+		if err := sleep(ctx, nextCheck); err != nil {
+			p.logger.Infof("lookup processor stopped: %s", ctx.Err())
+			return
+		}
+		nextCheckTime, skipped := p.runJob(ctx)
+		if skipped != nil {
+			p.logger.Infof("skipped entry %s as lookup not yet finished", *skipped)
+		}
+		nextCheck = time.Until(nextCheckTime)
+	}
+}
+
+func (p *lookupProcessor) runJob(ctx context.Context) (time.Time, *resources.ObjectName) {
+	var (
+		nextCheck time.Time
+		job       *lookupJob
+	)
+	p.lock.Lock()
+	if len(p.queue) == 0 {
+		nextCheck = time.Now().Add(p.checkPeriod)
+	} else {
+		idle := time.Until(p.queue[0].scheduledAt)
+		if idle < 0 {
+			job = p.queue[0]
+			job.scheduledAt = time.Now().Add(job.interval)
+			heap.Fix(&p.queue, 0)
+		}
+		nextCheck = p.queue[0].scheduledAt
+	}
+	p.lock.Unlock()
+
+	if job != nil {
+		if !job.running.CompareAndSwap(false, true) {
+			p.skipped.Inc()
+			p.metrics.IncrSkipped()
+			return nextCheck, &job.objectName
+		}
+		select {
+		case <-ctx.Done():
+			job.running.Store(false)
+			p.logger.Warnf("lookup cancelled: %s", ctx.Err())
+			return nextCheck, &job.objectName
+		case p.slots <- struct{}{}: // Acquire semaphore slot
+			go func(j *lookupJob) {
+				defer func() {
+					j.running.Store(false)
+					<-p.slots // Release semaphore slot
+				}()
+				j.lock.Lock()
+				defer j.lock.Unlock()
+				newLookupResult := lookupAllHostnamesIPs(ctx, j.oldLookupResults.hostnames...)
+				p.incrHostnameLookups(j.objectName, newLookupResult)
+				if j.updateLookupResult(newLookupResult) {
+					p.enqueueKey(j.objectName)
+				}
+			}(job)
+		}
+	}
+	return nextCheck, nil
+}
+
+func (p *lookupProcessor) incrHostnameLookups(name resources.ObjectName, results lookupAllResults) {
+	p.metrics.IncrHostnameLookups(name, len(results.hostnames), len(results.errs), results.duration)
+}
+
+func (p *lookupProcessor) enqueueKey(name resources.ObjectName) {
+	key := resources.NewClusterKey(p.cluster, entryGroupKind, name.Namespace(), name.Name())
+	if err := p.enqueuer.EnqueueKey(key); err != nil {
+		p.logger.Warnf("failed to enqueue key %s: %v", key, err)
+	}
+	p.metrics.IncrLookupChanged(name)
+}
+
+func (p *lookupProcessor) find(name resources.ObjectName) int {
+	for i, job := range p.queue {
+		if job.objectName == name {
+			return i
+		}
+	}
+	return -1
+}
+
+type lookupAllResults struct {
+	hostnames  []string
+	ipv4Addrs  []string
+	ipv6Addrs  []string
+	errs       []error
+	allIPAddrs sets.Set[string]
+	duration   time.Duration
+}
+
+func lookupAllHostnamesIPs(ctx context.Context, hostnames ...string) lookupAllResults {
+	start := time.Now()
+	results := make(chan lookupIPsResult, maxConcurrentLookupsPerJob)
+	go func() {
+		sem := make(chan struct{}, maxConcurrentLookupsPerJob)
+		for _, hostname := range hostnames {
+			select {
+			case <-ctx.Done():
+				results <- lookupIPsResult{err: ctx.Err()}
+			case sem <- struct{}{}: // Acquire semaphore slot
+				go func(h string) {
+					defer func() {
+						<-sem // Release semaphore slot
+					}()
+					results <- lookupIPs(h)
+				}(hostname)
+			}
+		}
+	}()
+
+	all := lookupAllResults{hostnames: hostnames, allIPAddrs: sets.New[string]()}
+	for range len(hostnames) {
+		result := <-results
+		if result.err != nil {
+			all.errs = append(all.errs, result.err)
+			continue
+		}
+
+		for _, addr := range result.ipv4Addrs {
+			if all.allIPAddrs.Has(addr) {
+				continue
+			}
+			all.ipv4Addrs = append(all.ipv4Addrs, addr)
+			all.allIPAddrs.Insert(addr)
+		}
+		for _, addr := range result.ipv6Addrs {
+			if all.allIPAddrs.Has(addr) {
+				continue
+			}
+			all.ipv6Addrs = append(all.ipv6Addrs, addr)
+			all.allIPAddrs.Insert(addr)
+		}
+	}
+	all.duration = time.Since(start)
+	return all
+}
+
+type lookupIPsResult struct {
+	ipv4Addrs []string
+	ipv6Addrs []string
+	err       error
+}
+
+func lookupIPs(hostname string) lookupIPsResult {
+	ips, err := lookupHost(hostname)
+	if err != nil {
+		return lookupIPsResult{err: fmt.Errorf("cannot lookup '%s': %s", hostname, err)}
+	}
+	ipv4addrs := make([]string, 0, len(ips))
+	ipv6addrs := make([]string, 0, len(ips))
+	for _, ip := range ips {
+		if ip.To4() != nil {
+			ipv4addrs = append(ipv4addrs, ip.String())
+		} else if ip.To16() != nil {
+			ipv6addrs = append(ipv6addrs, ip.String())
+		}
+	}
+	if len(ipv4addrs) == 0 && len(ipv6addrs) == 0 {
+		return lookupIPsResult{err: fmt.Errorf("%s has no IPv4/IPv6 address (of %d addresses)", hostname, len(ips))}
+	}
+	return lookupIPsResult{ipv4Addrs: ipv4addrs, ipv6Addrs: ipv6addrs}
+}
+
+func sleep(ctx context.Context, d time.Duration) error {
+	if d < 1*time.Microsecond {
+		return nil
+	} else if d > 30*time.Second {
+		d = 30 * time.Second
+	}
+	t := time.NewTimer(d)
+	select {
+	case <-ctx.Done():
+		t.Stop()
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}

--- a/pkg/dns/provider/lookupprocessor_test.go
+++ b/pkg/dns/provider/lookupprocessor_test.go
@@ -156,7 +156,7 @@ var _ = ginkgov2.Describe("Lookup processor", func() {
 		expectCountBetween("count3a", count3a, 3, 9)
 		Expect(count3c).To(Equal(count3a))
 		Expect(enqueuer.enqueuedCount).To(BeEmpty())
-		expectCountBetween("skipped", int(processor.skipped.Load()), -1, 4)
+		expectCountBetween("skipped", int(processor.skipped.Load()), -1, 6)
 	})
 
 	ginkgov2.It("performs multiple lookup jobs but skips on overload", func() {
@@ -212,7 +212,7 @@ var _ = ginkgov2.Describe("Lookup processor", func() {
 		Expect(enqueuer.enqueuedCount).To(HaveLen(2))
 		Expect(enqueuer.enqueuedCount[nameE2]).To(Equal(1))
 		Expect(enqueuer.enqueuedCount[nameE3]).To(Equal(1))
-		expectCountBetween("skipped", int(processor.skipped.Load()), -1, 4)
+		expectCountBetween("skipped", int(processor.skipped.Load()), -1, 6)
 		stat1 := metrics.lookups[nameE1]
 		Expect(stat1.count).To(Equal(count1))
 		stat3 := metrics.lookups[nameE3]

--- a/pkg/dns/provider/lookupprocessor_test.go
+++ b/pkg/dns/provider/lookupprocessor_test.go
@@ -1,0 +1,227 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/gardener/controller-manager-library/pkg/logger"
+	"github.com/gardener/controller-manager-library/pkg/resources"
+	ginkgov2 "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type testEnqueuer struct {
+	enqueuedCount map[resources.ObjectName]int
+}
+
+func (e *testEnqueuer) EnqueueKey(key resources.ClusterObjectKey) error {
+	e.enqueuedCount[key.ObjectName()]++
+	return nil
+}
+
+type mockLookupHostResult struct {
+	ips []net.IP
+	err error
+}
+
+type mockLookupHost struct {
+	delay       time.Duration
+	lookupMap   map[string]mockLookupHostResult
+	lock        sync.Mutex
+	lookupCount map[string]int
+}
+
+func (lh *mockLookupHost) LookupHost(hostname string) ([]net.IP, error) {
+	time.Sleep(lh.delay)
+	lh.lock.Lock()
+	lh.lookupCount[hostname] += 1
+	lh.lock.Unlock()
+	result, ok := lh.lookupMap[hostname]
+	if !ok {
+		return nil, fmt.Errorf("host not found")
+	}
+	return result.ips, result.err
+}
+
+type lookupStat struct {
+	count       int
+	targetCount int
+	errorCount  int
+	duration    time.Duration
+}
+
+type testMetrics struct {
+	lock    sync.Mutex
+	jobs    int
+	lookups map[resources.ObjectName]lookupStat
+}
+
+var _ lookupMetrics = &testMetrics{}
+
+func (t *testMetrics) IncrSkipped() {
+}
+
+func (t *testMetrics) IncrHostnameLookups(name resources.ObjectName, targetCount, errorCount int, duration time.Duration) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	stat := t.lookups[name]
+	stat.count++
+	stat.targetCount += targetCount
+	stat.errorCount += errorCount
+	stat.duration += duration
+	t.lookups[name] = stat
+}
+
+func (t *testMetrics) ReportCurrentJobCount(count int) {
+	t.jobs = count
+}
+
+func (t *testMetrics) IncrLookupChanged(_ resources.ObjectName) {
+}
+
+func (t *testMetrics) RemoveJob(_ resources.ObjectName) {
+}
+
+var _ = ginkgov2.Describe("Lookup processor", func() {
+	var (
+		processor *lookupProcessor
+		enqueuer  *testEnqueuer
+		mlh       *mockLookupHost
+		metrics   *testMetrics
+
+		nameE1 = resources.NewObjectName("ns1", "e1")
+		nameE2 = resources.NewObjectName("ns1", "e2")
+		nameE3 = resources.NewObjectName("ns1", "e3")
+	)
+
+	ginkgov2.BeforeEach(func() {
+		enqueuer = &testEnqueuer{enqueuedCount: map[resources.ObjectName]int{}}
+		metrics = &testMetrics{lookups: map[resources.ObjectName]lookupStat{}}
+		processor = newLookupProcessor(logger.New(), enqueuer, 2, 10*time.Millisecond, "default", metrics)
+		mlh = &mockLookupHost{
+			delay: 1 * time.Microsecond,
+			lookupMap: map[string]mockLookupHostResult{
+				"host1":        {ips: []net.IP{net.ParseIP("1.1.1.1")}},
+				"host2":        {ips: []net.IP{net.ParseIP("1.1.1.2")}},
+				"host3a":       {ips: []net.IP{net.ParseIP("1.1.1.3")}},
+				"host3b":       {ips: []net.IP{net.ParseIP("1.1.2.3")}},
+				"host3c":       {ips: []net.IP{net.ParseIP("1.1.3.3"), net.ParseIP("1.1.3.4"), net.ParseIP("fc00::3")}},
+				"host3c-alias": {ips: []net.IP{net.ParseIP("1.1.3.3"), net.ParseIP("1.1.3.4"), net.ParseIP("fc00::3")}},
+			},
+			lookupCount: map[string]int{},
+		}
+		lookupHost = mlh.LookupHost
+	})
+
+	ginkgov2.It("lookupAllHostnamesIPs should return expected results", func() {
+		ctx := context.Background()
+		results1 := lookupAllHostnamesIPs(ctx, "host3a", "host3b", "host3c")
+		Expect(results1.ipv4Addrs).To(HaveLen(4))
+		Expect(results1.ipv6Addrs).To(HaveLen(1))
+		Expect(results1.allIPAddrs).To(HaveLen(5))
+		results2 := lookupAllHostnamesIPs(ctx, "host3a", "host3b", "host3c", "host3c-alias")
+		Expect(results2.allIPAddrs).To(Equal(results1.allIPAddrs))
+	})
+
+	ginkgov2.It("performs multiple lookup jobs regularly", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		go processor.Run(ctx)
+
+		processor.Upsert(nameE1, lookupAllHostnamesIPs(ctx, "host1"), 1*time.Millisecond)
+		processor.Upsert(nameE2, lookupAllHostnamesIPs(ctx, "host2"), 2*time.Millisecond)
+		processor.Upsert(nameE3, lookupAllHostnamesIPs(ctx, "host3a", "host3b", "host3c"), 3*time.Millisecond)
+		time.Sleep(processor.checkPeriod)
+
+		time.Sleep(18 * time.Millisecond)
+		processor.Delete(nameE3)
+		processor.Delete(nameE3)
+		time.Sleep(18 * time.Millisecond)
+		cancel()
+		time.Sleep(1 * time.Millisecond)
+		Expect(processor.running.Load()).To(BeFalse())
+
+		count1 := mlh.lookupCount["host1"]
+		count2 := mlh.lookupCount["host2"]
+		count3a := mlh.lookupCount["host3a"]
+		count3c := mlh.lookupCount["host3c"]
+		expectCountBetween("count1", count1, 18, 54)
+		expectCountBetween("count2", count2, 9, 27)
+		expectCountBetween("count3a", count3a, 3, 9)
+		Expect(count3c).To(Equal(count3a))
+		Expect(enqueuer.enqueuedCount).To(BeEmpty())
+		Expect(processor.skipped.Load()).To(BeZero())
+	})
+
+	ginkgov2.It("performs multiple lookup jobs but skips on overload", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		mlh.delay = 1900 * time.Microsecond
+		go processor.Run(ctx)
+
+		processor.Upsert(nameE1, lookupAllHostnamesIPs(ctx, "host1"), 1*time.Millisecond)
+		processor.Upsert(nameE3, lookupAllHostnamesIPs(ctx, "host3a", "host3b", "host3c"), 1*time.Millisecond)
+		time.Sleep(processor.checkPeriod)
+
+		time.Sleep(30 * time.Millisecond)
+		cancel()
+		time.Sleep(1 * time.Millisecond)
+		Expect(processor.running.Load()).To(BeFalse())
+
+		count1 := mlh.lookupCount["host1"]
+		count3a := mlh.lookupCount["host3a"]
+		count3c := mlh.lookupCount["host3c"]
+		expectCountBetween("count1", count1, 10, 20)
+		expectCountBetween("count3a", count3a, 10, 20)
+		Expect(count3c).To(Equal(count3a))
+		Expect(enqueuer.enqueuedCount).To(BeEmpty())
+		expectCountBetween("skipped", int(processor.skipped.Load()), 20, 40)
+	})
+
+	ginkgov2.It("performs multiple lookup jobs and enqueues keys on lookup changes", func() {
+		changedIP := net.ParseIP("1.1.1.42")
+		ctx, cancel := context.WithCancel(context.Background())
+		go processor.Run(ctx)
+
+		processor.Upsert(nameE1, lookupAllHostnamesIPs(ctx, "host1"), 1*time.Millisecond)
+		processor.Upsert(nameE2, lookupAllHostnamesIPs(ctx, "host2"), 1*time.Millisecond)
+		processor.Upsert(nameE3, lookupAllHostnamesIPs(ctx, "host3a", "host3b", "host3c"), 1*time.Millisecond)
+		time.Sleep(processor.checkPeriod)
+
+		time.Sleep(10 * time.Millisecond)
+		processor.Upsert(nameE3, lookupAllHostnamesIPs(ctx, "host3a", "host3b", "not-existing-host"), 1*time.Millisecond)
+		mlh.lookupMap["host2"].ips[0] = changedIP
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+		time.Sleep(1 * time.Millisecond)
+		Expect(processor.running.Load()).To(BeFalse())
+
+		count1 := mlh.lookupCount["host1"]
+		count2 := mlh.lookupCount["host2"]
+		count3a := mlh.lookupCount["host3a"]
+		count3c := mlh.lookupCount["host3c"]
+		expectCountBetween("count1", count1, 20, 40)
+		expectCountBetween("count2", count2, 20, 40)
+		expectCountBetween("count3a", count3a, 20, 40)
+		expectCountBetween("count3c", count3c, 5, 15)
+		Expect(enqueuer.enqueuedCount).To(HaveLen(2))
+		Expect(enqueuer.enqueuedCount[nameE2]).To(Equal(1))
+		Expect(enqueuer.enqueuedCount[nameE3]).To(Equal(1))
+		Expect(processor.skipped.Load()).To(BeZero())
+		stat1 := metrics.lookups[nameE1]
+		Expect(stat1.count).To(Equal(count1))
+		stat3 := metrics.lookups[nameE3]
+		Expect(stat3.count).To(Equal(count3a))
+		Expect(stat3.targetCount).To(Equal(count3a * 3))
+		expectCountBetween("count not-existing-host", stat3.errorCount, 10, 30)
+	})
+})
+
+func expectCountBetween(name string, actual, lower, upper int) {
+	Expect(actual > lower && actual < upper).To(BeTrue(), fmt.Sprintf("%d < %s(%d) < %d", lower, name, actual, upper))
+}

--- a/pkg/dns/provider/lookupprocessor_test.go
+++ b/pkg/dns/provider/lookupprocessor_test.go
@@ -157,7 +157,7 @@ var _ = ginkgov2.Describe("Lookup processor", func() {
 		expectCountBetween("count3a", count3a, 3, 9)
 		Expect(count3c).To(Equal(count3a))
 		Expect(enqueuer.enqueuedCount).To(BeEmpty())
-		expectCountBetween("skipped", int(processor.skipped.Load()), -1, 6)
+		expectCountBetween("skipped", int(processor.skipped.Load()), -1, 9)
 	})
 
 	ginkgov2.It("performs multiple lookup jobs but skips on overload", func() {
@@ -215,7 +215,7 @@ var _ = ginkgov2.Describe("Lookup processor", func() {
 		Expect(enqueuer.enqueuedCount).To(HaveLen(2))
 		Expect(enqueuer.enqueuedCount[nameE2]).To(Equal(1))
 		Expect(enqueuer.enqueuedCount[nameE3]).To(Equal(1))
-		expectCountBetween("skipped", int(processor.skipped.Load()), -1, 6)
+		expectCountBetween("skipped", int(processor.skipped.Load()), -1, 9)
 		stat1 := metrics.lookups[nameE1]
 		Expect(stat1.count).To(Equal(count1))
 		stat3 := metrics.lookups[nameE3]

--- a/pkg/dns/provider/lookupprocessor_test.go
+++ b/pkg/dns/provider/lookupprocessor_test.go
@@ -156,7 +156,7 @@ var _ = ginkgov2.Describe("Lookup processor", func() {
 		expectCountBetween("count3a", count3a, 3, 9)
 		Expect(count3c).To(Equal(count3a))
 		Expect(enqueuer.enqueuedCount).To(BeEmpty())
-		Expect(processor.skipped.Load()).To(BeZero())
+		expectCountBetween("skipped", int(processor.skipped.Load()), -1, 4)
 	})
 
 	ginkgov2.It("performs multiple lookup jobs but skips on overload", func() {
@@ -180,7 +180,7 @@ var _ = ginkgov2.Describe("Lookup processor", func() {
 		expectCountBetween("count3a", count3a, 10, 20)
 		Expect(count3c).To(Equal(count3a))
 		Expect(enqueuer.enqueuedCount).To(BeEmpty())
-		expectCountBetween("skipped", int(processor.skipped.Load()), 20, 40)
+		expectCountBetween("skipped", int(processor.skipped.Load()), 20, 50)
 	})
 
 	ginkgov2.It("performs multiple lookup jobs and enqueues keys on lookup changes", func() {
@@ -212,7 +212,7 @@ var _ = ginkgov2.Describe("Lookup processor", func() {
 		Expect(enqueuer.enqueuedCount).To(HaveLen(2))
 		Expect(enqueuer.enqueuedCount[nameE2]).To(Equal(1))
 		Expect(enqueuer.enqueuedCount[nameE3]).To(Equal(1))
-		Expect(processor.skipped.Load()).To(BeZero())
+		expectCountBetween("skipped", int(processor.skipped.Load()), -1, 4)
 		stat1 := metrics.lookups[nameE1]
 		Expect(stat1.count).To(Equal(count1))
 		stat3 := metrics.lookups[nameE3]

--- a/pkg/dns/provider/lookupprocessor_test.go
+++ b/pkg/dns/provider/lookupprocessor_test.go
@@ -133,6 +133,7 @@ var _ = ginkgov2.Describe("Lookup processor", func() {
 	ginkgov2.It("performs multiple lookup jobs regularly", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		go processor.Run(ctx)
+		time.Sleep(10 * time.Millisecond)
 
 		processor.Upsert(nameE1, lookupAllHostnamesIPs(ctx, "host1"), 1*time.Millisecond)
 		processor.Upsert(nameE2, lookupAllHostnamesIPs(ctx, "host2"), 2*time.Millisecond)
@@ -163,6 +164,7 @@ var _ = ginkgov2.Describe("Lookup processor", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		mlh.delay = 1900 * time.Microsecond
 		go processor.Run(ctx)
+		time.Sleep(10 * time.Millisecond)
 
 		processor.Upsert(nameE1, lookupAllHostnamesIPs(ctx, "host1"), 1*time.Millisecond)
 		processor.Upsert(nameE3, lookupAllHostnamesIPs(ctx, "host3a", "host3b", "host3c"), 1*time.Millisecond)
@@ -187,6 +189,7 @@ var _ = ginkgov2.Describe("Lookup processor", func() {
 		changedIP := net.ParseIP("1.1.1.42")
 		ctx, cancel := context.WithCancel(context.Background())
 		go processor.Run(ctx)
+		time.Sleep(10 * time.Millisecond)
 
 		processor.Upsert(nameE1, lookupAllHostnamesIPs(ctx, "host1"), 1*time.Millisecond)
 		processor.Upsert(nameE2, lookupAllHostnamesIPs(ctx, "host2"), 1*time.Millisecond)

--- a/pkg/dns/provider/state_entry.go
+++ b/pkg/dns/provider/state_entry.go
@@ -331,6 +331,7 @@ func (this *state) EntryDeleted(logger logger.LogContext, key resources.ClusterO
 func (this *state) cleanupEntry(logger logger.LogContext, e *Entry) {
 	this.smartInfof(logger, "cleanup old entry (duplicate=%t)", e.duplicate)
 	this.entries.Delete(e)
+	this.DeleteLookupJob(e.ObjectName())
 	if this.dnsnames[e.ZonedDNSName()] == e {
 		var found *Entry
 		for _, a := range this.entries {

--- a/pkg/dns/provider/state_entry.go
+++ b/pkg/dns/provider/state_entry.go
@@ -283,12 +283,6 @@ func (this *state) HandleUpdateEntry(logger logger.LogContext, op string, object
 			}
 		}
 
-		if status.IsSucceeded() && new.IsValid() {
-			if new.Interval() > 0 {
-				status = status.RescheduleAfter(time.Duration(new.Interval()) * time.Second)
-			}
-		}
-
 		if new.IsModified() && !new.ZoneId().IsEmpty() {
 			this.smartInfof(logger, "trigger zone %q", new.ZoneId())
 			this.triggerHostedZone(new.ZoneId())
@@ -612,6 +606,14 @@ func (this *state) updateLockState(log logger.LogContext, dnsName string, e *Ent
 		e.updateRequired = true
 		_ = this.context.Enqueue(e.object)
 	}
+}
+
+func (this *state) DeleteLookupJob(entryName resources.ObjectName) {
+	this.lookupProcessor.Delete(entryName)
+}
+
+func (this *state) UpsertLookupJob(entryName resources.ObjectName, results lookupAllResults, interval time.Duration) {
+	this.lookupProcessor.Upsert(entryName, results, interval)
 }
 
 func AssureTimestamp(target **metav1.Time, ts time.Time) bool {

--- a/pkg/dns/source/controller.go
+++ b/pkg/dns/source/controller.go
@@ -37,6 +37,8 @@ const (
 	ROUTING_POLICY_ANNOTATION = dns.ANNOTATION_GROUP + "/routing-policy"
 	CLASS_ANNOTATION          = dns.CLASS_ANNOTATION
 	OWNER_ID_ANNOTATION       = dns.ANNOTATION_GROUP + "/owner-id"
+	// RESOLVE_TARGETS_TO_ADDRS_ANNOTATION is the annotation key for source objects to set the `.spec.resolveTargetsToAddresses` in the DNSEntry.
+	RESOLVE_TARGETS_TO_ADDRS_ANNOTATION = dns.ANNOTATION_GROUP + "/resolve-targets-to-addresses"
 )
 
 const (

--- a/pkg/dns/source/defaults.go
+++ b/pkg/dns/source/defaults.go
@@ -90,6 +90,7 @@ func (this *DefaultDNSSource) GetDNSInfo(logger logger.LogContext, obj resources
 		info.Targets = extraction.Targets
 		info.Text = extraction.Texts
 		info.IPStack = extraction.IPStack
+		info.ResolveTargetsToAddresses = extraction.ResolveTargetsToAddresses
 	}
 	return info, err
 }

--- a/pkg/dns/source/interface.go
+++ b/pkg/dns/source/interface.go
@@ -18,16 +18,17 @@ import (
 )
 
 type DNSInfo struct {
-	Names         dns.DNSNameSet
-	OwnerId       *string
-	TTL           *int64
-	Interval      *int64
-	Targets       utils.StringSet
-	Text          utils.StringSet
-	OrigRef       *v1alpha1.EntryReference
-	TargetRef     *v1alpha1.EntryReference
-	RoutingPolicy *v1alpha1.RoutingPolicy
-	IPStack       string
+	Names                     dns.DNSNameSet
+	OwnerId                   *string
+	TTL                       *int64
+	Interval                  *int64
+	Targets                   utils.StringSet
+	Text                      utils.StringSet
+	OrigRef                   *v1alpha1.EntryReference
+	TargetRef                 *v1alpha1.EntryReference
+	RoutingPolicy             *v1alpha1.RoutingPolicy
+	IPStack                   string
+	ResolveTargetsToAddresses *bool
 }
 
 type DNSFeedback interface {
@@ -57,9 +58,10 @@ type DNSSourceType interface {
 }
 
 type TargetExtraction struct {
-	Targets utils.StringSet
-	Texts   utils.StringSet
-	IPStack string
+	Targets                   utils.StringSet
+	Texts                     utils.StringSet
+	IPStack                   string
+	ResolveTargetsToAddresses *bool
 }
 
 type (

--- a/pkg/dns/source/reconciler.go
+++ b/pkg/dns/source/reconciler.go
@@ -470,6 +470,7 @@ func (this *sourceReconciler) createEntryFor(logger logger.LogContext, obj resou
 		annots[dns.AnnotationIPStack] = info.IPStack
 		entry.SetAnnotations(annots)
 	}
+	entry.Spec.ResolveTargetsToAddresses = info.ResolveTargetsToAddresses
 
 	e, _ := this.SlaveResoures()[0].Wrap(entry)
 
@@ -538,6 +539,10 @@ func (this *sourceReconciler) updateEntryFor(logger logger.LogContext, obj resou
 			mod.Modify(true)
 		}
 		mod.AssureInt64PtrPtr(&spec.CNameLookupInterval, info.Interval)
+		if !reflect.DeepEqual(spec.ResolveTargetsToAddresses, info.ResolveTargetsToAddresses) {
+			spec.ResolveTargetsToAddresses = info.ResolveTargetsToAddresses
+			mod.Modify(true)
+		}
 		targets := info.Targets
 		text := info.Text
 

--- a/pkg/dns/utils/utils_dns.go
+++ b/pkg/dns/utils/utils_dns.go
@@ -28,6 +28,7 @@ type DNSSpecification interface {
 	GetTargets() []string
 	GetText() []string
 	GetCNameLookupInterval() *int64
+	ResolveTargetsToAddresses() *bool
 	GetReference() *api.EntryReference
 	BaseStatus() *api.DNSBaseStatus
 	GetRoutingPolicy() *dns.RoutingPolicy

--- a/pkg/dns/utils/utils_entry.go
+++ b/pkg/dns/utils/utils_entry.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gardener/controller-manager-library/pkg/resources"
+	"github.com/gardener/controller-manager-library/pkg/utils"
 	"github.com/gardener/external-dns-management/pkg/dns"
 
 	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
@@ -84,6 +85,10 @@ func (this *DNSEntryObject) GetCNameLookupInterval() *int64 {
 	return this.DNSEntry().Spec.CNameLookupInterval
 }
 
+func (this *DNSEntryObject) ResolveTargetsToAddresses() *bool {
+	return this.DNSEntry().Spec.ResolveTargetsToAddresses
+}
+
 func (this *DNSEntryObject) GetReference() *api.EntryReference {
 	return this.DNSEntry().Spec.Reference
 }
@@ -134,6 +139,18 @@ func (this *DNSEntryObject) AcknowledgeRoutingPolicy(policy *dns.RoutingPolicy) 
 		return true
 	}
 	return false
+}
+
+func (this *DNSEntryObject) AcknowledgeCNAMELookupInterval(interval int64) bool {
+	s := this.Status()
+	if interval == 0 {
+		mod := s.CNameLookupInterval != nil
+		s.CNameLookupInterval = nil
+		return mod
+	}
+	var mod bool
+	s.CNameLookupInterval, mod = utils.AssureInt64PtrValue(false, s.CNameLookupInterval, interval)
+	return mod
 }
 
 func (this *DNSEntryObject) GetTargetSpec(p TargetProvider) TargetSpec {

--- a/pkg/dns/utils/utils_lock.go
+++ b/pkg/dns/utils/utils_lock.go
@@ -97,6 +97,10 @@ func (this *DNSLockObject) GetCNameLookupInterval() *int64 {
 	return nil
 }
 
+func (this *DNSLockObject) ResolveTargetsToAddresses() *bool {
+	return nil
+}
+
 func (this *DNSLockObject) GetReference() *api.EntryReference {
 	return nil
 }

--- a/test/integration/istioGatewayAnnotation_test.go
+++ b/test/integration/istioGatewayAnnotation_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	v12 "k8s.io/api/networking/v1"
+	"k8s.io/utils/ptr"
 )
 
 var _ = Describe("IstioGatewayAnnotation", func() {
@@ -21,11 +22,17 @@ var _ = Describe("IstioGatewayAnnotation", func() {
 		fakeExternalIP := "1.2.3.4"
 		status := &v1.LoadBalancerIngress{IP: fakeExternalIP}
 		svcDomain := "mysvc." + domain
+		svcDomain2 := "mysvc2." + domain
 		ttl := 456
 		svc, gw, err := testEnv.CreateServiceAndIstioGatewayWithAnnotation("mygateway", svcDomain, status, ttl, nil, nil)
 		Ω(err).ShouldNot(HaveOccurred())
+		svc2, gw2, err := testEnv.CreateServiceAndIstioGatewayWithAnnotation("mygateway2", svcDomain2, status, ttl, nil,
+			map[string]string{"dns.gardener.cloud/resolve-targets-to-addresses": "true"})
+		Ω(err).ShouldNot(HaveOccurred())
 
 		entryObj, err := testEnv.AwaitObjectByOwner("Gateway", gw.GetName())
+		Ω(err).ShouldNot(HaveOccurred())
+		entryObj2, err := testEnv.AwaitObjectByOwner("Gateway", gw2.GetName())
 		Ω(err).ShouldNot(HaveOccurred())
 
 		checkEntry(entryObj, pr)
@@ -37,17 +44,33 @@ var _ = Describe("IstioGatewayAnnotation", func() {
 		Ω(entry.Spec.OwnerId).Should(BeNil())
 		Ω(entry.Spec.TTL).ShouldNot(BeNil())
 		Ω(*entry.Spec.TTL).Should(Equal(int64(ttl)))
+		Ω(entry.Spec.ResolveTargetsToAddresses).To(BeNil())
+
+		checkEntry(entryObj2, pr)
+		entryObj2, err = testEnv.GetEntry(entryObj2.GetName())
+		Ω(err).ShouldNot(HaveOccurred())
+		entry2 := UnwrapEntry(entryObj2)
+		Ω(entry2.Spec.DNSName).Should(Equal(svcDomain2))
+		Ω(entry2.Spec.ResolveTargetsToAddresses).To(Equal(ptr.To(true)))
 
 		err = gw.Delete()
+		Ω(err).ShouldNot(HaveOccurred())
+		err = gw2.Delete()
 		Ω(err).ShouldNot(HaveOccurred())
 
 		err = svc.Delete()
 		Ω(err).ShouldNot(HaveOccurred())
+		err = svc2.Delete()
+		Ω(err).ShouldNot(HaveOccurred())
 
 		err = testEnv.AwaitServiceDeletion(gw.GetName())
 		Ω(err).ShouldNot(HaveOccurred())
+		err = testEnv.AwaitServiceDeletion(gw2.GetName())
+		Ω(err).ShouldNot(HaveOccurred())
 
 		err = testEnv.AwaitEntryDeletion(entryObj.GetName())
+		Ω(err).ShouldNot(HaveOccurred())
+		err = testEnv.AwaitEntryDeletion(entryObj2.GetName())
 		Ω(err).ShouldNot(HaveOccurred())
 	})
 

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -85,13 +85,14 @@ if [ "$LOCAL_APISERVER" != "" ]; then
   unset USE_EXISTING_CLUSTER
   echo using controller runtime envtest
 
-  K8S_VERSION=1.24.2
+  K8S_VERSION=1.29.3
   KUBEBUILDER_DIR=$(realpath -m kubebuilder_${K8S_VERSION})
   if [ ! -d "$KUBEBUILDER_DIR" ]; then
     curl -sSL "https://go.kubebuilder.io/test-tools/${K8S_VERSION}/$(go env GOOS)/$(go env GOARCH)" | tar -xvz
     mv kubebuilder "$KUBEBUILDER_DIR"
   fi
   export KUBEBUILDER_ASSETS="${KUBEBUILDER_DIR}/bin"
+  echo KUBEBUILDER_ASSETS=$KUBEBUILDER_ASSETS
 else
   export USE_EXISTING_CLUSTER=true
   export KUBECONFIG=$INTEGRATION_KUBECONFIG

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -27,6 +27,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	gatewayapisv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
@@ -51,7 +52,7 @@ func TestIntegration(t *testing.T) {
 var _ = BeforeSuite(func() {
 	var err error
 
-	controllerRuntimeTestEnv = &envtest.Environment{}
+	controllerRuntimeTestEnv = &envtest.Environment{UseExistingCluster: ptr.To(os.Getenv("USE_EXISTING_CLUSTER") != "")}
 	restConfig, err := controllerRuntimeTestEnv.Start()
 	Expect(err).ToNot(HaveOccurred())
 	Expect(restConfig).ToNot(BeNil())


### PR DESCRIPTION
**What this PR does / why we need it**:
The address lookups for domain names in `DNSEntries` to create  `A` or `AAAA` records have been moved to a separate background processing to avoid periodic reconciliation of such `DNSEntries`.
Additionally, it is now possible to create `A` or `AAAA` records instead of a `CNAME` record for a single domain name target by specifying `.spec.resolveTargetsToAddresses: true` as requested in #371.

Metrics have been added for monitoring usage and load by the lookup processor.

**Which issue(s) this PR fixes**:
Fixes #371 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The address lookups for domain names in `DNSEntries` to create  `A` or `AAAA` records has been moved to a separate background processing to avoid periodic reconciliation of such `DNSEntries`.
Additionally, it is now possible to create `A` or `AAAA` records instead of a `CNAME` record for a single domain name target by specifying `.spec.resolveTargetsToAddresses: true`.
```
