### PR TITLE
Add ignore annotation for DNSEntry and source resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ metadata:
     dns.gardener.cloud/ttl: "500"
     # If you are delegating the DNS Management to Gardener, uncomment the following line (see https://gardener.cloud/documentation/guides/administer_shoots/dns_names/)
     #dns.gardener.cloud/class: garden
+    # To temporarily skip reconciliation of created entries
+    #dns.gardener.cloud/ignore: "true"
   name: test-service
   namespace: default
 spec:
@@ -263,6 +265,8 @@ metadata:
     #dns.gardener.cloud/ttl: "500"
     # If you are delegating the DNS Management to Gardener, uncomment the following line (see https://gardener.cloud/documentation/guides/administer_shoots/dns_names/)
     #dns.gardener.cloud/class: garden
+    # To temporarily skip reconciliation of created entries
+    #dns.gardener.cloud/ignore: "true"
   name: my-gateway
   namespace: default
 spec:
@@ -327,6 +331,8 @@ metadata:
     #dns.gardener.cloud/ttl: "500"
     # If you are delegating the DNS Management to Gardener, uncomment the following line (see https://gardener.cloud/documentation/guides/administer_shoots/dns_names/)
     #dns.gardener.cloud/class: garden
+    # To temporarily skip reconciliation of created entries
+    #dns.gardener.cloud/ignore: "true"
   name: my-gateway
   namespace: default
 spec:

--- a/docs/usage/dnsentry_status.md
+++ b/docs/usage/dnsentry_status.md
@@ -23,4 +23,5 @@ Currently the available states are:
 - `Invalid` means there is a conflict with another DNS entry or owner. See `message` for details in this case.
 - `Stale` means the DNS records in the backend service are existing but there is a problem with the provider. See `message` for details in this case.
 - `Deleting` means the deletion of the DNS records in the DNS backend service is in progress.
+- `Ignored` means the entry is annotated with `dns.gardener.cloud/ignore=true` and reconciliation is skipped.
 - An empty state ` ` means that no matching provider has been found.

--- a/examples/40-entry-by-cnames.yaml
+++ b/examples/40-entry-by-cnames.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     # If you are delegating the DNS management to Gardener, uncomment the following line (see https://gardener.cloud/documentation/guides/administer_shoots/dns_names/)
     #dns.gardener.cloud/class: garden
+    # To temporarily skip reconciliation of an entry
+    #dns.gardener.cloud/ignore: "true"
   name: test
   namespace: default
 spec:

--- a/examples/40-entry-dns.yaml
+++ b/examples/40-entry-dns.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     # If you are delegating the DNS management to Gardener, uncomment the following line (see https://gardener.cloud/documentation/guides/administer_shoots/dns_names/)
     #dns.gardener.cloud/class: garden
+    # To temporarily skip reconciliation of an entry
+    #dns.gardener.cloud/ignore: "true"
   name: dns
   namespace: default
 spec:

--- a/examples/50-ingress-with-dns.yaml
+++ b/examples/50-ingress-with-dns.yaml
@@ -11,6 +11,8 @@ metadata:
     #dns.gardener.cloud/owner-id: second
     #dns.gardener.cloud/ip-stack: dual-stack     # AWS-route 53 only: enable both A and AAAA alias targets
     #dns.gardener.cloud/resolve-targets-to-addresses: "true"
+    # To temporarily skip reconciliation of created entries
+    #dns.gardener.cloud/ignore: "true"
   name: test-ingress
   namespace: default
 spec:

--- a/examples/50-service-with-dns.yaml
+++ b/examples/50-service-with-dns.yaml
@@ -10,6 +10,8 @@ metadata:
     #service.beta.kubernetes.io/aws-load-balancer-ip-address-type: dualstack   # AWS-route 53 only: enable both A and AAAA alias targets
     #dns.gardener.cloud/ip-stack: dual-stack                                   # AWS-route 53 only: alternative way to enable A and AAAA alias targets
     #dns.gardener.cloud/resolve-targets-to-addresses: "true"
+    # To temporarily skip reconciliation of created entries
+    #dns.gardener.cloud/ignore: "true"
   name: test-service
   namespace: default
 spec:

--- a/examples/55-gateway-api-with-dns.yaml
+++ b/examples/55-gateway-api-with-dns.yaml
@@ -6,6 +6,8 @@ metadata:
     #dns.gardener.cloud/ttl: "500"
     # If you are delegating the DNS Management to Gardener, uncomment the following line (see https://gardener.cloud/documentation/guides/administer_shoots/dns_names/)
     #dns.gardener.cloud/class: garden
+    # To temporarily skip reconciliation of created entries
+    #dns.gardener.cloud/ignore: "true"
   name: my-gateway
   namespace: default
 spec:

--- a/examples/55-istio-gateway-with-dns.yaml
+++ b/examples/55-istio-gateway-with-dns.yaml
@@ -6,6 +6,8 @@ metadata:
     #dns.gardener.cloud/ttl: "500"
     # If you are delegating the DNS Management to Gardener, uncomment the following line (see https://gardener.cloud/documentation/guides/administer_shoots/dns_names/)
     #dns.gardener.cloud/class: garden
+    # To temporarily skip reconciliation of created entries
+    #dns.gardener.cloud/ignore: "true"
   name: my-gateway
   namespace: default
 spec:

--- a/pkg/apis/dns/v1alpha1/state.go
+++ b/pkg/apis/dns/v1alpha1/state.go
@@ -11,4 +11,5 @@ const (
 	STATE_STALE    = "Stale"
 	STATE_READY    = "Ready"
 	STATE_DELETING = "Deleting"
+	STATE_IGNORED  = "Ignored"
 )

--- a/pkg/controller/source/dnsentry/handler.go
+++ b/pkg/controller/source/dnsentry/handler.go
@@ -55,6 +55,7 @@ func (this *DNSEntrySource) GetDNSInfo(_ logger.LogContext, obj resources.Object
 		RoutingPolicy:             entry.Spec.RoutingPolicy,
 		IPStack:                   entry.Annotations[dns.AnnotationIPStack],
 		ResolveTargetsToAddresses: entry.Spec.ResolveTargetsToAddresses,
+		Ignore:                    entry.Annotations[dns.AnnotationIgnore] == "true",
 	}
 	return info, nil
 }

--- a/pkg/controller/source/gateways/gatewayapi/handler.go
+++ b/pkg/controller/source/gateways/gatewayapi/handler.go
@@ -85,6 +85,9 @@ func (s *gatewaySource) GetDNSInfo(_ logger.LogContext, obj resources.ObjectData
 	if v := obj.GetAnnotations()[source.RESOLVE_TARGETS_TO_ADDRS_ANNOTATION]; v != "" {
 		info.ResolveTargetsToAddresses = ptr.To(v == "true")
 	}
+	if v := obj.GetAnnotations()[dns.AnnotationIgnore]; v != "" {
+		info.Ignore = v == "true"
+	}
 	return info, nil
 }
 

--- a/pkg/controller/source/gateways/istio/handler.go
+++ b/pkg/controller/source/gateways/istio/handler.go
@@ -100,6 +100,9 @@ func (s *gatewaySource) GetDNSInfo(logger logger.LogContext, obj resources.Objec
 	if v := obj.GetAnnotations()[source.RESOLVE_TARGETS_TO_ADDRS_ANNOTATION]; v != "" {
 		info.ResolveTargetsToAddresses = ptr.To(v == "true")
 	}
+	if v := obj.GetAnnotations()[dns.AnnotationIgnore]; v != "" {
+		info.Ignore = v == "true"
+	}
 	return info, nil
 }
 

--- a/pkg/controller/source/ingress/handler.go
+++ b/pkg/controller/source/ingress/handler.go
@@ -50,6 +50,9 @@ func (this *IngressSource) GetDNSInfo(_ logger.LogContext, obj resources.ObjectD
 	if v := obj.GetAnnotations()[source.RESOLVE_TARGETS_TO_ADDRS_ANNOTATION]; v != "" {
 		info.ResolveTargetsToAddresses = ptr.To(v == "true")
 	}
+	if v := obj.GetAnnotations()[dns.AnnotationIgnore]; v != "" {
+		info.Ignore = v == "true"
+	}
 	return info, nil
 }
 

--- a/pkg/controller/source/service/handler.go
+++ b/pkg/controller/source/service/handler.go
@@ -31,6 +31,7 @@ func GetTargets(_ logger.LogContext, obj resources.ObjectData, names dns.DNSName
 			}
 		}
 	}
+	ignore := false
 	var resolveTargetsToAddresses *bool
 	ipstack := ""
 	set := utils.StringSet{}
@@ -61,10 +62,14 @@ func GetTargets(_ logger.LogContext, obj resources.ObjectData, names dns.DNSName
 		if v := svc.Annotations[source.RESOLVE_TARGETS_TO_ADDRS_ANNOTATION]; v != "" {
 			resolveTargetsToAddresses = ptr.To(v == "true")
 		}
+		if v := svc.Annotations[dns.AnnotationIgnore]; v != "" {
+			ignore = v == "true"
+		}
 	}
 	return &source.TargetExtraction{
 		Targets:                   set,
 		IPStack:                   ipstack,
 		ResolveTargetsToAddresses: resolveTargetsToAddresses,
+		Ignore:                    ignore,
 	}, nil
 }

--- a/pkg/dns/const.go
+++ b/pkg/dns/const.go
@@ -29,4 +29,7 @@ const (
 	AnnotationValueIPStackIPv4        = "ipv4"
 	AnnotationValueIPStackIPDualStack = "dual-stack"
 	AnnotationValueIPStackIPv6        = "ipv6"
+
+	// AnnotationIgnore is an optional annotation for DNSEntries and source resources to ignore them on reconciliation.
+	AnnotationIgnore = ANNOTATION_GROUP + "/ignore"
 )

--- a/pkg/dns/source/defaults.go
+++ b/pkg/dns/source/defaults.go
@@ -91,6 +91,7 @@ func (this *DefaultDNSSource) GetDNSInfo(logger logger.LogContext, obj resources
 		info.Text = extraction.Texts
 		info.IPStack = extraction.IPStack
 		info.ResolveTargetsToAddresses = extraction.ResolveTargetsToAddresses
+		info.Ignore = extraction.Ignore
 	}
 	return info, err
 }

--- a/pkg/dns/source/interface.go
+++ b/pkg/dns/source/interface.go
@@ -29,6 +29,7 @@ type DNSInfo struct {
 	RoutingPolicy             *v1alpha1.RoutingPolicy
 	IPStack                   string
 	ResolveTargetsToAddresses *bool
+	Ignore                    bool
 }
 
 type DNSFeedback interface {
@@ -62,6 +63,7 @@ type TargetExtraction struct {
 	Texts                     utils.StringSet
 	IPStack                   string
 	ResolveTargetsToAddresses *bool
+	Ignore                    bool
 }
 
 type (

--- a/test/integration/ingressAnnotation_test.go
+++ b/test/integration/ingressAnnotation_test.go
@@ -45,6 +45,11 @@ var _ = Describe("IngressAnnotation", func() {
 		Ω(entry.Spec.OwnerId).Should(BeNil())
 		Ω(entry.Annotations["dns.gardener.cloud/ip-stack"]).Should(Equal("dual-stack"))
 
+		testEnv.AnnotateObject(ingress, "dns.gardener.cloud/ignore", "true")
+		testEnv.AwaitEntryState(entryObj.GetName(), "Ignored")
+		testEnv.AnnotateObject(ingress, "dns.gardener.cloud/ignore", "")
+		testEnv.AwaitEntryState(entryObj.GetName(), "Ready")
+
 		// keep old targets if ingress lost its load balancers
 		err = testEnv.PatchIngressLoadBalancer(ingress, "")
 		Ω(err).ShouldNot(HaveOccurred())

--- a/test/integration/istioGatewayAnnotation_test.go
+++ b/test/integration/istioGatewayAnnotation_test.go
@@ -46,6 +46,11 @@ var _ = Describe("IstioGatewayAnnotation", func() {
 		Ω(*entry.Spec.TTL).Should(Equal(int64(ttl)))
 		Ω(entry.Spec.ResolveTargetsToAddresses).To(BeNil())
 
+		testEnv.AnnotateObject(gw, "dns.gardener.cloud/ignore", "true")
+		testEnv.AwaitEntryState(entryObj.GetName(), "Ignored")
+		testEnv.AnnotateObject(gw, "dns.gardener.cloud/ignore", "")
+		testEnv.AwaitEntryState(entryObj.GetName(), "Ready")
+
 		checkEntry(entryObj2, pr)
 		entryObj2, err = testEnv.GetEntry(entryObj2.GetName())
 		Ω(err).ShouldNot(HaveOccurred())

--- a/test/integration/k8sgatewayAnnotation_test.go
+++ b/test/integration/k8sgatewayAnnotation_test.go
@@ -48,6 +48,11 @@ var _ = Describe("GatewayAPIGatewayAnnotation", func() {
 		Ω(*entry.Spec.TTL).Should(Equal(int64(ttl)))
 		Ω(entry.Spec.ResolveTargetsToAddresses).To(BeNil())
 
+		testEnv.AnnotateObject(gw, "dns.gardener.cloud/ignore", "true")
+		testEnv.AwaitEntryState(entryObj.GetName(), "Ignored")
+		testEnv.AnnotateObject(gw, "dns.gardener.cloud/ignore", "")
+		testEnv.AwaitEntryState(entryObj.GetName(), "Ready")
+
 		checkEntry(entryObj2, pr)
 		entryObj2, err = testEnv.GetEntry(entryObj2.GetName())
 		Ω(err).ShouldNot(HaveOccurred())

--- a/test/integration/serviceAnnotation_test.go
+++ b/test/integration/serviceAnnotation_test.go
@@ -70,6 +70,11 @@ var _ = Describe("ServiceAnnotation", func() {
 		Ω(*entry.Spec.TTL).Should(Equal(int64(ttl)))
 		Ω(entry.Annotations["dns.gardener.cloud/ip-stack"]).Should(Equal("dual-stack"))
 
+		testEnv.AnnotateObject(svc, "dns.gardener.cloud/ignore", "true")
+		testEnv.AwaitEntryState(entryObj.GetName(), "Ignored")
+		testEnv.AnnotateObject(svc, "dns.gardener.cloud/ignore", "")
+		testEnv.AwaitEntryState(entryObj.GetName(), "Ready")
+
 		entryObj2, err := testEnv.AwaitObjectByOwner("Service", svc2.GetName())
 		entry2 := UnwrapEntry(entryObj2)
 		Ω(err).ShouldNot(HaveOccurred())

--- a/test/integration/testenv.go
+++ b/test/integration/testenv.go
@@ -466,6 +466,37 @@ func (te *TestEnv) UpdateEntryTargets(obj resources.Object, targets ...string) (
 	return obj, err
 }
 
+func (te *TestEnv) UpdateEntry(obj resources.Object, modifier func(obj *v1alpha1.DNSEntry) error) (resources.Object, error) {
+	obj, err := te.GetEntry(obj.GetName())
+	if err != nil {
+		return nil, err
+	}
+	e := UnwrapEntry(obj)
+	err = modifier(e)
+	if err != nil {
+		return nil, err
+	}
+	err = obj.Update()
+	return obj, err
+}
+
+func (te *TestEnv) AnnotateObject(obj resources.Object, key, value string) error {
+	annots := obj.GetAnnotations()
+	if annots == nil {
+		if value != "" {
+			obj.SetAnnotations(map[string]string{key: value})
+		}
+	} else {
+		if value != "" {
+			annots[key] = value
+		} else {
+			delete(annots, key)
+		}
+		obj.SetAnnotations(annots)
+	}
+	return obj.Update()
+}
+
 func (te *TestEnv) DeleteEntryAndWait(obj resources.Object) error {
 	return te.DeleteEntriesAndWait(obj)
 }


### PR DESCRIPTION
**What this PR does / why we need it**: 
The annotation `dns.gardener.cloud/ignore=true` is introduced for `DNSEntries` to disable reconciliation temporarily.
The annotation is also available for source resources like `Ingress`, `Service`, `Gateway` (both Istio and Kubernetes Gateway API) and replicated `DNSEntries`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Add ignore annotation `dns.gardener.cloud/ignore=true` for  `DNSEntries` and source resources to disable reconciliation temporarily.
```
