### PR TITLE
chore: Remove obsolete Make target adjust-install-gosec.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,16 +103,10 @@ integrationtests: $(GINKGO)
 docker-images:
 	@docker build -t $(IMAGE_REPOSITORY):$(IMAGE_TAG) -f Dockerfile --target dns-controller-manager .
 
-# TODO(martinweindel): Remove once https://github.com/gardener/gardener/pull/10642 is available as release.
-TOOLS_PKG_PATH := $(shell go list -tags tools -f '{{ .Dir }}' github.com/gardener/gardener/hack/tools 2>/dev/null)
-.PHONY: adjust-install-gosec.sh
-adjust-install-gosec.sh:
-	@chmod +xw $(TOOLS_PKG_PATH)/install-gosec.sh
-
 .PHONY: sast
-sast: adjust-install-gosec.sh $(GOSEC)
+sast: $(GOSEC)
 	@./hack/sast.sh
 
 .PHONY: sast-report
-sast-report: adjust-install-gosec.sh $(GOSEC)
+sast-report: $(GOSEC)
 	@./hack/sast.sh --gosec-report true


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

Removes the obsolete Make target `adjust-install-gosec.sh` as the PR referenced by the `TODO` is available as of [`gardener/gardener@v1.106.0`](https://github.com/gardener/gardener/pull/10642).

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @MartinWeindel 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
