### PR TITLE
Use filepath.Clean to get rid of gosec G304

### DIFF
--- a/test/functional/config/config.go
+++ b/test/functional/config/config.go
@@ -7,6 +7,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -104,7 +105,7 @@ func InitConfig() *Config {
 }
 
 func LoadConfig(filename string) (*Config, error) {
-	f, err := os.Open(filename) // #nosec G304 -- only used during tests to read test configuration
+	f, err := os.Open(filepath.Clean(filename))
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +176,7 @@ func (p *ProviderConfig) TTLValue() int {
 
 func (p *ProviderConfig) CreateTempManifest(basePath, testName string, manifestTemplate *template.Template) (string, error) {
 	filename := fmt.Sprintf("%s/tmp-%s-%s.yaml", basePath, p.Name, testName)
-	f, err := os.Create(filename) // #nosec G304 -- only used during tests to write to a temp file
+	f, err := os.Create(filepath.Clean(filename))
 	if err != nil {
 		return "", err
 	}

--- a/test/integration/testenv.go
+++ b/test/integration/testenv.go
@@ -170,8 +170,8 @@ func (te *TestEnv) ApplyCRDs(dir string) error {
 }
 
 // readDocuments reads documents from file.
-func readDocuments(fp string) ([][]byte, error) {
-	b, err := os.ReadFile(fp) // #nosec G304 -- only used during tests to read test configuration
+func readDocuments(filename string) ([][]byte, error) {
+	b, err := os.ReadFile(filepath.Clean(filename))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Minor improvement to get rid of gosec warning G304

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
