### PR TITLE
Drop support for metadata records

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ For extending or adapting this project with your own source or provisioning cont
 
 - [External DNS Management](#external-dns-management)
   - [Index](#index)
+  - [Important Note: Support for owner identifiers is discontinued](#important-note-support-for-owner-identifiers-is-discontinued)
   - [Quick start](#quick-start)
     - [Automatic creation of DNS entries for services and ingresses](#automatic-creation-of-dns-entries-for-services-and-ingresses)
       - [`A` DNS records with alias targets for provider type AWS-Route53 and AWS load balancers](#a-dns-records-with-alias-targets-for-provider-type-aws-route53-and-aws-load-balancers)
@@ -55,6 +56,29 @@ For extending or adapting this project with your own source or provisioning cont
     - [Using the standard Compound Provisioning Controller](#using-the-standard-compound-provisioning-controller)
     - [Multiple Cluster Support](#multiple-cluster-support)
   - [Why not use the community `external-dns` solution?](#why-not-use-the-community-external-dns-solution)
+
+## Important Note: Support for owner identifiers is discontinued
+
+Starting with release `v0.23`, the support for owner identifiers is discontinued.
+
+The creation and management of meta data DNS records holding the owner identifier for each `DNSEntry` has been removed.
+These meta data DNS records will be removed automatically. To avoid running into rate limits, this removals will happen
+only during updates or with low batch size during the periodic reconciliation.
+Depending on size of the hosted zone these cleanup can take multiple days.
+To ensure the correct work of the cleanup of these special `TXT` DNS records, the owner identifier provided via 
+the `--identifier` command line option and the `DNSOwner` custom resources need still be provided as before.
+In a future release, the `DNSOwner` resources will be removed completely.
+
+These identifiers are now only used for cleanup, but not for any other purposes.
+
+The ownership information was used to several purposes:
+- detect conflicts (i.e. same DNS record written by multiple dns-controller-manager instances)
+- handing over responsibility of DNS records from one to another controller instance
+- detection of orphan DNS records and their cleanup
+
+Please note that these edge cases are not supported anymore.
+For handing over responsibility of DNS record, please use the `dns.gardener.cloud/ignore=true` annotation 
+on `DNSEntries` or the annotated source objects (like `Ingress`, `Service`, etc.)
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -61,17 +61,17 @@ For extending or adapting this project with your own source or provisioning cont
 
 Starting with release `v0.23`, the support for owner identifiers is discontinued.
 
-The creation and management of meta data DNS records holding the owner identifier for each `DNSEntry` has been removed.
-These meta data DNS records will be removed automatically. To avoid running into rate limits, this removals will happen
+The creation and management of metadata DNS records holding the owner identifier for each `DNSEntry` has been removed.
+These metadata DNS records will be removed automatically. To avoid running into rate limits, this removals will happen
 only during updates or with low batch size during the periodic reconciliation.
-Depending on size of the hosted zone these cleanup can take multiple days.
+Depending on the size of the hosted zone the cleanup can take multiple days.
 To ensure the correct work of the cleanup of these special `TXT` DNS records, the owner identifier provided via 
-the `--identifier` command line option and the `DNSOwner` custom resources need still be provided as before.
+the `--identifier` command line option and the `DNSOwner` custom resources must still be provided as before.
 In a future release, the `DNSOwner` resources will be removed completely.
 
 These identifiers are now only used for cleanup, but not for any other purposes.
 
-The ownership information was used to several purposes:
+The ownership information was used for several purposes:
 - detect conflicts (i.e. same DNS record written by multiple dns-controller-manager instances)
 - handing over responsibility of DNS records from one to another controller instance
 - detection of orphan DNS records and their cleanup
@@ -580,366 +580,376 @@ Usage:
   dns-controller-manager [flags]
 
 Flags:
-      --accepted-maintainers string                                   accepted maintainer key(s) for crds
-      --advanced.batch-size int                                       batch size for change requests (currently only used for aws-route53)
-      --advanced.max-retries int                                      maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53)
-      --alicloud-dns.advanced.batch-size int                          batch size for change requests (currently only used for aws-route53)
-      --alicloud-dns.advanced.max-retries int                         maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53)
-      --alicloud-dns.blocked-zone zone-id                             Blocks a zone given in the format zone-id from a provider as if the zone is not existing.
-      --alicloud-dns.ratelimiter.burst int                            number of burst requests for rate limiter
-      --alicloud-dns.ratelimiter.enabled                              enables rate limiter for DNS provider requests
-      --alicloud-dns.ratelimiter.qps int                              maximum requests/queries per second
-      --annotation.default.pool.size int                              Worker pool size for pool default of controller annotation
-      --annotation.pool.size int                                      Worker pool size of controller annotation
-      --annotation.setup int                                          number of processors for controller setup of controller annotation
-      --aws-route53.advanced.batch-size int                           batch size for change requests (currently only used for aws-route53)
-      --aws-route53.advanced.max-retries int                          maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53)
-      --aws-route53.blocked-zone zone-id                              Blocks a zone given in the format zone-id from a provider as if the zone is not existing.
-      --aws-route53.ratelimiter.burst int                             number of burst requests for rate limiter
-      --aws-route53.ratelimiter.enabled                               enables rate limiter for DNS provider requests
-      --aws-route53.ratelimiter.qps int                               maximum requests/queries per second
-      --azure-dns.advanced.batch-size int                             batch size for change requests (currently only used for aws-route53)
-      --azure-dns.advanced.max-retries int                            maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53)
-      --azure-dns.blocked-zone zone-id                                Blocks a zone given in the format zone-id from a provider as if the zone is not existing.
-      --azure-dns.ratelimiter.burst int                               number of burst requests for rate limiter
-      --azure-dns.ratelimiter.enabled                                 enables rate limiter for DNS provider requests
-      --azure-dns.ratelimiter.qps int                                 maximum requests/queries per second
-      --azure-private-dns.advanced.batch-size int                     batch size for change requests (currently only used for aws-route53)
-      --azure-private-dns.advanced.max-retries int                    maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53)
-      --azure-private-dns.blocked-zone zone-id                        Blocks a zone given in the format zone-id from a provider as if the zone is not existing.
-      --azure-private-dns.ratelimiter.burst int                       number of burst requests for rate limiter
-      --azure-private-dns.ratelimiter.enabled                         enables rate limiter for DNS provider requests
-      --azure-private-dns.ratelimiter.qps int                         maximum requests/queries per second
-      --bind-address-http string                                      HTTP server bind address
-      --blocked-zone zone-id                                          Blocks a zone given in the format zone-id from a provider as if the zone is not existing.
-      --cache-ttl int                                                 Time-to-live for provider hosted zone cache
-      --cloudflare-dns.advanced.batch-size int                        batch size for change requests (currently only used for aws-route53)
-      --cloudflare-dns.advanced.max-retries int                       maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53)
-      --cloudflare-dns.blocked-zone zone-id                           Blocks a zone given in the format zone-id from a provider as if the zone is not existing.
-      --cloudflare-dns.ratelimiter.burst int                          number of burst requests for rate limiter
-      --cloudflare-dns.ratelimiter.enabled                            enables rate limiter for DNS provider requests
-      --cloudflare-dns.ratelimiter.qps int                            maximum requests/queries per second
-      --compound.advanced.batch-size int                              batch size for change requests (currently only used for aws-route53) of controller compound
-      --compound.advanced.max-retries int                             maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53) of controller compound
-      --compound.alicloud-dns.advanced.batch-size int                 batch size for change requests (currently only used for aws-route53) of controller compound
-      --compound.alicloud-dns.advanced.max-retries int                maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53) of controller compound
-      --compound.alicloud-dns.blocked-zone zone-id                    Blocks a zone given in the format zone-id from a provider as if the zone is not existing. of controller compound
-      --compound.alicloud-dns.ratelimiter.burst int                   number of burst requests for rate limiter of controller compound
-      --compound.alicloud-dns.ratelimiter.enabled                     enables rate limiter for DNS provider requests of controller compound
-      --compound.alicloud-dns.ratelimiter.qps int                     maximum requests/queries per second of controller compound
-      --compound.aws-route53.advanced.batch-size int                  batch size for change requests (currently only used for aws-route53) of controller compound
-      --compound.aws-route53.advanced.max-retries int                 maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53) of controller compound
-      --compound.aws-route53.blocked-zone zone-id                     Blocks a zone given in the format zone-id from a provider as if the zone is not existing. of controller compound
-      --compound.aws-route53.ratelimiter.burst int                    number of burst requests for rate limiter of controller compound
-      --compound.aws-route53.ratelimiter.enabled                      enables rate limiter for DNS provider requests of controller compound
-      --compound.aws-route53.ratelimiter.qps int                      maximum requests/queries per second of controller compound
-      --compound.azure-dns.advanced.batch-size int                    batch size for change requests (currently only used for aws-route53) of controller compound
-      --compound.azure-dns.advanced.max-retries int                   maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53) of controller compound
-      --compound.azure-dns.blocked-zone zone-id                       Blocks a zone given in the format zone-id from a provider as if the zone is not existing. of controller compound
-      --compound.azure-dns.ratelimiter.burst int                      number of burst requests for rate limiter of controller compound
-      --compound.azure-dns.ratelimiter.enabled                        enables rate limiter for DNS provider requests of controller compound
-      --compound.azure-dns.ratelimiter.qps int                        maximum requests/queries per second of controller compound
-      --compound.azure-private-dns.advanced.batch-size int            batch size for change requests (currently only used for aws-route53) of controller compound
-      --compound.azure-private-dns.advanced.max-retries int           maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53) of controller compound
-      --compound.azure-private-dns.blocked-zone zone-id               Blocks a zone given in the format zone-id from a provider as if the zone is not existing. of controller compound
-      --compound.azure-private-dns.ratelimiter.burst int              number of burst requests for rate limiter of controller compound
-      --compound.azure-private-dns.ratelimiter.enabled                enables rate limiter for DNS provider requests of controller compound
-      --compound.azure-private-dns.ratelimiter.qps int                maximum requests/queries per second of controller compound
-      --compound.blocked-zone zone-id                                 Blocks a zone given in the format zone-id from a provider as if the zone is not existing. of controller compound
-      --compound.cache-ttl int                                        Time-to-live for provider hosted zone cache of controller compound
-      --compound.cloudflare-dns.advanced.batch-size int               batch size for change requests (currently only used for aws-route53) of controller compound
-      --compound.cloudflare-dns.advanced.max-retries int              maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53) of controller compound
-      --compound.cloudflare-dns.blocked-zone zone-id                  Blocks a zone given in the format zone-id from a provider as if the zone is not existing. of controller compound
-      --compound.cloudflare-dns.ratelimiter.burst int                 number of burst requests for rate limiter of controller compound
-      --compound.cloudflare-dns.ratelimiter.enabled                   enables rate limiter for DNS provider requests of controller compound
-      --compound.cloudflare-dns.ratelimiter.qps int                   maximum requests/queries per second of controller compound
-      --compound.default.pool.size int                                Worker pool size for pool default of controller compound
-      --compound.disable-dnsname-validation                           disable validation of domain names according to RFC 1123. of controller compound
-      --compound.disable-zone-state-caching                           disable use of cached dns zone state on changes of controller compound
-      --compound.dns-class string                                     Class identifier used to differentiate responsible controllers for entry resources of controller compound
-      --compound.dns-delay duration                                   delay between two dns reconciliations of controller compound
-      --compound.dns.pool.resync-period duration                      Period for resynchronization for pool dns of controller compound
-      --compound.dns.pool.size int                                    Worker pool size for pool dns of controller compound
-      --compound.dry-run                                              just check, don't modify of controller compound
-      --compound.google-clouddns.advanced.batch-size int              batch size for change requests (currently only used for aws-route53) of controller compound
-      --compound.google-clouddns.advanced.max-retries int             maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53) of controller compound
-      --compound.google-clouddns.blocked-zone zone-id                 Blocks a zone given in the format zone-id from a provider as if the zone is not existing. of controller compound
-      --compound.google-clouddns.ratelimiter.burst int                number of burst requests for rate limiter of controller compound
-      --compound.google-clouddns.ratelimiter.enabled                  enables rate limiter for DNS provider requests of controller compound
-      --compound.google-clouddns.ratelimiter.qps int                  maximum requests/queries per second of controller compound
-      --compound.identifier string                                    Identifier used to mark DNS entries in DNS system of controller compound
-      --compound.infoblox-dns.advanced.batch-size int                 batch size for change requests (currently only used for aws-route53) of controller compound
-      --compound.infoblox-dns.advanced.max-retries int                maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53) of controller compound
-      --compound.infoblox-dns.blocked-zone zone-id                    Blocks a zone given in the format zone-id from a provider as if the zone is not existing. of controller compound
-      --compound.infoblox-dns.ratelimiter.burst int                   number of burst requests for rate limiter of controller compound
-      --compound.infoblox-dns.ratelimiter.enabled                     enables rate limiter for DNS provider requests of controller compound
-      --compound.infoblox-dns.ratelimiter.qps int                     maximum requests/queries per second of controller compound
-      --compound.lock-status-check-period duration                    interval for dns lock status checks of controller compound
+      --accepted-maintainers string                                     accepted maintainer key(s) for crds
+      --advanced.batch-size int                                         batch size for change requests (currently only used for aws-route53)
+      --advanced.max-retries int                                        maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53)
+      --alicloud-dns.advanced.batch-size int                            batch size for change requests (currently only used for aws-route53)
+      --alicloud-dns.advanced.max-retries int                           maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53)
+      --alicloud-dns.blocked-zone zone-id                               Blocks a zone given in the format zone-id from a provider as if the zone is not existing.
+      --alicloud-dns.ratelimiter.burst int                              number of burst requests for rate limiter
+      --alicloud-dns.ratelimiter.enabled                                enables rate limiter for DNS provider requests
+      --alicloud-dns.ratelimiter.qps int                                maximum requests/queries per second
+      --annotation.default.pool.size int                                Worker pool size for pool default of controller annotation
+      --annotation.pool.size int                                        Worker pool size of controller annotation
+      --annotation.setup int                                            number of processors for controller setup of controller annotation
+      --aws-route53.advanced.batch-size int                             batch size for change requests (currently only used for aws-route53)
+      --aws-route53.advanced.max-retries int                            maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53)
+      --aws-route53.blocked-zone zone-id                                Blocks a zone given in the format zone-id from a provider as if the zone is not existing.
+      --aws-route53.ratelimiter.burst int                               number of burst requests for rate limiter
+      --aws-route53.ratelimiter.enabled                                 enables rate limiter for DNS provider requests
+      --aws-route53.ratelimiter.qps int                                 maximum requests/queries per second
+      --azure-dns.advanced.batch-size int                               batch size for change requests (currently only used for aws-route53)
+      --azure-dns.advanced.max-retries int                              maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53)
+      --azure-dns.blocked-zone zone-id                                  Blocks a zone given in the format zone-id from a provider as if the zone is not existing.
+      --azure-dns.ratelimiter.burst int                                 number of burst requests for rate limiter
+      --azure-dns.ratelimiter.enabled                                   enables rate limiter for DNS provider requests
+      --azure-dns.ratelimiter.qps int                                   maximum requests/queries per second
+      --azure-private-dns.advanced.batch-size int                       batch size for change requests (currently only used for aws-route53)
+      --azure-private-dns.advanced.max-retries int                      maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53)
+      --azure-private-dns.blocked-zone zone-id                          Blocks a zone given in the format zone-id from a provider as if the zone is not existing.
+      --azure-private-dns.ratelimiter.burst int                         number of burst requests for rate limiter
+      --azure-private-dns.ratelimiter.enabled                           enables rate limiter for DNS provider requests
+      --azure-private-dns.ratelimiter.qps int                           maximum requests/queries per second
+      --bind-address-http string                                        HTTP server bind address
+      --blocked-zone zone-id                                            Blocks a zone given in the format zone-id from a provider as if the zone is not existing.
+      --cache-ttl int                                                   Time-to-live for provider hosted zone cache
+      --cloudflare-dns.advanced.batch-size int                          batch size for change requests (currently only used for aws-route53)
+      --cloudflare-dns.advanced.max-retries int                         maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53)
+      --cloudflare-dns.blocked-zone zone-id                             Blocks a zone given in the format zone-id from a provider as if the zone is not existing.
+      --cloudflare-dns.ratelimiter.burst int                            number of burst requests for rate limiter
+      --cloudflare-dns.ratelimiter.enabled                              enables rate limiter for DNS provider requests
+      --cloudflare-dns.ratelimiter.qps int                              maximum requests/queries per second
+      --compound.advanced.batch-size int                                batch size for change requests (currently only used for aws-route53) of controller compound
+      --compound.advanced.max-retries int                               maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53) of controller compound
+      --compound.alicloud-dns.advanced.batch-size int                   batch size for change requests (currently only used for aws-route53) of controller compound
+      --compound.alicloud-dns.advanced.max-retries int                  maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53) of controller compound
+      --compound.alicloud-dns.blocked-zone zone-id                      Blocks a zone given in the format zone-id from a provider as if the zone is not existing. of controller compound
+      --compound.alicloud-dns.ratelimiter.burst int                     number of burst requests for rate limiter of controller compound
+      --compound.alicloud-dns.ratelimiter.enabled                       enables rate limiter for DNS provider requests of controller compound
+      --compound.alicloud-dns.ratelimiter.qps int                       maximum requests/queries per second of controller compound
+      --compound.aws-route53.advanced.batch-size int                    batch size for change requests (currently only used for aws-route53) of controller compound
+      --compound.aws-route53.advanced.max-retries int                   maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53) of controller compound
+      --compound.aws-route53.blocked-zone zone-id                       Blocks a zone given in the format zone-id from a provider as if the zone is not existing. of controller compound
+      --compound.aws-route53.ratelimiter.burst int                      number of burst requests for rate limiter of controller compound
+      --compound.aws-route53.ratelimiter.enabled                        enables rate limiter for DNS provider requests of controller compound
+      --compound.aws-route53.ratelimiter.qps int                        maximum requests/queries per second of controller compound
+      --compound.azure-dns.advanced.batch-size int                      batch size for change requests (currently only used for aws-route53) of controller compound
+      --compound.azure-dns.advanced.max-retries int                     maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53) of controller compound
+      --compound.azure-dns.blocked-zone zone-id                         Blocks a zone given in the format zone-id from a provider as if the zone is not existing. of controller compound
+      --compound.azure-dns.ratelimiter.burst int                        number of burst requests for rate limiter of controller compound
+      --compound.azure-dns.ratelimiter.enabled                          enables rate limiter for DNS provider requests of controller compound
+      --compound.azure-dns.ratelimiter.qps int                          maximum requests/queries per second of controller compound
+      --compound.azure-private-dns.advanced.batch-size int              batch size for change requests (currently only used for aws-route53) of controller compound
+      --compound.azure-private-dns.advanced.max-retries int             maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53) of controller compound
+      --compound.azure-private-dns.blocked-zone zone-id                 Blocks a zone given in the format zone-id from a provider as if the zone is not existing. of controller compound
+      --compound.azure-private-dns.ratelimiter.burst int                number of burst requests for rate limiter of controller compound
+      --compound.azure-private-dns.ratelimiter.enabled                  enables rate limiter for DNS provider requests of controller compound
+      --compound.azure-private-dns.ratelimiter.qps int                  maximum requests/queries per second of controller compound
+      --compound.blocked-zone zone-id                                   Blocks a zone given in the format zone-id from a provider as if the zone is not existing. of controller compound
+      --compound.cache-ttl int                                          Time-to-live for provider hosted zone cache of controller compound
+      --compound.cloudflare-dns.advanced.batch-size int                 batch size for change requests (currently only used for aws-route53) of controller compound
+      --compound.cloudflare-dns.advanced.max-retries int                maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53) of controller compound
+      --compound.cloudflare-dns.blocked-zone zone-id                    Blocks a zone given in the format zone-id from a provider as if the zone is not existing. of controller compound
+      --compound.cloudflare-dns.ratelimiter.burst int                   number of burst requests for rate limiter of controller compound
+      --compound.cloudflare-dns.ratelimiter.enabled                     enables rate limiter for DNS provider requests of controller compound
+      --compound.cloudflare-dns.ratelimiter.qps int                     maximum requests/queries per second of controller compound
+      --compound.default.pool.size int                                  Worker pool size for pool default of controller compound
+      --compound.disable-dnsname-validation                             disable validation of domain names according to RFC 1123. of controller compound
+      --compound.disable-zone-state-caching                             disable use of cached dns zone state on changes of controller compound
+      --compound.dns-class string                                       Class identifier used to differentiate responsible controllers for entry resources of controller compound
+      --compound.dns-delay duration                                     delay between two dns reconciliations of controller compound
+      --compound.dns.pool.resync-period duration                        Period for resynchronization for pool dns of controller compound
+      --compound.dns.pool.size int                                      Worker pool size for pool dns of controller compound
+      --compound.dry-run                                                just check, don't modify of controller compound
+      --compound.google-clouddns.advanced.batch-size int                batch size for change requests (currently only used for aws-route53) of controller compound
+      --compound.google-clouddns.advanced.max-retries int               maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53) of controller compound
+      --compound.google-clouddns.blocked-zone zone-id                   Blocks a zone given in the format zone-id from a provider as if the zone is not existing. of controller compound
+      --compound.google-clouddns.ratelimiter.burst int                  number of burst requests for rate limiter of controller compound
+      --compound.google-clouddns.ratelimiter.enabled                    enables rate limiter for DNS provider requests of controller compound
+      --compound.google-clouddns.ratelimiter.qps int                    maximum requests/queries per second of controller compound
+      --compound.identifier string                                      Identifier used to mark DNS entries in DNS system of controller compound
+      --compound.infoblox-dns.advanced.batch-size int                   batch size for change requests (currently only used for aws-route53) of controller compound
+      --compound.infoblox-dns.advanced.max-retries int                  maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53) of controller compound
+      --compound.infoblox-dns.blocked-zone zone-id                      Blocks a zone given in the format zone-id from a provider as if the zone is not existing. of controller compound
+      --compound.infoblox-dns.ratelimiter.burst int                     number of burst requests for rate limiter of controller compound
+      --compound.infoblox-dns.ratelimiter.enabled                       enables rate limiter for DNS provider requests of controller compound
+      --compound.infoblox-dns.ratelimiter.qps int                       maximum requests/queries per second of controller compound
+      --compound.lock-status-check-period duration                      interval for dns lock status checks of controller compound
       --compound.max-metadata-record-deletions-per-reconciliation int   maximum number of metadata owner records that can be deleted per zone reconciliation of controller compound
-      --compound.netlify-dns.advanced.batch-size int                  batch size for change requests (currently only used for aws-route53) of controller compound
-      --compound.netlify-dns.advanced.max-retries int                 maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53) of controller compound
-      --compound.netlify-dns.blocked-zone zone-id                     Blocks a zone given in the format zone-id from a provider as if the zone is not existing. of controller compound
-      --compound.netlify-dns.ratelimiter.burst int                    number of burst requests for rate limiter of controller compound
-      --compound.netlify-dns.ratelimiter.enabled                      enables rate limiter for DNS provider requests of controller compound
-      --compound.netlify-dns.ratelimiter.qps int                      maximum requests/queries per second of controller compound
-      --compound.openstack-designate.advanced.batch-size int          batch size for change requests (currently only used for aws-route53) of controller compound
-      --compound.openstack-designate.advanced.max-retries int         maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53) of controller compound
-      --compound.openstack-designate.blocked-zone zone-id             Blocks a zone given in the format zone-id from a provider as if the zone is not existing. of controller compound
-      --compound.openstack-designate.ratelimiter.burst int            number of burst requests for rate limiter of controller compound
-      --compound.openstack-designate.ratelimiter.enabled              enables rate limiter for DNS provider requests of controller compound
-      --compound.openstack-designate.ratelimiter.qps int              maximum requests/queries per second of controller compound
-      --compound.ownerids.pool.size int                               Worker pool size for pool ownerids of controller compound
-      --compound.pool.resync-period duration                          Period for resynchronization of controller compound
-      --compound.pool.size int                                        Worker pool size of controller compound
-      --compound.provider-types string                                comma separated list of provider types to enable of controller compound
-      --compound.providers.pool.resync-period duration                Period for resynchronization for pool providers of controller compound
-      --compound.providers.pool.size int                              Worker pool size for pool providers of controller compound
-      --compound.ratelimiter.burst int                                number of burst requests for rate limiter of controller compound
-      --compound.ratelimiter.enabled                                  enables rate limiter for DNS provider requests of controller compound
-      --compound.ratelimiter.qps int                                  maximum requests/queries per second of controller compound
-      --compound.remote-access-cacert string                          CA who signed client certs file of controller compound
-      --compound.remote-access-client-id string                       identifier used for remote access of controller compound
-      --compound.remote-access-port int                               port of remote access server for remote-enabled providers of controller compound
-      --compound.remote-access-server-secret-name string              name of secret containing remote access server's certificate of controller compound
-      --compound.remote.advanced.batch-size int                       batch size for change requests (currently only used for aws-route53) of controller compound
-      --compound.remote.advanced.max-retries int                      maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53) of controller compound
-      --compound.remote.blocked-zone zone-id                          Blocks a zone given in the format zone-id from a provider as if the zone is not existing. of controller compound
-      --compound.remote.ratelimiter.burst int                         number of burst requests for rate limiter of controller compound
-      --compound.remote.ratelimiter.enabled                           enables rate limiter for DNS provider requests of controller compound
-      --compound.remote.ratelimiter.qps int                           maximum requests/queries per second of controller compound
-      --compound.reschedule-delay duration                            reschedule delay after losing provider of controller compound
-      --compound.rfc2136.advanced.batch-size int                      batch size for change requests (currently only used for aws-route53) of controller compound
-      --compound.rfc2136.advanced.max-retries int                     maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53) of controller compound
-      --compound.rfc2136.blocked-zone zone-id                         Blocks a zone given in the format zone-id from a provider as if the zone is not existing. of controller compound
-      --compound.rfc2136.ratelimiter.burst int                        number of burst requests for rate limiter of controller compound
-      --compound.rfc2136.ratelimiter.enabled                          enables rate limiter for DNS provider requests of controller compound
-      --compound.rfc2136.ratelimiter.qps int                          maximum requests/queries per second of controller compound
-      --compound.secrets.pool.size int                                Worker pool size for pool secrets of controller compound
-      --compound.setup int                                            number of processors for controller setup of controller compound
-      --compound.ttl int                                              Default time-to-live for DNS entries. Defines how long the record is kept in cache by DNS servers or resolvers. of controller compound
-      --compound.zonepolicies.pool.size int                           Worker pool size for pool zonepolicies of controller compound
-      --config string                                                 config file
-  -c, --controllers string                                            comma separated list of controllers to start (<name>,<group>,all)
-      --cpuprofile string                                             set file for cpu profiling
-      --default.pool.resync-period duration                           Period for resynchronization for pool default
-      --default.pool.size int                                         Worker pool size for pool default
-      --disable-dnsname-validation                                    disable validation of domain names according to RFC 1123.
-      --disable-namespace-restriction                                 disable access restriction for namespace local access only
-      --disable-zone-state-caching                                    disable use of cached dns zone state on changes
-      --dns-class string                                              identifier used to differentiate responsible controllers for providers, identifier used to differentiate responsible controllers for entries, Class identifier used to differentiate responsible controllers for entry resources
-      --dns-delay duration                                            delay between two dns reconciliations
-      --dns-target-class string                                       identifier used to differentiate responsible dns controllers for target providers, identifier used to differentiate responsible dns controllers for target entries
-      --dns.pool.resync-period duration                               Period for resynchronization for pool dns
-      --dns.pool.size int                                             Worker pool size for pool dns
-      --dnsentry-source.default.pool.resync-period duration           Period for resynchronization for pool default of controller dnsentry-source
-      --dnsentry-source.default.pool.size int                         Worker pool size for pool default of controller dnsentry-source
-      --dnsentry-source.dns-class string                              identifier used to differentiate responsible controllers for entries of controller dnsentry-source
-      --dnsentry-source.dns-target-class string                       identifier used to differentiate responsible dns controllers for target entries of controller dnsentry-source
-      --dnsentry-source.exclude-domains stringArray                   excluded domains of controller dnsentry-source
-      --dnsentry-source.key string                                    selecting key for annotation of controller dnsentry-source
-      --dnsentry-source.pool.resync-period duration                   Period for resynchronization of controller dnsentry-source
-      --dnsentry-source.pool.size int                                 Worker pool size of controller dnsentry-source
-      --dnsentry-source.target-creator-label-name string              label name to store the creator for generated DNS entries of controller dnsentry-source
-      --dnsentry-source.target-creator-label-value string             label value for creator label of controller dnsentry-source
-      --dnsentry-source.target-name-prefix string                     name prefix in target namespace for cross cluster generation of controller dnsentry-source
-      --dnsentry-source.target-namespace string                       target namespace for cross cluster generation of controller dnsentry-source
-      --dnsentry-source.target-owner-id string                        owner id to use for generated DNS entries of controller dnsentry-source
-      --dnsentry-source.target-owner-object string                    owner object to use for generated DNS entries of controller dnsentry-source
-      --dnsentry-source.target-realms string                          realm(s) to use for generated DNS entries of controller dnsentry-source
-      --dnsentry-source.target-set-ignore-owners                      mark generated DNS entries to omit owner based access control of controller dnsentry-source
-      --dnsentry-source.targets.pool.size int                         Worker pool size for pool targets of controller dnsentry-source
-      --dnsprovider-replication.default.pool.resync-period duration   Period for resynchronization for pool default of controller dnsprovider-replication
-      --dnsprovider-replication.default.pool.size int                 Worker pool size for pool default of controller dnsprovider-replication
-      --dnsprovider-replication.dns-class string                      identifier used to differentiate responsible controllers for providers of controller dnsprovider-replication
-      --dnsprovider-replication.dns-target-class string               identifier used to differentiate responsible dns controllers for target providers of controller dnsprovider-replication
-      --dnsprovider-replication.pool.resync-period duration           Period for resynchronization of controller dnsprovider-replication
-      --dnsprovider-replication.pool.size int                         Worker pool size of controller dnsprovider-replication
-      --dnsprovider-replication.target-creator-label-name string      label name to store the creator for replicated DNS providers of controller dnsprovider-replication
-      --dnsprovider-replication.target-creator-label-value string     label value for creator label of controller dnsprovider-replication
-      --dnsprovider-replication.target-name-prefix string             name prefix in target namespace for cross cluster replication of controller dnsprovider-replication
-      --dnsprovider-replication.target-namespace string               target namespace for cross cluster generation of controller dnsprovider-replication
-      --dnsprovider-replication.target-realms string                  realm(s) to use for replicated DNS provider of controller dnsprovider-replication
-      --dnsprovider-replication.targets.pool.size int                 Worker pool size for pool targets of controller dnsprovider-replication
-      --dry-run                                                       just check, don't modify
-      --enable-profiling                                              enables profiling server at path /debug/pprof (needs option --server-port-http)
-      --exclude-domains stringArray                                   excluded domains
-      --force-crd-update                                              enforce update of crds even they are unmanaged
-      --google-clouddns.advanced.batch-size int                       batch size for change requests (currently only used for aws-route53)
-      --google-clouddns.advanced.max-retries int                      maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53)
-      --google-clouddns.blocked-zone zone-id                          Blocks a zone given in the format zone-id from a provider as if the zone is not existing.
-      --google-clouddns.ratelimiter.burst int                         number of burst requests for rate limiter
-      --google-clouddns.ratelimiter.enabled                           enables rate limiter for DNS provider requests
-      --google-clouddns.ratelimiter.qps int                           maximum requests/queries per second
-      --grace-period duration                                         inactivity grace period for detecting end of cleanup for shutdown
-  -h, --help                                                          help for dns-controller-manager
-      --httproutes.pool.size int                                      Worker pool size for pool httproutes
-      --identifier string                                             Identifier used to mark DNS entries in DNS system
-      --infoblox-dns.advanced.batch-size int                          batch size for change requests (currently only used for aws-route53)
-      --infoblox-dns.advanced.max-retries int                         maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53)
-      --infoblox-dns.blocked-zone zone-id                             Blocks a zone given in the format zone-id from a provider as if the zone is not existing.
-      --infoblox-dns.ratelimiter.burst int                            number of burst requests for rate limiter
-      --infoblox-dns.ratelimiter.enabled                              enables rate limiter for DNS provider requests
-      --infoblox-dns.ratelimiter.qps int                              maximum requests/queries per second
-      --ingress-dns.default.pool.resync-period duration               Period for resynchronization for pool default of controller ingress-dns
-      --ingress-dns.default.pool.size int                             Worker pool size for pool default of controller ingress-dns
-      --ingress-dns.dns-class string                                  identifier used to differentiate responsible controllers for entries of controller ingress-dns
-      --ingress-dns.dns-target-class string                           identifier used to differentiate responsible dns controllers for target entries of controller ingress-dns
-      --ingress-dns.exclude-domains stringArray                       excluded domains of controller ingress-dns
-      --ingress-dns.key string                                        selecting key for annotation of controller ingress-dns
-      --ingress-dns.pool.resync-period duration                       Period for resynchronization of controller ingress-dns
-      --ingress-dns.pool.size int                                     Worker pool size of controller ingress-dns
-      --ingress-dns.target-creator-label-name string                  label name to store the creator for generated DNS entries of controller ingress-dns
-      --ingress-dns.target-creator-label-value string                 label value for creator label of controller ingress-dns
-      --ingress-dns.target-name-prefix string                         name prefix in target namespace for cross cluster generation of controller ingress-dns
-      --ingress-dns.target-namespace string                           target namespace for cross cluster generation of controller ingress-dns
-      --ingress-dns.target-owner-id string                            owner id to use for generated DNS entries of controller ingress-dns
-      --ingress-dns.target-owner-object string                        owner object to use for generated DNS entries of controller ingress-dns
-      --ingress-dns.target-realms string                              realm(s) to use for generated DNS entries of controller ingress-dns
-      --ingress-dns.target-set-ignore-owners                          mark generated DNS entries to omit owner based access control of controller ingress-dns
-      --ingress-dns.targets.pool.size int                             Worker pool size for pool targets of controller ingress-dns
-      --istio-gateways-dns.default.pool.resync-period duration        Period for resynchronization for pool default of controller istio-gateways-dns
-      --istio-gateways-dns.default.pool.size int                      Worker pool size for pool default of controller istio-gateways-dns
-      --istio-gateways-dns.dns-class string                           identifier used to differentiate responsible controllers for entries of controller istio-gateways-dns
-      --istio-gateways-dns.dns-target-class string                    identifier used to differentiate responsible dns controllers for target entries of controller istio-gateways-dns
-      --istio-gateways-dns.exclude-domains stringArray                excluded domains of controller istio-gateways-dns
-      --istio-gateways-dns.key string                                 selecting key for annotation of controller istio-gateways-dns
-      --istio-gateways-dns.pool.resync-period duration                Period for resynchronization of controller istio-gateways-dns
-      --istio-gateways-dns.pool.size int                              Worker pool size of controller istio-gateways-dns
-      --istio-gateways-dns.target-creator-label-name string           label name to store the creator for generated DNS entries of controller istio-gateways-dns
-      --istio-gateways-dns.target-creator-label-value string          label value for creator label of controller istio-gateways-dns
-      --istio-gateways-dns.target-name-prefix string                  name prefix in target namespace for cross cluster generation of controller istio-gateways-dns
-      --istio-gateways-dns.target-namespace string                    target namespace for cross cluster generation of controller istio-gateways-dns
-      --istio-gateways-dns.target-owner-id string                     owner id to use for generated DNS entries of controller istio-gateways-dns
-      --istio-gateways-dns.target-owner-object string                 owner object to use for generated DNS entries of controller istio-gateways-dns
-      --istio-gateways-dns.target-realms string                       realm(s) to use for generated DNS entries of controller istio-gateways-dns
-      --istio-gateways-dns.target-set-ignore-owners                   mark generated DNS entries to omit owner based access control of controller istio-gateways-dns
-      --istio-gateways-dns.targets.pool.size int                      Worker pool size for pool targets of controller istio-gateways-dns
-      --istio-gateways-dns.targetsources.pool.size int                Worker pool size for pool targetsources of controller istio-gateways-dns
-      --istio-gateways-dns.virtualservices.pool.size int              Worker pool size for pool virtualservices of controller istio-gateways-dns
-      --k8s-gateways-dns.default.pool.resync-period duration          Period for resynchronization for pool default of controller k8s-gateways-dns
-      --k8s-gateways-dns.default.pool.size int                        Worker pool size for pool default of controller k8s-gateways-dns
-      --k8s-gateways-dns.dns-class string                             identifier used to differentiate responsible controllers for entries of controller k8s-gateways-dns
-      --k8s-gateways-dns.dns-target-class string                      identifier used to differentiate responsible dns controllers for target entries of controller k8s-gateways-dns
-      --k8s-gateways-dns.exclude-domains stringArray                  excluded domains of controller k8s-gateways-dns
-      --k8s-gateways-dns.httproutes.pool.size int                     Worker pool size for pool httproutes of controller k8s-gateways-dns
-      --k8s-gateways-dns.key string                                   selecting key for annotation of controller k8s-gateways-dns
-      --k8s-gateways-dns.pool.resync-period duration                  Period for resynchronization of controller k8s-gateways-dns
-      --k8s-gateways-dns.pool.size int                                Worker pool size of controller k8s-gateways-dns
-      --k8s-gateways-dns.target-creator-label-name string             label name to store the creator for generated DNS entries of controller k8s-gateways-dns
-      --k8s-gateways-dns.target-creator-label-value string            label value for creator label of controller k8s-gateways-dns
-      --k8s-gateways-dns.target-name-prefix string                    name prefix in target namespace for cross cluster generation of controller k8s-gateways-dns
-      --k8s-gateways-dns.target-namespace string                      target namespace for cross cluster generation of controller k8s-gateways-dns
-      --k8s-gateways-dns.target-owner-id string                       owner id to use for generated DNS entries of controller k8s-gateways-dns
-      --k8s-gateways-dns.target-owner-object string                   owner object to use for generated DNS entries of controller k8s-gateways-dns
-      --k8s-gateways-dns.target-realms string                         realm(s) to use for generated DNS entries of controller k8s-gateways-dns
-      --k8s-gateways-dns.target-set-ignore-owners                     mark generated DNS entries to omit owner based access control of controller k8s-gateways-dns
-      --k8s-gateways-dns.targets.pool.size int                        Worker pool size for pool targets of controller k8s-gateways-dns
-      --key string                                                    selecting key for annotation
-      --kubeconfig string                                             default cluster access
-      --kubeconfig.disable-deploy-crds                                disable deployment of required crds for cluster default
-      --kubeconfig.id string                                          id for cluster default
-      --kubeconfig.migration-ids string                               migration id for cluster default
-      --lease-duration duration                                       lease duration
-      --lease-name string                                             name for lease object
-      --lease-renew-deadline duration                                 lease renew deadline
-      --lease-resource-lock string                                    determines which resource lock to use for leader election, defaults to 'leases'
-      --lease-retry-period duration                                   lease retry period
-      --lock-status-check-period duration                             interval for dns lock status checks
-  -D, --log-level string                                              logrus log level
-      --maintainer string                                             maintainer key for crds (default "dns-controller-manager")
-      --max-metadata-record-deletions-per-reconciliation int          maximum number of metadata owner records that can be deleted per zone reconciliation      
-      --name string                                                   name used for controller manager (default "dns-controller-manager")
-      --namespace string                                              namespace for lease (default "kube-system")
-  -n, --namespace-local-access-only                                   enable access restriction for namespace local access only (deprecated)
-      --netlify-dns.advanced.batch-size int                           batch size for change requests (currently only used for aws-route53)
-      --netlify-dns.advanced.max-retries int                          maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53)
-      --netlify-dns.blocked-zone zone-id                              Blocks a zone given in the format zone-id from a provider as if the zone is not existing.
-      --netlify-dns.ratelimiter.burst int                             number of burst requests for rate limiter
-      --netlify-dns.ratelimiter.enabled                               enables rate limiter for DNS provider requests
-      --netlify-dns.ratelimiter.qps int                               maximum requests/queries per second
-      --omit-lease                                                    omit lease for development
-      --openstack-designate.advanced.batch-size int                   batch size for change requests (currently only used for aws-route53)
-      --openstack-designate.advanced.max-retries int                  maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53)
-      --openstack-designate.blocked-zone zone-id                      Blocks a zone given in the format zone-id from a provider as if the zone is not existing.
-      --openstack-designate.ratelimiter.burst int                     number of burst requests for rate limiter
-      --openstack-designate.ratelimiter.enabled                       enables rate limiter for DNS provider requests
-      --openstack-designate.ratelimiter.qps int                       maximum requests/queries per second
-      --ownerids.pool.size int                                        Worker pool size for pool ownerids
-      --plugin-file string                                            directory containing go plugins
-      --pool.resync-period duration                                   Period for resynchronization
-      --pool.size int                                                 Worker pool size
-      --provider-types string                                         comma separated list of provider types to enable
-      --providers string                                              cluster to look for provider objects
-      --providers.disable-deploy-crds                                 disable deployment of required crds for cluster provider
-      --providers.id string                                           id for cluster provider
-      --providers.migration-ids string                                migration id for cluster provider
-      --providers.pool.resync-period duration                         Period for resynchronization for pool providers
-      --providers.pool.size int                                       Worker pool size for pool providers
-      --ratelimiter.burst int                                         number of burst requests for rate limiter
-      --ratelimiter.enabled                                           enables rate limiter for DNS provider requests
-      --ratelimiter.qps int                                           maximum requests/queries per second
-      --remote-access-cacert string                                   filename for certificate of client CA, CA who signed client certs file
-      --remote-access-cakey string                                    filename for private key of client CA
-      --remote-access-client-id string                                identifier used for remote access
-      --remote-access-port int                                        port of remote access server for remote-enabled providers
-      --remote-access-server-secret-name string                       name of secret containing remote access server's certificate
-      --remote.advanced.batch-size int                                batch size for change requests (currently only used for aws-route53)
-      --remote.advanced.max-retries int                               maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53)
-      --remote.blocked-zone zone-id                                   Blocks a zone given in the format zone-id from a provider as if the zone is not existing.
-      --remote.ratelimiter.burst int                                  number of burst requests for rate limiter
-      --remote.ratelimiter.enabled                                    enables rate limiter for DNS provider requests
-      --remote.ratelimiter.qps int                                    maximum requests/queries per second
-      --remoteaccesscertificates.default.pool.size int                Worker pool size for pool default of controller remoteaccesscertificates
-      --remoteaccesscertificates.pool.size int                        Worker pool size of controller remoteaccesscertificates
-      --remoteaccesscertificates.remote-access-cacert string          filename for certificate of client CA of controller remoteaccesscertificates
-      --remoteaccesscertificates.remote-access-cakey string           filename for private key of client CA of controller remoteaccesscertificates
-      --reschedule-delay duration                                     reschedule delay after losing provider
-      --rfc2136.advanced.batch-size int                               batch size for change requests (currently only used for aws-route53)
-      --rfc2136.advanced.max-retries int                              maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53)
-      --rfc2136.blocked-zone zone-id                                  Blocks a zone given in the format zone-id from a provider as if the zone is not existing.
-      --rfc2136.ratelimiter.burst int                                 number of burst requests for rate limiter
-      --rfc2136.ratelimiter.enabled                                   enables rate limiter for DNS provider requests
-      --rfc2136.ratelimiter.qps int                                   maximum requests/queries per second
-      --secrets.pool.size int                                         Worker pool size for pool secrets
-      --server-port-http int                                          HTTP server port (serving /healthz, /metrics, ...)
-      --service-dns.default.pool.resync-period duration               Period for resynchronization for pool default of controller service-dns
-      --service-dns.default.pool.size int                             Worker pool size for pool default of controller service-dns
-      --service-dns.dns-class string                                  identifier used to differentiate responsible controllers for entries of controller service-dns
-      --service-dns.dns-target-class string                           identifier used to differentiate responsible dns controllers for target entries of controller service-dns
-      --service-dns.exclude-domains stringArray                       excluded domains of controller service-dns
-      --service-dns.key string                                        selecting key for annotation of controller service-dns
-      --service-dns.pool.resync-period duration                       Period for resynchronization of controller service-dns
-      --service-dns.pool.size int                                     Worker pool size of controller service-dns
-      --service-dns.target-creator-label-name string                  label name to store the creator for generated DNS entries of controller service-dns
-      --service-dns.target-creator-label-value string                 label value for creator label of controller service-dns
-      --service-dns.target-name-prefix string                         name prefix in target namespace for cross cluster generation of controller service-dns
-      --service-dns.target-namespace string                           target namespace for cross cluster generation of controller service-dns
-      --service-dns.target-owner-id string                            owner id to use for generated DNS entries of controller service-dns
-      --service-dns.target-owner-object string                        owner object to use for generated DNS entries of controller service-dns
-      --service-dns.target-realms string                              realm(s) to use for generated DNS entries of controller service-dns
-      --service-dns.target-set-ignore-owners                          mark generated DNS entries to omit owner based access control of controller service-dns
-      --service-dns.targets.pool.size int                             Worker pool size for pool targets of controller service-dns
-      --setup int                                                     number of processors for controller setup
-      --target string                                                 target cluster for dns requests
-      --target-creator-label-name string                              label name to store the creator for replicated DNS providers, label name to store the creator for generated DNS entries
-      --target-creator-label-value string                             label value for creator label
-      --target-name-prefix string                                     name prefix in target namespace for cross cluster replication, name prefix in target namespace for cross cluster generation
-      --target-namespace string                                       target namespace for cross cluster generation
-      --target-owner-id string                                        owner id to use for generated DNS entries
-      --target-owner-object string                                    owner object to use for generated DNS entries
-      --target-realms string                                          realm(s) to use for replicated DNS provider, realm(s) to use for generated DNS entries
-      --target-set-ignore-owners                                      mark generated DNS entries to omit owner based access control
-      --target.disable-deploy-crds                                    disable deployment of required crds for cluster target
-      --target.id string                                              id for cluster target
-      --target.migration-ids string                                   migration id for cluster target
-      --targets.pool.size int                                         Worker pool size for pool targets
-      --targetsources.pool.size int                                   Worker pool size for pool targetsources
-      --ttl int                                                       Default time-to-live for DNS entries. Defines how long the record is kept in cache by DNS servers or resolvers.
-  -v, --version                                                       version for dns-controller-manager
-      --virtualservices.pool.size int                                 Worker pool size for pool virtualservices
-      --watch-gateways-crds.default.pool.size int                     Worker pool size for pool default of controller watch-gateways-crds
-      --watch-gateways-crds.pool.size int                             Worker pool size of controller watch-gateways-crds
-      --zonepolicies.pool.size int                                    Worker pool size for pool zonepolicies
+      --compound.netlify-dns.advanced.batch-size int                    batch size for change requests (currently only used for aws-route53) of controller compound
+      --compound.netlify-dns.advanced.max-retries int                   maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53) of controller compound
+      --compound.netlify-dns.blocked-zone zone-id                       Blocks a zone given in the format zone-id from a provider as if the zone is not existing. of controller compound
+      --compound.netlify-dns.ratelimiter.burst int                      number of burst requests for rate limiter of controller compound
+      --compound.netlify-dns.ratelimiter.enabled                        enables rate limiter for DNS provider requests of controller compound
+      --compound.netlify-dns.ratelimiter.qps int                        maximum requests/queries per second of controller compound
+      --compound.openstack-designate.advanced.batch-size int            batch size for change requests (currently only used for aws-route53) of controller compound
+      --compound.openstack-designate.advanced.max-retries int           maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53) of controller compound
+      --compound.openstack-designate.blocked-zone zone-id               Blocks a zone given in the format zone-id from a provider as if the zone is not existing. of controller compound
+      --compound.openstack-designate.ratelimiter.burst int              number of burst requests for rate limiter of controller compound
+      --compound.openstack-designate.ratelimiter.enabled                enables rate limiter for DNS provider requests of controller compound
+      --compound.openstack-designate.ratelimiter.qps int                maximum requests/queries per second of controller compound
+      --compound.ownerids.pool.size int                                 Worker pool size for pool ownerids of controller compound
+      --compound.pool.resync-period duration                            Period for resynchronization of controller compound
+      --compound.pool.size int                                          Worker pool size of controller compound
+      --compound.powerdns.advanced.batch-size int                       batch size for change requests (currently only used for aws-route53) of controller compound
+      --compound.powerdns.advanced.max-retries int                      maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53) of controller compound
+      --compound.powerdns.blocked-zone zone-id                          Blocks a zone given in the format zone-id from a provider as if the zone is not existing. of controller compound
+      --compound.powerdns.ratelimiter.burst int                         number of burst requests for rate limiter of controller compound
+      --compound.powerdns.ratelimiter.enabled                           enables rate limiter for DNS provider requests of controller compound
+      --compound.powerdns.ratelimiter.qps int                           maximum requests/queries per second of controller compound
+      --compound.provider-types string                                  comma separated list of provider types to enable of controller compound
+      --compound.providers.pool.resync-period duration                  Period for resynchronization for pool providers of controller compound
+      --compound.providers.pool.size int                                Worker pool size for pool providers of controller compound
+      --compound.ratelimiter.burst int                                  number of burst requests for rate limiter of controller compound
+      --compound.ratelimiter.enabled                                    enables rate limiter for DNS provider requests of controller compound
+      --compound.ratelimiter.qps int                                    maximum requests/queries per second of controller compound
+      --compound.remote-access-cacert string                            CA who signed client certs file of controller compound
+      --compound.remote-access-client-id string                         identifier used for remote access of controller compound
+      --compound.remote-access-port int                                 port of remote access server for remote-enabled providers of controller compound
+      --compound.remote-access-server-secret-name string                name of secret containing remote access server's certificate of controller compound
+      --compound.remote.advanced.batch-size int                         batch size for change requests (currently only used for aws-route53) of controller compound
+      --compound.remote.advanced.max-retries int                        maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53) of controller compound
+      --compound.remote.blocked-zone zone-id                            Blocks a zone given in the format zone-id from a provider as if the zone is not existing. of controller compound
+      --compound.remote.ratelimiter.burst int                           number of burst requests for rate limiter of controller compound
+      --compound.remote.ratelimiter.enabled                             enables rate limiter for DNS provider requests of controller compound
+      --compound.remote.ratelimiter.qps int                             maximum requests/queries per second of controller compound
+      --compound.reschedule-delay duration                              reschedule delay after losing provider of controller compound
+      --compound.rfc2136.advanced.batch-size int                        batch size for change requests (currently only used for aws-route53) of controller compound
+      --compound.rfc2136.advanced.max-retries int                       maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53) of controller compound
+      --compound.rfc2136.blocked-zone zone-id                           Blocks a zone given in the format zone-id from a provider as if the zone is not existing. of controller compound
+      --compound.rfc2136.ratelimiter.burst int                          number of burst requests for rate limiter of controller compound
+      --compound.rfc2136.ratelimiter.enabled                            enables rate limiter for DNS provider requests of controller compound
+      --compound.rfc2136.ratelimiter.qps int                            maximum requests/queries per second of controller compound
+      --compound.secrets.pool.size int                                  Worker pool size for pool secrets of controller compound
+      --compound.setup int                                              number of processors for controller setup of controller compound
+      --compound.ttl int                                                Default time-to-live for DNS entries. Defines how long the record is kept in cache by DNS servers or resolvers. of controller compound
+      --compound.zonepolicies.pool.size int                             Worker pool size for pool zonepolicies of controller compound
+      --config string                                                   config file
+  -c, --controllers string                                              comma separated list of controllers to start (<name>,<group>,all)
+      --cpuprofile string                                               set file for cpu profiling
+      --default.pool.resync-period duration                             Period for resynchronization for pool default
+      --default.pool.size int                                           Worker pool size for pool default
+      --disable-dnsname-validation                                      disable validation of domain names according to RFC 1123.
+      --disable-namespace-restriction                                   disable access restriction for namespace local access only
+      --disable-zone-state-caching                                      disable use of cached dns zone state on changes
+      --dns-class string                                                identifier used to differentiate responsible controllers for entries, identifier used to differentiate responsible controllers for providers, Class identifier used to differentiate responsible controllers for entry resources
+      --dns-delay duration                                              delay between two dns reconciliations
+      --dns-target-class string                                         identifier used to differentiate responsible dns controllers for target entries, identifier used to differentiate responsible dns controllers for target providers
+      --dns.pool.resync-period duration                                 Period for resynchronization for pool dns
+      --dns.pool.size int                                               Worker pool size for pool dns
+      --dnsentry-source.default.pool.resync-period duration             Period for resynchronization for pool default of controller dnsentry-source
+      --dnsentry-source.default.pool.size int                           Worker pool size for pool default of controller dnsentry-source
+      --dnsentry-source.dns-class string                                identifier used to differentiate responsible controllers for entries of controller dnsentry-source
+      --dnsentry-source.dns-target-class string                         identifier used to differentiate responsible dns controllers for target entries of controller dnsentry-source
+      --dnsentry-source.exclude-domains stringArray                     excluded domains of controller dnsentry-source
+      --dnsentry-source.key string                                      selecting key for annotation of controller dnsentry-source
+      --dnsentry-source.pool.resync-period duration                     Period for resynchronization of controller dnsentry-source
+      --dnsentry-source.pool.size int                                   Worker pool size of controller dnsentry-source
+      --dnsentry-source.target-creator-label-name string                label name to store the creator for generated DNS entries of controller dnsentry-source
+      --dnsentry-source.target-creator-label-value string               label value for creator label of controller dnsentry-source
+      --dnsentry-source.target-name-prefix string                       name prefix in target namespace for cross cluster generation of controller dnsentry-source
+      --dnsentry-source.target-namespace string                         target namespace for cross cluster generation of controller dnsentry-source
+      --dnsentry-source.target-owner-id string                          owner id to use for generated DNS entries of controller dnsentry-source
+      --dnsentry-source.target-owner-object string                      owner object to use for generated DNS entries of controller dnsentry-source
+      --dnsentry-source.target-realms string                            realm(s) to use for generated DNS entries of controller dnsentry-source
+      --dnsentry-source.target-set-ignore-owners                        mark generated DNS entries to omit owner based access control of controller dnsentry-source
+      --dnsentry-source.targets.pool.size int                           Worker pool size for pool targets of controller dnsentry-source
+      --dnsprovider-replication.default.pool.resync-period duration     Period for resynchronization for pool default of controller dnsprovider-replication
+      --dnsprovider-replication.default.pool.size int                   Worker pool size for pool default of controller dnsprovider-replication
+      --dnsprovider-replication.dns-class string                        identifier used to differentiate responsible controllers for providers of controller dnsprovider-replication
+      --dnsprovider-replication.dns-target-class string                 identifier used to differentiate responsible dns controllers for target providers of controller dnsprovider-replication
+      --dnsprovider-replication.pool.resync-period duration             Period for resynchronization of controller dnsprovider-replication
+      --dnsprovider-replication.pool.size int                           Worker pool size of controller dnsprovider-replication
+      --dnsprovider-replication.target-creator-label-name string        label name to store the creator for replicated DNS providers of controller dnsprovider-replication
+      --dnsprovider-replication.target-creator-label-value string       label value for creator label of controller dnsprovider-replication
+      --dnsprovider-replication.target-name-prefix string               name prefix in target namespace for cross cluster replication of controller dnsprovider-replication
+      --dnsprovider-replication.target-namespace string                 target namespace for cross cluster generation of controller dnsprovider-replication
+      --dnsprovider-replication.target-realms string                    realm(s) to use for replicated DNS provider of controller dnsprovider-replication
+      --dnsprovider-replication.targets.pool.size int                   Worker pool size for pool targets of controller dnsprovider-replication
+      --dry-run                                                         just check, don't modify
+      --enable-profiling                                                enables profiling server at path /debug/pprof (needs option --server-port-http)
+      --exclude-domains stringArray                                     excluded domains
+      --force-crd-update                                                enforce update of crds even they are unmanaged
+      --google-clouddns.advanced.batch-size int                         batch size for change requests (currently only used for aws-route53)
+      --google-clouddns.advanced.max-retries int                        maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53)
+      --google-clouddns.blocked-zone zone-id                            Blocks a zone given in the format zone-id from a provider as if the zone is not existing.
+      --google-clouddns.ratelimiter.burst int                           number of burst requests for rate limiter
+      --google-clouddns.ratelimiter.enabled                             enables rate limiter for DNS provider requests
+      --google-clouddns.ratelimiter.qps int                             maximum requests/queries per second
+      --grace-period duration                                           inactivity grace period for detecting end of cleanup for shutdown
+  -h, --help                                                            help for dns-controller-manager
+      --httproutes.pool.size int                                        Worker pool size for pool httproutes
+      --identifier string                                               Identifier used to mark DNS entries in DNS system
+      --infoblox-dns.advanced.batch-size int                            batch size for change requests (currently only used for aws-route53)
+      --infoblox-dns.advanced.max-retries int                           maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53)
+      --infoblox-dns.blocked-zone zone-id                               Blocks a zone given in the format zone-id from a provider as if the zone is not existing.
+      --infoblox-dns.ratelimiter.burst int                              number of burst requests for rate limiter
+      --infoblox-dns.ratelimiter.enabled                                enables rate limiter for DNS provider requests
+      --infoblox-dns.ratelimiter.qps int                                maximum requests/queries per second
+      --ingress-dns.default.pool.resync-period duration                 Period for resynchronization for pool default of controller ingress-dns
+      --ingress-dns.default.pool.size int                               Worker pool size for pool default of controller ingress-dns
+      --ingress-dns.dns-class string                                    identifier used to differentiate responsible controllers for entries of controller ingress-dns
+      --ingress-dns.dns-target-class string                             identifier used to differentiate responsible dns controllers for target entries of controller ingress-dns
+      --ingress-dns.exclude-domains stringArray                         excluded domains of controller ingress-dns
+      --ingress-dns.key string                                          selecting key for annotation of controller ingress-dns
+      --ingress-dns.pool.resync-period duration                         Period for resynchronization of controller ingress-dns
+      --ingress-dns.pool.size int                                       Worker pool size of controller ingress-dns
+      --ingress-dns.target-creator-label-name string                    label name to store the creator for generated DNS entries of controller ingress-dns
+      --ingress-dns.target-creator-label-value string                   label value for creator label of controller ingress-dns
+      --ingress-dns.target-name-prefix string                           name prefix in target namespace for cross cluster generation of controller ingress-dns
+      --ingress-dns.target-namespace string                             target namespace for cross cluster generation of controller ingress-dns
+      --ingress-dns.target-owner-id string                              owner id to use for generated DNS entries of controller ingress-dns
+      --ingress-dns.target-owner-object string                          owner object to use for generated DNS entries of controller ingress-dns
+      --ingress-dns.target-realms string                                realm(s) to use for generated DNS entries of controller ingress-dns
+      --ingress-dns.target-set-ignore-owners                            mark generated DNS entries to omit owner based access control of controller ingress-dns
+      --ingress-dns.targets.pool.size int                               Worker pool size for pool targets of controller ingress-dns
+      --istio-gateways-dns.default.pool.resync-period duration          Period for resynchronization for pool default of controller istio-gateways-dns
+      --istio-gateways-dns.default.pool.size int                        Worker pool size for pool default of controller istio-gateways-dns
+      --istio-gateways-dns.dns-class string                             identifier used to differentiate responsible controllers for entries of controller istio-gateways-dns
+      --istio-gateways-dns.dns-target-class string                      identifier used to differentiate responsible dns controllers for target entries of controller istio-gateways-dns
+      --istio-gateways-dns.exclude-domains stringArray                  excluded domains of controller istio-gateways-dns
+      --istio-gateways-dns.key string                                   selecting key for annotation of controller istio-gateways-dns
+      --istio-gateways-dns.pool.resync-period duration                  Period for resynchronization of controller istio-gateways-dns
+      --istio-gateways-dns.pool.size int                                Worker pool size of controller istio-gateways-dns
+      --istio-gateways-dns.target-creator-label-name string             label name to store the creator for generated DNS entries of controller istio-gateways-dns
+      --istio-gateways-dns.target-creator-label-value string            label value for creator label of controller istio-gateways-dns
+      --istio-gateways-dns.target-name-prefix string                    name prefix in target namespace for cross cluster generation of controller istio-gateways-dns
+      --istio-gateways-dns.target-namespace string                      target namespace for cross cluster generation of controller istio-gateways-dns
+      --istio-gateways-dns.target-owner-id string                       owner id to use for generated DNS entries of controller istio-gateways-dns
+      --istio-gateways-dns.target-owner-object string                   owner object to use for generated DNS entries of controller istio-gateways-dns
+      --istio-gateways-dns.target-realms string                         realm(s) to use for generated DNS entries of controller istio-gateways-dns
+      --istio-gateways-dns.target-set-ignore-owners                     mark generated DNS entries to omit owner based access control of controller istio-gateways-dns
+      --istio-gateways-dns.targets.pool.size int                        Worker pool size for pool targets of controller istio-gateways-dns
+      --istio-gateways-dns.targetsources.pool.size int                  Worker pool size for pool targetsources of controller istio-gateways-dns
+      --istio-gateways-dns.virtualservices.pool.size int                Worker pool size for pool virtualservices of controller istio-gateways-dns
+      --k8s-gateways-dns.default.pool.resync-period duration            Period for resynchronization for pool default of controller k8s-gateways-dns
+      --k8s-gateways-dns.default.pool.size int                          Worker pool size for pool default of controller k8s-gateways-dns
+      --k8s-gateways-dns.dns-class string                               identifier used to differentiate responsible controllers for entries of controller k8s-gateways-dns
+      --k8s-gateways-dns.dns-target-class string                        identifier used to differentiate responsible dns controllers for target entries of controller k8s-gateways-dns
+      --k8s-gateways-dns.exclude-domains stringArray                    excluded domains of controller k8s-gateways-dns
+      --k8s-gateways-dns.httproutes.pool.size int                       Worker pool size for pool httproutes of controller k8s-gateways-dns
+      --k8s-gateways-dns.key string                                     selecting key for annotation of controller k8s-gateways-dns
+      --k8s-gateways-dns.pool.resync-period duration                    Period for resynchronization of controller k8s-gateways-dns
+      --k8s-gateways-dns.pool.size int                                  Worker pool size of controller k8s-gateways-dns
+      --k8s-gateways-dns.target-creator-label-name string               label name to store the creator for generated DNS entries of controller k8s-gateways-dns
+      --k8s-gateways-dns.target-creator-label-value string              label value for creator label of controller k8s-gateways-dns
+      --k8s-gateways-dns.target-name-prefix string                      name prefix in target namespace for cross cluster generation of controller k8s-gateways-dns
+      --k8s-gateways-dns.target-namespace string                        target namespace for cross cluster generation of controller k8s-gateways-dns
+      --k8s-gateways-dns.target-owner-id string                         owner id to use for generated DNS entries of controller k8s-gateways-dns
+      --k8s-gateways-dns.target-owner-object string                     owner object to use for generated DNS entries of controller k8s-gateways-dns
+      --k8s-gateways-dns.target-realms string                           realm(s) to use for generated DNS entries of controller k8s-gateways-dns
+      --k8s-gateways-dns.target-set-ignore-owners                       mark generated DNS entries to omit owner based access control of controller k8s-gateways-dns
+      --k8s-gateways-dns.targets.pool.size int                          Worker pool size for pool targets of controller k8s-gateways-dns
+      --key string                                                      selecting key for annotation
+      --kubeconfig string                                               default cluster access
+      --kubeconfig.conditional-deploy-crds                              deployment of required crds for cluster default only if there is no managed resource in garden namespace deploying it
+      --kubeconfig.disable-deploy-crds                                  disable deployment of required crds for cluster default
+      --kubeconfig.id string                                            id for cluster default
+      --kubeconfig.migration-ids string                                 migration id for cluster default
+      --lease-duration duration                                         lease duration
+      --lease-name string                                               name for lease object
+      --lease-renew-deadline duration                                   lease renew deadline
+      --lease-resource-lock string                                      determines which resource lock to use for leader election, defaults to 'leases'
+      --lease-retry-period duration                                     lease retry period
+      --lock-status-check-period duration                               interval for dns lock status checks
+  -D, --log-level string                                                logrus log level
+      --maintainer string                                               maintainer key for crds (default "dns-controller-manager")
+      --max-metadata-record-deletions-per-reconciliation int            maximum number of metadata owner records that can be deleted per zone reconciliation
+      --name string                                                     name used for controller manager (default "dns-controller-manager")
+      --namespace string                                                namespace for lease (default "kube-system")
+  -n, --namespace-local-access-only                                     enable access restriction for namespace local access only (deprecated)
+      --netlify-dns.advanced.batch-size int                             batch size for change requests (currently only used for aws-route53)
+      --netlify-dns.advanced.max-retries int                            maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53)
+      --netlify-dns.blocked-zone zone-id                                Blocks a zone given in the format zone-id from a provider as if the zone is not existing.
+      --netlify-dns.ratelimiter.burst int                               number of burst requests for rate limiter
+      --netlify-dns.ratelimiter.enabled                                 enables rate limiter for DNS provider requests
+      --netlify-dns.ratelimiter.qps int                                 maximum requests/queries per second
+      --omit-lease                                                      omit lease for development
+      --openstack-designate.advanced.batch-size int                     batch size for change requests (currently only used for aws-route53)
+      --openstack-designate.advanced.max-retries int                    maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53)
+      --openstack-designate.blocked-zone zone-id                        Blocks a zone given in the format zone-id from a provider as if the zone is not existing.
+      --openstack-designate.ratelimiter.burst int                       number of burst requests for rate limiter
+      --openstack-designate.ratelimiter.enabled                         enables rate limiter for DNS provider requests
+      --openstack-designate.ratelimiter.qps int                         maximum requests/queries per second
+      --ownerids.pool.size int                                          Worker pool size for pool ownerids
+      --plugin-file string                                              directory containing go plugins
+      --pool.resync-period duration                                     Period for resynchronization
+      --pool.size int                                                   Worker pool size
+      --powerdns.advanced.batch-size int                                batch size for change requests (currently only used for aws-route53)
+      --powerdns.advanced.max-retries int                               maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53)
+      --powerdns.blocked-zone zone-id                                   Blocks a zone given in the format zone-id from a provider as if the zone is not existing.
+      --powerdns.ratelimiter.burst int                                  number of burst requests for rate limiter
+      --powerdns.ratelimiter.enabled                                    enables rate limiter for DNS provider requests
+      --powerdns.ratelimiter.qps int                                    maximum requests/queries per second
+      --provider-types string                                           comma separated list of provider types to enable
+      --providers string                                                cluster to look for provider objects
+      --providers.conditional-deploy-crds                               deployment of required crds for cluster provider only if there is no managed resource in garden namespace deploying it
+      --providers.disable-deploy-crds                                   disable deployment of required crds for cluster provider
+      --providers.id string                                             id for cluster provider
+      --providers.migration-ids string                                  migration id for cluster provider
+      --providers.pool.resync-period duration                           Period for resynchronization for pool providers
+      --providers.pool.size int                                         Worker pool size for pool providers
+      --ratelimiter.burst int                                           number of burst requests for rate limiter
+      --ratelimiter.enabled                                             enables rate limiter for DNS provider requests
+      --ratelimiter.qps int                                             maximum requests/queries per second
+      --remote-access-cacert string                                     CA who signed client certs file
+      --remote-access-client-id string                                  identifier used for remote access
+      --remote-access-port int                                          port of remote access server for remote-enabled providers
+      --remote-access-server-secret-name string                         name of secret containing remote access server's certificate
+      --remote.advanced.batch-size int                                  batch size for change requests (currently only used for aws-route53)
+      --remote.advanced.max-retries int                                 maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53)
+      --remote.blocked-zone zone-id                                     Blocks a zone given in the format zone-id from a provider as if the zone is not existing.
+      --remote.ratelimiter.burst int                                    number of burst requests for rate limiter
+      --remote.ratelimiter.enabled                                      enables rate limiter for DNS provider requests
+      --remote.ratelimiter.qps int                                      maximum requests/queries per second
+      --reschedule-delay duration                                       reschedule delay after losing provider
+      --rfc2136.advanced.batch-size int                                 batch size for change requests (currently only used for aws-route53)
+      --rfc2136.advanced.max-retries int                                maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53)
+      --rfc2136.blocked-zone zone-id                                    Blocks a zone given in the format zone-id from a provider as if the zone is not existing.
+      --rfc2136.ratelimiter.burst int                                   number of burst requests for rate limiter
+      --rfc2136.ratelimiter.enabled                                     enables rate limiter for DNS provider requests
+      --rfc2136.ratelimiter.qps int                                     maximum requests/queries per second
+      --secrets.pool.size int                                           Worker pool size for pool secrets
+      --server-port-http int                                            HTTP server port (serving /healthz, /metrics, ...)
+      --service-dns.default.pool.resync-period duration                 Period for resynchronization for pool default of controller service-dns
+      --service-dns.default.pool.size int                               Worker pool size for pool default of controller service-dns
+      --service-dns.dns-class string                                    identifier used to differentiate responsible controllers for entries of controller service-dns
+      --service-dns.dns-target-class string                             identifier used to differentiate responsible dns controllers for target entries of controller service-dns
+      --service-dns.exclude-domains stringArray                         excluded domains of controller service-dns
+      --service-dns.key string                                          selecting key for annotation of controller service-dns
+      --service-dns.pool.resync-period duration                         Period for resynchronization of controller service-dns
+      --service-dns.pool.size int                                       Worker pool size of controller service-dns
+      --service-dns.target-creator-label-name string                    label name to store the creator for generated DNS entries of controller service-dns
+      --service-dns.target-creator-label-value string                   label value for creator label of controller service-dns
+      --service-dns.target-name-prefix string                           name prefix in target namespace for cross cluster generation of controller service-dns
+      --service-dns.target-namespace string                             target namespace for cross cluster generation of controller service-dns
+      --service-dns.target-owner-id string                              owner id to use for generated DNS entries of controller service-dns
+      --service-dns.target-owner-object string                          owner object to use for generated DNS entries of controller service-dns
+      --service-dns.target-realms string                                realm(s) to use for generated DNS entries of controller service-dns
+      --service-dns.target-set-ignore-owners                            mark generated DNS entries to omit owner based access control of controller service-dns
+      --service-dns.targets.pool.size int                               Worker pool size for pool targets of controller service-dns
+      --setup int                                                       number of processors for controller setup
+      --target string                                                   target cluster for dns requests
+      --target-creator-label-name string                                label name to store the creator for generated DNS entries, label name to store the creator for replicated DNS providers
+      --target-creator-label-value string                               label value for creator label
+      --target-name-prefix string                                       name prefix in target namespace for cross cluster generation, name prefix in target namespace for cross cluster replication
+      --target-namespace string                                         target namespace for cross cluster generation
+      --target-owner-id string                                          owner id to use for generated DNS entries
+      --target-owner-object string                                      owner object to use for generated DNS entries
+      --target-realms string                                            realm(s) to use for generated DNS entries, realm(s) to use for replicated DNS provider
+      --target-set-ignore-owners                                        mark generated DNS entries to omit owner based access control
+      --target.conditional-deploy-crds                                  deployment of required crds for cluster target only if there is no managed resource in garden namespace deploying it
+      --target.disable-deploy-crds                                      disable deployment of required crds for cluster target
+      --target.id string                                                id for cluster target
+      --target.migration-ids string                                     migration id for cluster target
+      --targets.pool.size int                                           Worker pool size for pool targets
+      --targetsources.pool.size int                                     Worker pool size for pool targetsources
+      --ttl int                                                         Default time-to-live for DNS entries. Defines how long the record is kept in cache by DNS servers or resolvers.
+  -v, --version                                                         version for dns-controller-manager
+      --virtualservices.pool.size int                                   Worker pool size for pool virtualservices
+      --watch-gateways-crds.default.pool.size int                       Worker pool size for pool default of controller watch-gateways-crds
+      --watch-gateways-crds.pool.size int                               Worker pool size of controller watch-gateways-crds
+      --zonepolicies.pool.size int                                      Worker pool size for pool zonepolicies
 ```
 
 ## Extensions

--- a/README.md
+++ b/README.md
@@ -541,13 +541,13 @@ The following provider types can be selected (comma separated):
 - `remote`: Remote DNS provider (a dns-controller-manager with enabled remote access service)
 - `powerdns`: PowerDNS provider
 
-If the compound DNS Provisioning Controller is enabled it is important to specify a
-unique controller identity using the `--identifier` option.
-This identifier is stored in the DNS system to identify the DNS entries
-managed by a dedicated controller. There should never be two
-DNS controllers with the same identifier running at the same time for the
-same DNS domains/accounts. In release `v0.23`, the `--identifier` option is only used to 
-cleanup the "metadata records" created by the DNS Provisioning Controller.
+If the compound DNS Provisioning Controller is enabled, a unique controller identity was specified using the
+`--identifier` option in former release.
+This identifier was used to tag the DNS entries managed by a dedicated controller by creating additional
+"metadata `TXT` records" in the DNS system.
+Starting with release `v0.23`, this feature has been dropped as it doubles the number of DNS records.
+It is still important and required to specify the `--identifier` option to enable the cleanup of "metadata records" 
+created by former releases of the DNS Provisioning Controller.
 
 Here is the complete list of options provided:
 

--- a/charts/external-dns-management/templates/deployment.yaml
+++ b/charts/external-dns-management/templates/deployment.yaml
@@ -324,6 +324,9 @@ spec:
         {{- if .Values.configuration.compoundLockStatusCheckPeriod }}
         - --compound.lock-status-check-period={{ .Values.configuration.compoundLockStatusCheckPeriod }}
         {{- end }}
+        {{- if .Values.configuration.compoundMaxMetadataRecordDeletionsPerReconciliation }}
+        - --compound.max-metadata-record-deletions-per-reconciliation={{ .Values.configuration.compoundMaxMetadataRecordDeletionsPerReconciliation }}
+        {{- end }}
         {{- if .Values.configuration.compoundNetlifyDnsAdvancedBatchSize }}
         - --compound.netlify-dns.advanced.batch-size={{ .Values.configuration.compoundNetlifyDnsAdvancedBatchSize }}
         {{- end }}
@@ -419,9 +422,6 @@ spec:
         {{- end }}
         {{- if .Values.configuration.compoundSetup }}
         - --compound.setup={{ .Values.configuration.compoundSetup }}
-        {{- end }}
-        {{- if .Values.configuration.compoundStatisticPoolSize }}
-        - --compound.statistic.pool.size={{ .Values.configuration.compoundStatisticPoolSize }}
         {{- end }}
         {{- if .Values.configuration.compoundTtl }}
         - --compound.ttl={{ .Values.configuration.compoundTtl }}
@@ -801,6 +801,9 @@ spec:
         {{- if .Values.configuration.maintainer }}
         - --maintainer={{ .Values.configuration.maintainer }}
         {{- end }}
+        {{- if .Values.configuration.maxMetadataRecordDeletionsPerReconciliation }}
+        - --max-metadata-record-deletions-per-reconciliation={{ .Values.configuration.maxMetadataRecordDeletionsPerReconciliation }}
+        {{- end }}
         {{- if .Values.configuration.namespace }}
         - --namespace={{ .Values.configuration.namespace }}
         {{- end }}
@@ -974,9 +977,6 @@ spec:
         {{- end }}
         {{- if .Values.configuration.setup }}
         - --setup={{ .Values.configuration.setup }}
-        {{- end }}
-        {{- if .Values.configuration.statisticPoolSize }}
-        - --statistic.pool.size={{ .Values.configuration.statisticPoolSize }}
         {{- end }}
         {{- if .Values.configuration.target }}
         - --target={{ .Values.configuration.target }}

--- a/charts/external-dns-management/values.yaml
+++ b/charts/external-dns-management/values.yaml
@@ -132,6 +132,7 @@ configuration:
   # compoundInfobloxDnsRatelimiterEnabled:
   # compoundInfobloxDnsRatelimiterQps:
   # compoundLockStatusCheckPeriod:
+  # compoundMaxMetadataRecordDeletionsPerReconciliation:
   # compoundNetlifyDnsAdvancedBatchSize:
   # compoundNetlifyDnsAdvancedMaxRetries:
   # compoundNetlifyDnsRatelimiterBurst:
@@ -164,7 +165,6 @@ configuration:
   # compoundRfc2136RatelimiterQps:
   # compoundSecretsPoolSize: 2
   # compoundSetup: 10
-  # compoundStatisticPoolSize:
   # compoundTtl: 120
   # compoundZonepoliciesPoolSize:
   # config:
@@ -291,6 +291,7 @@ configuration:
   # lockStatusCheckPeriod:
   # logLevel: info
   # maintainer:
+  # maxMetadataRecordDeletionsPerReconciliation:
   # namespace: default
   # namespaceLocalAccessOnly: false
   # netlifyDnsAdvancedBatchSize:
@@ -350,7 +351,6 @@ configuration:
   # serviceDNSTargetsPoolSize: 2
   # servicesPoolSize:
   # setup: 10
-  # statisticPoolSize:
   # target: ""
   # targetCreatorLabelName: ""
   # targetCreatorLabelValue: ""

--- a/examples/60-owner.yaml
+++ b/examples/60-owner.yaml
@@ -1,3 +1,5 @@
+# Please note that starting with release `v0.23` DNSOwner resources are only used to clean up metadata DNS records.
+# The owner identifiers are not used for any other purpose anymore.
 apiVersion: dns.gardener.cloud/v1alpha1
 kind: DNSOwner
 metadata:

--- a/hack/tools/loadtest/main.go
+++ b/hack/tools/loadtest/main.go
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//
+// This small tool can be used to create a given number of DNS entries for load tests:
+//
+// Usage:
+//	go run main.go
+//
+//  Command line options:
+//     -base-domain string
+//     		base domain for the entries (mandatory)
+//     -count int
+//     		number of entries to create (default 10)
+//     -kubeconfig string
+//     		absolute path to the kubeconfig file (defaults to the env variable `KUBECONFIG`)
+//     -label string
+//     		label value for label 'loadtest' to set on the entries (default "true")
+//
+// You may use `kubectl delete dnsentry -l loadtest=<label-value>` to delete them all at once.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	dnsmanclient "github.com/gardener/external-dns-management/pkg/dnsman2/client"
+	"github.com/gardener/gardener/pkg/controllerutils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	kubeconfig string
+	baseDomain string
+	labelValue string
+	count      int
+)
+
+func main() {
+	flag.StringVar(&kubeconfig, "kubeconfig", os.Getenv("KUBECONFIG"), "absolute path to the kubeconfig file")
+	flag.IntVar(&count, "count", 10, "number of entries to create")
+	flag.StringVar(&baseDomain, "base-domain", "", "base domain for the entries")
+	flag.StringVar(&labelValue, "label", "true", "label value for label 'loadtest' to set on the entries")
+	flag.Parse()
+
+	if baseDomain == "" {
+		fmt.Fprintf(os.Stderr, "-base-domain is required\n")
+		os.Exit(1)
+	}
+
+	c, err := createClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create client: %w\n", err)
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+
+	fmt.Fprintf(os.Stdout, "Creating %d entries - please wait\n", count)
+
+	if err := createEntries(ctx, c, count, "e%05d", baseDomain, "loadtest", labelValue); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create entries: %w\n", err)
+		os.Exit(2)
+	}
+
+	fmt.Fprintf(os.Stdout, "Done - all %d entries created\n", count)
+}
+
+func createEntries(ctx context.Context, c client.Client, count int, nameTemplate, baseDomain, labelKey, labelValue string) error {
+	for i := 0; i < count; i++ {
+		entry := &dnsv1alpha1.DNSEntry{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      fmt.Sprintf(nameTemplate, i),
+			},
+		}
+		if _, err := controllerutils.CreateOrGetAndMergePatch(ctx, c, entry, func() error {
+			entry.Labels = map[string]string{
+				labelKey: labelValue,
+			}
+			entry.Spec = dnsv1alpha1.DNSEntrySpec{
+				DNSName: fmt.Sprintf("%s.%s", fmt.Sprintf(nameTemplate, i), baseDomain),
+				Targets: []string{fmt.Sprintf("2.%d.%d.%d", i>>16, (i&0xff00)>>8, i&0xff)},
+				TTL:     ptr.To[int64](120),
+			}
+			return nil
+		}); err != nil {
+			return fmt.Errorf("failed to create/update entry %s: %w", entry.Name, err)
+		}
+		if i > 0 && i%100 == 0 {
+			fmt.Fprintf(os.Stdout, "%d/%d entries created...\n", i, count)
+		}
+	}
+
+	return nil
+}
+
+func createClient() (client.Client, error) {
+	if kubeconfig == "" {
+		return nil, fmt.Errorf("-kubeconfig or KUBECONFIG env var is required")
+	}
+
+	cfg, err := clientcmd.LoadFromFile(kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+	clientConfig := clientcmd.NewDefaultClientConfig(*cfg, &clientcmd.ConfigOverrides{})
+	restConfig, err := clientConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return client.New(restConfig, client.Options{Scheme: dnsmanclient.ClusterScheme})
+}

--- a/pkg/controller/provider/alicloud/handler.go
+++ b/pkg/controller/provider/alicloud/handler.go
@@ -111,10 +111,6 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, _ provider.ZoneCache
 	return state, nil
 }
 
-func (h *Handler) ReportZoneStateConflict(zone provider.DNSHostedZone, err error) bool {
-	return h.cache.ReportZoneStateConflict(zone, err)
-}
-
 func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
 	err := raw.ExecuteRequests(logger, &h.config, h.access, zone, state, reqs)
 	h.cache.ApplyRequests(logger, err, zone, reqs)

--- a/pkg/controller/provider/aws/execution.go
+++ b/pkg/controller/provider/aws/execution.go
@@ -72,8 +72,8 @@ func buildResourceRecordSet(ctx context.Context, name dns.DNSSetName, policy *dn
 }
 
 func (this *Execution) addChange(ctx context.Context, action route53types.ChangeAction, req *provider.ChangeRequest, dnsset *dns.DNSSet) error {
-	name, rset := dns.MapToProvider(req.Type, dnsset, this.zone.Domain())
-	name = name.Align()
+	name := dnsset.Name.Align()
+	rset := dnsset.Sets[req.Type]
 	if len(rset.Records) == 0 {
 		return nil
 	}

--- a/pkg/controller/provider/aws/handler.go
+++ b/pkg/controller/provider/aws/handler.go
@@ -204,10 +204,6 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, _ provider.ZoneCache
 	return provider.NewDNSZoneState(dnssets), nil
 }
 
-func (h *Handler) ReportZoneStateConflict(zone provider.DNSHostedZone, err error) bool {
-	return h.cache.ReportZoneStateConflict(zone, err)
-}
-
 func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
 	ctx := context.Background()
 	err := h.executeRequests(ctx, logger, zone, state, reqs)

--- a/pkg/controller/provider/azure-private/execution.go
+++ b/pkg/controller/provider/azure-private/execution.go
@@ -56,12 +56,12 @@ func (exec *Execution) buildRecordSet(req *provider.ChangeRequest) (buildStatus,
 		return bs_invalidRoutingPolicy, "", nil
 	}
 
-	setName, rset := dns.MapToProvider(req.Type, dnsset, exec.zoneName)
-	name, ok := utils.DropZoneName(setName.DNSName, exec.zoneName)
+	name, ok := utils.DropZoneName(dnsset.Name.DNSName, exec.zoneName)
 	if !ok {
 		return bs_invalidName, "", &armprivatedns.RecordSet{Name: &name}
 	}
 
+	rset := dnsset.Sets[req.Type]
 	if len(rset.Records) == 0 {
 		return bs_empty, "", nil
 	}

--- a/pkg/controller/provider/azure-private/handler.go
+++ b/pkg/controller/provider/azure-private/handler.go
@@ -184,10 +184,6 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, _ provider.ZoneCache
 	return provider.NewDNSZoneState(dnssets), nil
 }
 
-func (h *Handler) ReportZoneStateConflict(zone provider.DNSHostedZone, err error) bool {
-	return h.cache.ReportZoneStateConflict(zone, err)
-}
-
 func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
 	err := h.executeRequests(logger, zone, state, reqs)
 	h.cache.ApplyRequests(logger, err, zone, reqs)

--- a/pkg/controller/provider/azure/execution.go
+++ b/pkg/controller/provider/azure/execution.go
@@ -56,12 +56,12 @@ func (exec *Execution) buildRecordSet(req *provider.ChangeRequest) (buildStatus,
 		return bs_invalidRoutingPolicy, "", nil
 	}
 
-	setName, rset := dns.MapToProvider(req.Type, dnsset, exec.zoneName)
-	name, ok := utils.DropZoneName(setName.DNSName, exec.zoneName)
+	name, ok := utils.DropZoneName(dnsset.Name.DNSName, exec.zoneName)
 	if !ok {
 		return bs_invalidName, "", &armdns.RecordSet{Name: &name}
 	}
 
+	rset := dnsset.Sets[req.Type]
 	if len(rset.Records) == 0 {
 		return bs_empty, "", nil
 	}

--- a/pkg/controller/provider/azure/handler.go
+++ b/pkg/controller/provider/azure/handler.go
@@ -184,10 +184,6 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, _ provider.ZoneCache
 	return provider.NewDNSZoneState(dnssets), nil
 }
 
-func (h *Handler) ReportZoneStateConflict(zone provider.DNSHostedZone, err error) bool {
-	return h.cache.ReportZoneStateConflict(zone, err)
-}
-
 func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
 	err := h.executeRequests(logger, zone, state, reqs)
 	h.cache.ApplyRequests(logger, err, zone, reqs)

--- a/pkg/controller/provider/cloudflare/handler.go
+++ b/pkg/controller/provider/cloudflare/handler.go
@@ -109,10 +109,6 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, _ provider.ZoneCache
 	return state, nil
 }
 
-func (h *Handler) ReportZoneStateConflict(zone provider.DNSHostedZone, err error) bool {
-	return h.cache.ReportZoneStateConflict(zone, err)
-}
-
 func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
 	err := raw.ExecuteRequests(logger, &h.config, h.access, zone, state, reqs)
 	h.cache.ApplyRequests(logger, err, zone, reqs)

--- a/pkg/controller/provider/google/execution.go
+++ b/pkg/controller/provider/google/execution.go
@@ -51,11 +51,13 @@ func (this *Execution) addChange(req *provider.ChangeRequest) {
 	var err error
 
 	if req.Addition != nil {
-		setName, newset = dns.MapToProvider(req.Type, req.Addition, this.zone.Domain())
+		setName = req.Addition.Name
+		newset = req.Addition.Sets[req.Type]
 		policy, err = extractRoutingPolicy(req.Addition)
 	}
 	if req.Deletion != nil {
-		setName, oldset = dns.MapToProvider(req.Type, req.Deletion, this.zone.Domain())
+		setName = req.Deletion.Name
+		oldset = req.Deletion.Sets[req.Type]
 		if req.Addition == nil {
 			policy, err = extractRoutingPolicy(req.Deletion)
 		}

--- a/pkg/controller/provider/google/handler.go
+++ b/pkg/controller/provider/google/handler.go
@@ -186,10 +186,6 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, _ provider.ZoneCache
 	return provider.NewDNSZoneState(dnssets), nil
 }
 
-func (h *Handler) ReportZoneStateConflict(zone provider.DNSHostedZone, err error) bool {
-	return h.cache.ReportZoneStateConflict(zone, err)
-}
-
 func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
 	err := h.executeRequests(logger, zone, state, reqs)
 	h.cache.ApplyRequests(logger, err, zone, reqs)

--- a/pkg/controller/provider/mock/handler.go
+++ b/pkg/controller/provider/mock/handler.go
@@ -109,10 +109,6 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, _ provider.ZoneCache
 	return h.mock.CloneZoneState(zone)
 }
 
-func (h *Handler) ReportZoneStateConflict(zone provider.DNSHostedZone, err error) bool {
-	return h.cache.ReportZoneStateConflict(zone, err)
-}
-
 func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
 	err := h.executeRequests(logger, zone, state, reqs)
 	h.cache.ApplyRequests(logger, err, zone, reqs)

--- a/pkg/controller/provider/netlify/handler.go
+++ b/pkg/controller/provider/netlify/handler.go
@@ -127,10 +127,6 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, _ provider.ZoneCache
 	return state, nil
 }
 
-func (h *Handler) ReportZoneStateConflict(zone provider.DNSHostedZone, err error) bool {
-	return h.cache.ReportZoneStateConflict(zone, err)
-}
-
 func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
 	err := raw.ExecuteRequests(logger, &h.config, h.access, zone, state, reqs)
 	h.cache.ApplyRequests(logger, err, zone, reqs)

--- a/pkg/controller/provider/openstack/execution.go
+++ b/pkg/controller/provider/openstack/execution.go
@@ -52,8 +52,8 @@ func (exec *Execution) buildRecordSet(req *provider.ChangeRequest) (buildStatus,
 		return bsInvalidRoutingPolicy, nil
 	}
 
-	name, rset := dns.MapToProvider(req.Type, dnsset, exec.zone.Domain())
-
+	name := dnsset.Name
+	rset := dnsset.Sets[req.Type]
 	if len(rset.Records) == 0 {
 		return bsEmpty, nil
 	}

--- a/pkg/controller/provider/openstack/handler.go
+++ b/pkg/controller/provider/openstack/handler.go
@@ -194,10 +194,6 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, _ provider.ZoneCache
 	return provider.NewDNSZoneState(dnssets), nil
 }
 
-func (h *Handler) ReportZoneStateConflict(zone provider.DNSHostedZone, err error) bool {
-	return h.cache.ReportZoneStateConflict(zone, err)
-}
-
 // ExecuteRequests applies a given change request to a given hosted zone.
 func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
 	err := h.executeRequests(logger, zone, state, reqs)

--- a/pkg/controller/provider/openstack/handler_test.go
+++ b/pkg/controller/provider/openstack/handler_test.go
@@ -269,22 +269,10 @@ func TestGetZoneStateAndExecuteRequests(t *testing.T) {
 			Records: []string{"1.2.3.4", "5.6.7.8"},
 		},
 		{
-			Name:    "comment-sub1.z1.test.",
-			TTL:     600,
-			Type:    "TXT",
-			Records: []string{"\"owner=test\"", "\"prefix=comment-\""},
-		},
-		{
 			Name:    "sub2.z1.test.",
 			TTL:     302,
 			Type:    "CNAME",
 			Records: []string{"cname.target.test."},
-		},
-		{
-			Name:    "comment-sub2.z1.test.",
-			TTL:     600,
-			Type:    "TXT",
-			Records: []string{"\"owner=test\"", "\"prefix=comment-\""},
 		},
 		{
 			Name:    "sub3.z1.test.",
@@ -298,7 +286,6 @@ func TestGetZoneStateAndExecuteRequests(t *testing.T) {
 		Ω(err).ShouldNot(HaveOccurred(), fmt.Sprintf("CreateRecordSet failed for %s %s", opts.Name, opts.Type))
 	}
 
-	stdMeta := buildRecordSet("META", 600, "\"owner=test\"", "\"prefix=comment-\"")
 	sub1 := dns.DNSSetName{DNSName: "sub1.z1.test"}
 	sub2 := dns.DNSSetName{DNSName: "sub2.z1.test"}
 	sub3 := dns.DNSSetName{DNSName: "sub3.z1.test"}
@@ -306,15 +293,13 @@ func TestGetZoneStateAndExecuteRequests(t *testing.T) {
 		sub1: &dns.DNSSet{
 			Name: sub1,
 			Sets: dns.RecordSets{
-				"A":    buildRecordSet("A", 301, "1.2.3.4", "5.6.7.8"),
-				"META": stdMeta,
+				"A": buildRecordSet("A", 301, "1.2.3.4", "5.6.7.8"),
 			},
 		},
 		sub2: &dns.DNSSet{
 			Name: sub2,
 			Sets: dns.RecordSets{
 				"CNAME": buildRecordSet("CNAME", 302, "cname.target.test"),
-				"META":  stdMeta,
 			},
 		},
 		dns.DNSSetName{DNSName: "sub3.z1.test"}: &dns.DNSSet{
@@ -344,16 +329,6 @@ func TestGetZoneStateAndExecuteRequests(t *testing.T) {
 			},
 		},
 		{
-			Action: provider.R_CREATE,
-			Type:   "META",
-			Addition: &dns.DNSSet{
-				Name: sub4,
-				Sets: dns.RecordSets{
-					"META": stdMeta,
-				},
-			},
-		},
-		{
 			Action: provider.R_UPDATE,
 			Type:   "A",
 			Addition: &dns.DNSSet{
@@ -370,11 +345,6 @@ func TestGetZoneStateAndExecuteRequests(t *testing.T) {
 		},
 		{
 			Action:   provider.R_DELETE,
-			Type:     "META",
-			Deletion: expectedDnssets[sub2],
-		},
-		{
-			Action:   provider.R_DELETE,
 			Type:     "TXT",
 			Deletion: expectedDnssets[sub3],
 		},
@@ -386,15 +356,13 @@ func TestGetZoneStateAndExecuteRequests(t *testing.T) {
 		sub1: &dns.DNSSet{
 			Name: sub1,
 			Sets: dns.RecordSets{
-				"A":    buildRecordSet("A", 305, "1.2.3.55", "5.6.7.8"),
-				"META": stdMeta,
+				"A": buildRecordSet("A", 305, "1.2.3.55", "5.6.7.8"),
 			},
 		},
 		sub4: &dns.DNSSet{
 			Name: sub4,
 			Sets: dns.RecordSets{
-				"A":    buildRecordSet("A", 304, "11.22.33.44"),
-				"META": stdMeta,
+				"A": buildRecordSet("A", 304, "11.22.33.44"),
 			},
 		},
 	}

--- a/pkg/controller/provider/powerdns/execution.go
+++ b/pkg/controller/provider/powerdns/execution.go
@@ -42,7 +42,8 @@ func (exec *Execution) buildRecordSet(req *provider.ChangeRequest) (*RecordSet, 
 		dnsset = req.Deletion
 	}
 
-	name, rset := dns.MapToProvider(req.Type, dnsset, exec.zone.Domain())
+	name := dnsset.Name
+	rset := dnsset.Sets[req.Type]
 
 	if name.SetIdentifier != "" || dnsset.RoutingPolicy != nil {
 		return nil, fmt.Errorf("routing policies not supported for " + TYPE_CODE)

--- a/pkg/controller/provider/powerdns/handler.go
+++ b/pkg/controller/provider/powerdns/handler.go
@@ -147,10 +147,6 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, _ provider.ZoneCache
 	return provider.NewDNSZoneState(dnssets), nil
 }
 
-func (h *Handler) ReportZoneStateConflict(zone provider.DNSHostedZone, err error) bool {
-	return h.cache.ReportZoneStateConflict(zone, err)
-}
-
 func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
 	err := h.executeRequests(logger, zone, state, reqs)
 	h.cache.ApplyRequests(logger, err, zone, reqs)

--- a/pkg/controller/provider/remote/handler.go
+++ b/pkg/controller/provider/remote/handler.go
@@ -241,10 +241,6 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, _ provider.ZoneCache
 	return provider.NewDNSZoneState(dnssets), nil
 }
 
-func (h *Handler) ReportZoneStateConflict(zone provider.DNSHostedZone, err error) bool {
-	return h.cache.ReportZoneStateConflict(zone, err)
-}
-
 func (h *Handler) MapTargets(dnsName string, targets []provider.Target) []provider.Target {
 	if h.isAWSRoute53(dnsName) {
 		return mapping.MapTargets(targets)

--- a/pkg/controller/provider/rfc2136/execution.go
+++ b/pkg/controller/provider/rfc2136/execution.go
@@ -39,10 +39,12 @@ func (exec *Execution) buildRecordSet(req *provider.ChangeRequest) ([]miekgdns.R
 
 	domain := dns.NormalizeHostname(exec.handler.zone)
 	if req.Addition != nil {
-		setName, addset = dns.MapToProvider(req.Type, req.Addition, domain)
+		setName = req.Addition.Name
+		addset = req.Addition.Sets[req.Type]
 	}
 	if req.Deletion != nil {
-		setName, delset = dns.MapToProvider(req.Type, req.Deletion, domain)
+		setName = req.Deletion.Name
+		delset = req.Deletion.Sets[req.Type]
 	}
 	if setName.DNSName == "" || (addset.Length() == 0 && delset.Length() == 0) {
 		return nil, nil, nil

--- a/pkg/controller/provider/rfc2136/handler.go
+++ b/pkg/controller/provider/rfc2136/handler.go
@@ -199,10 +199,6 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, _ provider.ZoneCache
 	return provider.NewDNSZoneState(dnssets), nil
 }
 
-func (h *Handler) ReportZoneStateConflict(zone provider.DNSHostedZone, err error) bool {
-	return h.cache.ReportZoneStateConflict(zone, err)
-}
-
 func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
 	err := h.executeRequests(logger, zone, state, reqs)
 	h.cache.ApplyRequests(logger, err, zone, reqs)

--- a/pkg/dns/dnsset.go
+++ b/pkg/dns/dnsset.go
@@ -8,40 +8,20 @@ import (
 	"reflect"
 
 	"github.com/gardener/controller-manager-library/pkg/utils"
-
-	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
-// A DNSSet contains Record sets for an DNS name. The name is given without
+// A DNSSet contains record sets for an DNS name. The name is given without
 // trailing dot. If the provider required this dot, it must be removed or addeed
 // whe reading or writing recordsets, respectively.
 // Supported record set types are:
 // - TXT
 // - CNAME
 // - A
-// - META   virtual type used by this API (see below) to store meta data
+// - AAAA
 //
 // If multiple CNAME records are given they will be mapped to A records
-// by resolving the cnames. THis resolution will be updated periodically,
-//
-// The META records contain attribute settings of the form "<attr>=<value>".
-// They are used to store the identifier of the controller and other
-// meta data to identity sets maintained or owned by this controller.
-// This record set must be stored and restored by the provider in some
-//  applicable way.
-//
-// This library supports a default mechanics for ths task, that can be used by
-// the provider:
-// This record set always contains a prefix attribute used to map META
-// records to TXT records finally stored by the provider.
-// Because not all regular record types can be combined with TXT records
-// the META text records are stores for a separate dns name composed of
-// the prefix and the original name.
-// This mapping is done by the the two functions MapFromProvider and
-// MapToProvider. These methods can be called by the provider when reading
-// or writing a record set, respectively. The map the given set to
-// an effective set and dns name for the desired purpose.
+// by resolving the cnames. This resolution will be updated periodically.
 
 type DNSSets map[DNSSetName]*DNSSet
 
@@ -55,10 +35,7 @@ func (dnssets DNSSets) AddRecordSetFromProvider(dnsName string, rs *RecordSet) {
 }
 
 func (dnssets DNSSets) AddRecordSetFromProviderEx(setName DNSSetName, policy *RoutingPolicy, rs *RecordSet) {
-	name := setName.Normalize()
-	name, rs = MapFromProvider(name, rs)
-
-	dnssets.AddRecordSet(name, policy, rs)
+	dnssets.AddRecordSet(setName.Normalize(), policy, rs)
 }
 
 func (dnssets DNSSets) AddRecordSet(name DNSSetName, policy *RoutingPolicy, rs *RecordSet) {
@@ -94,30 +71,8 @@ func (dnssets DNSSets) Clone() DNSSets {
 	return clone
 }
 
-// GetOwners returns all owners for all DNSSets
-func (dnssets DNSSets) GetOwners() utils.StringSet {
-	owners := utils.NewStringSet()
-	for _, dnsset := range dnssets {
-		o := dnsset.GetMetaAttr(ATTR_OWNER)
-		if o != "" {
-			owners.Add(o)
-		}
-	}
-	return owners
-}
-
-const (
-	ATTR_OWNER  = "owner"
-	ATTR_PREFIX = "prefix"
-	ATTR_KIND   = "kind"
-
-	ATTR_TIMESTAMP = "ts"
-	ATTR_LOCKID    = "lockid"
-)
-
 type DNSSet struct {
 	Name          DNSSetName
-	Kind          string
 	UpdateGroup   string
 	Sets          RecordSets
 	RoutingPolicy *RoutingPolicy
@@ -125,7 +80,7 @@ type DNSSet struct {
 
 func (this *DNSSet) Clone() *DNSSet {
 	return &DNSSet{
-		Name: this.Name, Sets: this.Sets.Clone(), UpdateGroup: this.UpdateGroup, Kind: this.Kind,
+		Name: this.Name, Sets: this.Sets.Clone(), UpdateGroup: this.UpdateGroup,
 		RoutingPolicy: this.RoutingPolicy.Clone(),
 	}
 }
@@ -167,59 +122,6 @@ func (this *DNSSet) DeleteTxtAttr(name string) {
 	this.deleteAttr(RS_TXT, name)
 }
 
-func (this *DNSSet) GetMetaAttr(name string) string {
-	return this.getAttr(RS_META, name)
-}
-
-func (this *DNSSet) SetMetaAttr(name string, value string) {
-	this.setAttr(RS_META, name, value)
-}
-
-func (this *DNSSet) DeleteMetaAttr(name string) {
-	this.deleteAttr(RS_META, name)
-}
-
-func (this *DNSSet) IsOwnedBy(ownership Ownership) bool {
-	o := this.GetMetaAttr(ATTR_OWNER)
-	return o != "" && ownership.IsResponsibleFor(o)
-}
-
-func (this *DNSSet) IsForeign(ownership Ownership) bool {
-	o := this.GetMetaAttr(ATTR_OWNER)
-	return o != "" && !ownership.IsResponsibleFor(o)
-}
-
-func (this *DNSSet) GetOwner() string {
-	return this.GetMetaAttr(ATTR_OWNER)
-}
-
-func (this *DNSSet) SetOwner(ownerid string) *DNSSet {
-	this.SetMetaAttr(ATTR_OWNER, ownerid)
-	return this
-}
-
-func (this *DNSSet) GetKind() string {
-	if this.Kind == "" {
-		this.Kind = this.GetMetaAttr(ATTR_KIND)
-	}
-	if this.Kind == "" {
-		this.Kind = api.DNSEntryKind
-	}
-	return this.Kind
-}
-
-func (this *DNSSet) SetKind(t string, prop ...bool) *DNSSet {
-	this.Kind = t
-	if t != api.DNSEntryKind {
-		if len(prop) == 0 || prop[0] {
-			this.SetMetaAttr(ATTR_KIND, t)
-		}
-	} else {
-		this.DeleteMetaAttr(ATTR_KIND)
-	}
-	return this
-}
-
 func (this *DNSSet) SetRecordSet(rtype string, ttl int64, values ...string) {
 	records := make([]*Record, len(values))
 	for i, r := range values {
@@ -232,8 +134,17 @@ func NewDNSSet(name DNSSetName, routingPolicy *RoutingPolicy) *DNSSet {
 	return &DNSSet{Name: name, RoutingPolicy: routingPolicy, Sets: map[string]*RecordSet{}}
 }
 
+// Match matches DNSSet equality
+func (this *DNSSet) Match(that *DNSSet) bool {
+	return this.match(that, nil)
+}
+
 // MatchRecordTypeSubset matches DNSSet equality for given record type subset.
 func (this *DNSSet) MatchRecordTypeSubset(that *DNSSet, rtype string) bool {
+	return this.match(that, &rtype)
+}
+
+func (this *DNSSet) match(that *DNSSet, restrictToRecordType *string) bool {
 	if this == that {
 		return true
 	}
@@ -249,13 +160,25 @@ func (this *DNSSet) MatchRecordTypeSubset(that *DNSSet, rtype string) bool {
 	if this.RoutingPolicy != that.RoutingPolicy && !reflect.DeepEqual(this.RoutingPolicy, that.RoutingPolicy) {
 		return false
 	}
-	rs1 := this.Sets[rtype]
-	rs2 := that.Sets[rtype]
-	if (rs1 == nil) != (rs2 == nil) {
+	if restrictToRecordType != nil {
+		rs1, rs2 := this.Sets[*restrictToRecordType], that.Sets[*restrictToRecordType]
+		if rs1 != nil && rs2 != nil {
+			return rs1.Match(rs2)
+		}
+		return rs1 == nil && rs2 == nil
+	}
+
+	if len(this.Sets) != len(that.Sets) {
 		return false
 	}
-	if rs1 != nil && !rs1.Match(rs2) {
-		return false
+	for k, v := range this.Sets {
+		w := that.Sets[k]
+		if w == nil {
+			return false
+		}
+		if !v.Match(w) {
+			return false
+		}
 	}
 	return true
 }

--- a/pkg/dns/dnsset.go
+++ b/pkg/dns/dnsset.go
@@ -11,9 +11,9 @@ import (
 )
 
 ////////////////////////////////////////////////////////////////////////////////
-// A DNSSet contains record sets for an DNS name. The name is given without
-// trailing dot. If the provider required this dot, it must be removed or addeed
-// whe reading or writing recordsets, respectively.
+// A DNSSet contains record sets for a DNS name. The name is given without
+// trailing dot. If the provider requires this dot, it must be removed or added
+// whe reading or writing record sets, respectively.
 // Supported record set types are:
 // - TXT
 // - CNAME
@@ -30,24 +30,24 @@ type Ownership interface {
 	GetIds() utils.StringSet
 }
 
-func (dnssets DNSSets) AddRecordSetFromProvider(dnsName string, rs *RecordSet) {
-	dnssets.AddRecordSetFromProviderEx(DNSSetName{DNSName: dnsName}, nil, rs)
+func (dnssets DNSSets) AddRecordSetFromProvider(dnsName string, recordSet *RecordSet) {
+	dnssets.AddRecordSetFromProviderEx(DNSSetName{DNSName: dnsName}, nil, recordSet)
 }
 
-func (dnssets DNSSets) AddRecordSetFromProviderEx(setName DNSSetName, policy *RoutingPolicy, rs *RecordSet) {
-	dnssets.AddRecordSet(setName.Normalize(), policy, rs)
+func (dnssets DNSSets) AddRecordSetFromProviderEx(setName DNSSetName, policy *RoutingPolicy, recordSet *RecordSet) {
+	dnssets.AddRecordSet(setName.Normalize(), policy, recordSet)
 }
 
-func (dnssets DNSSets) AddRecordSet(name DNSSetName, policy *RoutingPolicy, rs *RecordSet) {
+func (dnssets DNSSets) AddRecordSet(name DNSSetName, policy *RoutingPolicy, recordSet *RecordSet) {
 	dnsset := dnssets[name]
 	if dnsset == nil {
 		dnsset = NewDNSSet(name, policy)
 		dnssets[name] = dnsset
 	}
-	dnsset.Sets[rs.Type] = rs
-	if rs.Type == RS_CNAME {
-		for i := range rs.Records {
-			rs.Records[i].Value = NormalizeHostname(rs.Records[i].Value)
+	dnsset.Sets[recordSet.Type] = recordSet
+	if recordSet.Type == RS_CNAME {
+		for i := range recordSet.Records {
+			recordSet.Records[i].Value = NormalizeHostname(recordSet.Records[i].Value)
 		}
 	}
 	dnsset.RoutingPolicy = policy
@@ -85,28 +85,28 @@ func (this *DNSSet) Clone() *DNSSet {
 	}
 }
 
-func (this *DNSSet) getAttr(ty string, name string) string {
-	rset := this.Sets[ty]
-	if rset != nil {
-		return rset.GetAttr(name)
+func (this *DNSSet) getAttr(recordType string, name string) string {
+	recordSet := this.Sets[recordType]
+	if recordSet != nil {
+		return recordSet.GetAttr(name)
 	}
 	return ""
 }
 
-func (this *DNSSet) setAttr(ty string, name string, value string) {
-	rset := this.Sets[ty]
-	if rset == nil {
-		rset = newAttrRecordSet(ty, name, value)
-		this.Sets[rset.Type] = rset
+func (this *DNSSet) setAttr(recordType string, name string, value string) {
+	recordSet := this.Sets[recordType]
+	if recordSet == nil {
+		recordSet = newAttrRecordSet(recordType, name, value)
+		this.Sets[recordSet.Type] = recordSet
 	} else {
-		rset.SetAttr(name, value)
+		recordSet.SetAttr(name, value)
 	}
 }
 
-func (this *DNSSet) deleteAttr(ty string, name string) {
-	rset := this.Sets[ty]
-	if rset != nil {
-		rset.DeleteAttr(name)
+func (this *DNSSet) deleteAttr(recordType string, name string) {
+	recordSet := this.Sets[recordType]
+	if recordSet != nil {
+		recordSet.DeleteAttr(name)
 	}
 }
 
@@ -122,12 +122,12 @@ func (this *DNSSet) DeleteTxtAttr(name string) {
 	this.deleteAttr(RS_TXT, name)
 }
 
-func (this *DNSSet) SetRecordSet(rtype string, ttl int64, values ...string) {
+func (this *DNSSet) SetRecordSet(recordType string, ttl int64, values ...string) {
 	records := make([]*Record, len(values))
 	for i, r := range values {
 		records[i] = &Record{Value: r}
 	}
-	this.Sets[rtype] = &RecordSet{Type: rtype, TTL: ttl, IgnoreTTL: false, Records: records}
+	this.Sets[recordType] = &RecordSet{Type: recordType, TTL: ttl, IgnoreTTL: false, Records: records}
 }
 
 func NewDNSSet(name DNSSetName, routingPolicy *RoutingPolicy) *DNSSet {
@@ -140,8 +140,8 @@ func (this *DNSSet) Match(that *DNSSet) bool {
 }
 
 // MatchRecordTypeSubset matches DNSSet equality for given record type subset.
-func (this *DNSSet) MatchRecordTypeSubset(that *DNSSet, rtype string) bool {
-	return this.match(that, &rtype)
+func (this *DNSSet) MatchRecordTypeSubset(that *DNSSet, recordType string) bool {
+	return this.match(that, &recordType)
 }
 
 func (this *DNSSet) match(that *DNSSet, restrictToRecordType *string) bool {

--- a/pkg/dns/mapping.go
+++ b/pkg/dns/mapping.go
@@ -8,12 +8,6 @@ import (
 	"strings"
 )
 
-////////////////////////////////////////////////////////////////////////////////
-// Text Record ObjectName Mapping
-////////////////////////////////////////////////////////////////////////////////
-
-var TxtPrefix = "comment-"
-
 func AlignHostname(host string) string {
 	if strings.HasSuffix(host, ".") {
 		return host
@@ -29,77 +23,4 @@ func NormalizeHostname(host string) string {
 		return host[:len(host)-1]
 	}
 	return host
-}
-
-func MapToProvider(rtype string, dnsset *DNSSet, base string) (DNSSetName, *RecordSet) {
-	dnsName := dnsset.Name.DNSName
-	rs := dnsset.Sets[rtype]
-	if rtype == RS_META {
-		prefix := dnsset.GetMetaAttr(ATTR_PREFIX)
-		if prefix == "" {
-			prefix = TxtPrefix
-			dnsset.SetMetaAttr(ATTR_PREFIX, prefix)
-		}
-		metaName := calcMetaRecordDomainName(dnsName, prefix, base)
-		new := *dnsset.Sets[rtype]
-		new.Type = RS_TXT
-		return dnsset.Name.WithDNSName(metaName), &new
-	}
-	return dnsset.Name, rs
-}
-
-func calcMetaRecordDomainName(name, prefix, base string) string {
-	add := ""
-	if name == base {
-		prefix += "-base."
-	} else if strings.HasPrefix(name, "*.") {
-		add = "*."
-		name = name[2:]
-		if name == base {
-			prefix += "-base."
-		}
-	} else if strings.HasPrefix(name, "@.") {
-		// special case: allow apex label for Azure
-		name = name[2:]
-		prefix += "---at."
-	}
-	return add + prefix + name
-}
-
-// CalcMetaRecordDomainNameForValidation returns domain name of metadata TXT DNS record if globally defined prefix is used.
-// As it does not consider the zone, it may be wrong for the zone base domain.
-func CalcMetaRecordDomainNameForValidation(name string) string {
-	return calcMetaRecordDomainName(name, TxtPrefix, "")
-}
-
-func MapFromProvider(name DNSSetName, rs *RecordSet) (DNSSetName, *RecordSet) {
-	dns := name.DNSName
-	if rs.Type == RS_TXT {
-		prefix := rs.GetAttr(ATTR_PREFIX)
-		if prefix != "" {
-			add := ""
-			if strings.HasPrefix(dns, "*.") {
-				add = "*."
-				dns = dns[2:]
-			}
-			if strings.HasPrefix(dns, prefix) {
-				new := *rs
-				new.Type = RS_META
-				dns = dns[len(prefix):]
-				if strings.HasPrefix(dns, "-base.") {
-					dns = dns[6:]
-				} else if strings.HasPrefix(dns, "---at.") {
-					dns = dns[6:]
-					add = "@."
-				} else {
-					// for backwards compatibility of form *.comment-.basedomain
-					dns = strings.TrimPrefix(dns, ".")
-				}
-				return name.WithDNSName(add + dns), &new
-			} else {
-				return name.WithDNSName(add + dns), rs
-			}
-		}
-	}
-	return name.WithDNSName(dns), rs
 }

--- a/pkg/dns/mapping_test.go
+++ b/pkg/dns/mapping_test.go
@@ -6,8 +6,6 @@ package dns
 
 import (
 	"testing"
-
-	. "github.com/onsi/gomega"
 )
 
 func TestAlignHostname(t *testing.T) {
@@ -34,54 +32,5 @@ func TestNormalizeHostname(t *testing.T) {
 		if result != entry.wanted {
 			t.Errorf("%s: wanted %s, but got %s", entry.input, entry.wanted, result)
 		}
-	}
-}
-
-func TestMapToFromProvider(t *testing.T) {
-	RegisterTestingT(t)
-
-	table := []struct {
-		domainName          string
-		hasOwnCommentRecord bool
-		wantedName          string
-	}{
-		{"a.myzone.de", false, "comment-a.myzone.de"},
-		{"a.myzone.de", true, "mycomment-a.myzone.de"},
-		{"*.a.myzone.de", false, "*.comment-a.myzone.de"},
-		{"*.myzone.de", false, "*.comment--base.myzone.de"},
-		{"@.myzone.de", false, "comment----at.myzone.de"},
-		{"myzone.de", false, "comment--base.myzone.de"},
-	}
-
-	rtype := RS_META
-	base := "myzone.de"
-
-	for _, entry := range table {
-		inputRecords := Records{&Record{"\"owner=test\""}}
-		var wantedRecords Records
-		if entry.hasOwnCommentRecord {
-			inputRecords = append(inputRecords, &Record{"\"prefix=mycomment-\""})
-			wantedRecords = inputRecords
-		} else {
-			wantedRecords = append(inputRecords, &Record{"\"prefix=comment-\""})
-		}
-		dnsset := DNSSet{
-			Name: DNSSetName{DNSName: entry.domainName},
-			Sets: RecordSets{RS_META: &RecordSet{Type: RS_META, TTL: 600, Records: inputRecords}},
-		}
-
-		actualName, actualRecordSet := MapToProvider(rtype, &dnsset, base)
-
-		Ω(actualName).Should(Equal(DNSSetName{DNSName: entry.wantedName}), "Name should match")
-		Ω(actualRecordSet.Type).Should(Equal(RS_TXT), "Type mismatch")
-		Ω(actualRecordSet.TTL).Should(Equal(int64(600)), "TTL mismatch")
-		Ω(actualRecordSet.Records).Should(Equal(wantedRecords))
-
-		reversedName, reversedRecordSet := MapFromProvider(actualName, actualRecordSet)
-
-		Ω(reversedName).Should(Equal(DNSSetName{DNSName: entry.domainName}), "Reversed name should match")
-		Ω(reversedRecordSet.Type).Should(Equal(RS_META), "Reversed RecordSet.Type should match")
-		Ω(reversedRecordSet.TTL).Should(Equal(int64(600)), "TTL mismatch")
-		Ω(reversedRecordSet.Records).Should(Equal(wantedRecords))
 	}
 }

--- a/pkg/dns/provider/changemodel.go
+++ b/pkg/dns/provider/changemodel.go
@@ -383,31 +383,31 @@ func (this *ChangeModel) Exec(apply bool, delete bool, name dns.DNSSetName, upda
 	mod := false
 	if oldset != nil {
 		this.Debugf("found old for entry %q", oldset.Name)
-		for ty, rset := range newset.Sets {
-			curset := oldset.Sets[ty]
+		for recordType, recordSet := range newset.Sets {
+			curset := oldset.Sets[recordType]
 			if curset == nil {
 				if apply {
-					view.addCreateRequest(newset, ty, done)
+					view.addCreateRequest(newset, recordType, done)
 				}
 				mod = true
 			} else {
-				olddns := oldset.Sets[ty]
-				newdns := newset.Sets[ty]
+				olddns := oldset.Sets[recordType]
+				newdns := newset.Sets[recordType]
 				if olddns.Match(newdns) {
-					if !curset.Match(rset) || !reflect.DeepEqual(spec.RoutingPolicy(), oldset.RoutingPolicy) {
+					if !curset.Match(recordSet) || !reflect.DeepEqual(spec.RoutingPolicy(), oldset.RoutingPolicy) {
 						if apply {
-							view.addUpdateRequest(oldset, newset, ty, done)
+							view.addUpdateRequest(oldset, newset, recordType, done)
 						}
 						mod = true
 					} else {
 						if apply {
-							this.Debugf("records type %s up to date for %s", ty, name)
+							this.Debugf("records type %s up to date for %s", recordType, name)
 						}
 					}
 				} else {
 					if apply {
-						view.addCreateRequest(newset, ty, done)
-						view.addDeleteRequest(oldset, ty, this.wrappedDoneHandler(name, nil))
+						view.addCreateRequest(newset, recordType, done)
+						view.addDeleteRequest(oldset, recordType, this.wrappedDoneHandler(name, nil))
 					}
 					mod = true
 				}

--- a/pkg/dns/provider/changemodel.go
+++ b/pkg/dns/provider/changemodel.go
@@ -9,7 +9,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"time"
 
 	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"github.com/gardener/external-dns-management/pkg/dns"
@@ -335,23 +334,23 @@ func (this *ChangeModel) Setup() error {
 	return err
 }
 
-func (this *ChangeModel) Check(name dns.DNSSetName, updateGroup string, createdAt time.Time, done DoneHandler, spec TargetSpec) ChangeResult {
-	return this.Exec(false, false, name, updateGroup, createdAt, done, spec)
+func (this *ChangeModel) Check(name dns.DNSSetName, updateGroup string, done DoneHandler, spec TargetSpec) ChangeResult {
+	return this.Exec(false, false, name, updateGroup, done, spec)
 }
 
-func (this *ChangeModel) Apply(name dns.DNSSetName, updateGroup string, createdAt time.Time, done DoneHandler, spec TargetSpec) ChangeResult {
-	return this.Exec(true, false, name, updateGroup, createdAt, done, spec)
+func (this *ChangeModel) Apply(name dns.DNSSetName, updateGroup string, done DoneHandler, spec TargetSpec) ChangeResult {
+	return this.Exec(true, false, name, updateGroup, done, spec)
 }
 
-func (this *ChangeModel) Delete(name dns.DNSSetName, updateGroup string, createdAt time.Time, done DoneHandler, spec TargetSpec) ChangeResult {
-	return this.Exec(true, true, name, updateGroup, createdAt, done, spec)
+func (this *ChangeModel) Delete(name dns.DNSSetName, updateGroup string, done DoneHandler, spec TargetSpec) ChangeResult {
+	return this.Exec(true, true, name, updateGroup, done, spec)
 }
 
 func (this *ChangeModel) PseudoApply(name dns.DNSSetName, spec TargetSpec) {
 	this.applied[name] = dns.NewDNSSet(name, spec.RoutingPolicy())
 }
 
-func (this *ChangeModel) Exec(apply bool, delete bool, name dns.DNSSetName, updateGroup string, createdAt time.Time, done DoneHandler, spec TargetSpec) ChangeResult {
+func (this *ChangeModel) Exec(apply bool, delete bool, name dns.DNSSetName, updateGroup string, done DoneHandler, spec TargetSpec) ChangeResult {
 	// this.Infof("%s: %v", name, targets)
 	if len(spec.Targets()) == 0 && !delete {
 		return ChangeResult{}

--- a/pkg/dns/provider/changemodel.go
+++ b/pkg/dns/provider/changemodel.go
@@ -7,11 +7,12 @@ package provider
 import (
 	"fmt"
 	"reflect"
+	"strconv"
+	"strings"
 	"time"
 
 	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"github.com/gardener/external-dns-management/pkg/dns"
-	perrs "github.com/gardener/external-dns-management/pkg/dns/provider/errors"
 	dnsutils "github.com/gardener/external-dns-management/pkg/dns/utils"
 
 	"github.com/gardener/controller-manager-library/pkg/logger"
@@ -88,6 +89,8 @@ type ChangeGroup struct {
 	requests      ChangeRequests
 	model         *ChangeModel
 	providerCount int
+
+	cleanedMetadataRecords int
 }
 
 func newChangeGroup(name string, provider DNSProvider, model *ChangeModel) *ChangeGroup {
@@ -99,46 +102,89 @@ func (this *ChangeGroup) cleanup(logger logger.LogContext, model *ChangeModel) b
 	for _, s := range this.dnssets {
 		_, ok := model.applied[s.Name]
 		if !ok {
-			if s.IsOwnedBy(model.ownership) {
-				if model.ExistsInEquivalentZone(s.Name) {
+			if model.ExistsInEquivalentZone(s.Name) {
+				continue
+			}
+			if e := model.IsStale(ZonedDNSSetName{ZoneID: model.ZoneId(), DNSSetName: s.Name}); e != nil {
+				if e.IsDeleting() {
+					model.failedDNSNames.Add(s.Name) // preventing deletion of stale entry
+				}
+				status := e.Object().Status()
+				msg := MSG_PRESERVED
+				trigger := false
+				if status.State == api.STATE_ERROR || status.State == api.STATE_INVALID {
+					msg = msg + ": " + utils.StringValue(status.Message)
+					model.Infof("found stale set '%s': %s -> preserve unchanged", utils.StringValue(status.Message), s.Name)
+				} else {
+					model.Infof("found stale set '%s' -> preserve unchanged", s.Name)
+					trigger = true
+				}
+				upd, err := e.UpdateStatus(logger, api.STATE_STALE, msg)
+				if trigger && (!upd || err != nil) {
+					e.Trigger(logger)
+				}
+			} else {
+				oldSet := model.oldDNSSets[s.Name]
+				if oldSet == nil {
+					// not part of transaction, but old metadata entries may be present for cleanup
+					mod = this.partialCleanupOfMetadataRecords(logger, s) || mod
 					continue
 				}
-				if e := model.IsStale(ZonedDNSSetName{ZoneID: model.ZoneId(), DNSSetName: s.Name}); e != nil {
-					if e.IsDeleting() {
-						model.failedDNSNames.Add(s.Name) // preventing deletion of stale entry
+				model.Infof("found unapplied managed set '%s'", s.Name)
+				var done DoneHandler
+				for _, e := range model.context.entries {
+					if e.dnsSetName == s.Name {
+						done = NewStatusUpdate(logger, e, model.context.fhandler)
+						break
 					}
-					status := e.Object().Status()
-					msg := MSG_PRESERVED
-					trigger := false
-					if status.State == api.STATE_ERROR || status.State == api.STATE_INVALID {
-						msg = msg + ": " + utils.StringValue(status.Message)
-						model.Infof("found stale set '%s': %s -> preserve unchanged", utils.StringValue(status.Message), s.Name)
-					} else {
-						model.Infof("found stale set '%s' -> preserve unchanged", s.Name)
-						trigger = true
+				}
+				for ty := range s.Sets {
+					if _, ok := oldSet.Sets[ty]; !ok {
+						continue
 					}
-					upd, err := e.UpdateStatus(logger, api.STATE_STALE, msg)
-					if trigger && (!upd || err != nil) {
-						e.Trigger(logger)
-					}
-				} else {
-					model.Infof("found unapplied managed set '%s'", s.Name)
-					var done DoneHandler
-					for _, e := range model.context.entries {
-						if e.dnsSetName == s.Name {
-							done = NewStatusUpdate(logger, e, model.context.fhandler)
-							break
-						}
-					}
-					for ty := range s.Sets {
-						mod = true
-						this.addDeleteRequest(s, ty, model.wrappedDoneHandler(s.Name, done))
-					}
+					mod = true
+					this.addDeleteRequest(s, ty, model.wrappedDoneHandler(s.Name, done))
 				}
 			}
 		}
 	}
 	return mod
+}
+
+func (this *ChangeGroup) partialCleanupOfMetadataRecords(logger logger.LogContext, s *dns.DNSSet) bool {
+	if this.cleanedMetadataRecords >= this.model.config.MaxMetadataRecordDeletionsPerReconciliation {
+		// Maximum number of metadata records to delete per reconciliation reached.
+		// To avoid excessive deletions, we stop here and continue in the next reconciliation
+		return false
+	}
+	if this.model.ownership == nil || len(this.model.ownership.GetIds()) == 0 {
+		// no known owners to clean up metadata records
+		return false
+	}
+
+	if set, ok := s.Sets[dns.RS_TXT]; ok {
+		name := s.Name.DNSName
+		for _, prefix := range []string{"comment-", "*.comment-"} {
+			if strings.HasPrefix(name, prefix) {
+				var foundPrefix, foundOwner bool
+				for _, r := range set.Records {
+					v, _ := strconv.Unquote(r.Value)
+					if strings.HasPrefix(v, "prefix=comment-") {
+						foundPrefix = true
+					} else if strings.HasPrefix(v, "owner=") && this.model.ownership.IsResponsibleFor(strings.TrimPrefix(v, "owner=")) {
+						foundOwner = true
+					}
+				}
+				if foundPrefix && foundOwner {
+					logger.Infof("cleaning up metadata record for %s", name)
+					this.cleanedMetadataRecords++
+					this.addDeleteRequest(s, dns.RS_TXT, nil)
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 func (this *ChangeGroup) update(logger logger.LogContext, model *ChangeModel) bool {
@@ -191,6 +237,7 @@ type ChangeModel struct {
 	providergroups map[string]*ChangeGroup
 	zonestate      DNSZoneState
 	failedDNSNames dns.DNSNameSet
+	oldDNSSets     dns.DNSSets
 }
 
 type ChangeResult struct {
@@ -199,7 +246,7 @@ type ChangeResult struct {
 	Error    error
 }
 
-func NewChangeModel(logger logger.LogContext, ownership dns.Ownership, req *zoneReconciliation, config Config) *ChangeModel {
+func NewChangeModel(logger logger.LogContext, ownership dns.Ownership, req *zoneReconciliation, config Config, oldDNSSets dns.DNSSets) *ChangeModel {
 	return &ChangeModel{
 		LogContext:     logger,
 		config:         config,
@@ -208,6 +255,7 @@ func NewChangeModel(logger logger.LogContext, ownership dns.Ownership, req *zone
 		applied:        map[dns.DNSSetName]*dns.DNSSet{},
 		providergroups: map[string]*ChangeGroup{},
 		failedDNSNames: dns.DNSNameSet{},
+		oldDNSSets:     oldDNSSets,
 	}
 }
 
@@ -267,7 +315,6 @@ func (this *ChangeModel) Setup() error {
 		return err
 	}
 	sets := this.zonestate.GetDNSSets()
-	this.context.zone.SetOwners(sets.GetOwners())
 	this.dangling = newChangeGroup("dangling entries", provider, this)
 	for setName, set := range sets {
 		var view *ChangeGroup
@@ -331,78 +378,54 @@ func (this *ChangeModel) Exec(apply bool, delete bool, name dns.DNSSetName, upda
 	oldset := view.dnssets[name]
 	newset := dns.NewDNSSet(name, spec.RoutingPolicy())
 	newset.UpdateGroup = updateGroup
-	newset.SetKind(spec.Kind())
 	if !delete {
-		this.ApplySpec(newset, oldset, p, spec)
+		this.ApplySpec(newset, p, spec)
 	}
 	mod := false
 	if oldset != nil {
-		this.Debugf("found old for %s %q", oldset.GetKind(), oldset.Name)
-		if this.IsForeign(oldset) {
-			err := &perrs.AlreadyBusyForOwner{Name: name, EntryCreatedAt: createdAt, Owner: oldset.GetOwner()}
-			retry := p.ReportZoneStateConflict(this.context.zone.getZone(), err)
-			if done != nil {
-				if apply && !retry {
-					done.SetInvalid(err)
+		this.Debugf("found old for entry %q", oldset.Name)
+		for ty, rset := range newset.Sets {
+			curset := oldset.Sets[ty]
+			if curset == nil {
+				if apply {
+					view.addCreateRequest(newset, ty, done)
 				}
+				mod = true
 			} else {
-				this.Warnf("no done handler and %s", err)
-			}
-			return ChangeResult{Error: err, Retry: retry}
-		} else {
-			if !spec.Responsible(oldset, this.ownership) {
-				return ChangeResult{}
-			}
-			if oldset.GetOwner() == "" && !this.Owns(oldset) {
-				if delete {
-					return ChangeResult{}
-				}
-				this.Infof("catch entry %q by reassigning owner", name)
-			}
-			for ty, rset := range newset.Sets {
-				curset := oldset.Sets[ty]
-				if curset == nil {
-					if apply {
-						view.addCreateRequest(newset, ty, done)
-					}
-					mod = true
-				} else {
-					olddns, _ := dns.MapToProvider(ty, oldset, this.Domain())
-					newdns, _ := dns.MapToProvider(ty, newset, this.Domain())
-					if olddns == newdns {
-						if !curset.Match(rset) || !reflect.DeepEqual(spec.RoutingPolicy(), oldset.RoutingPolicy) {
-							if apply {
-								view.addUpdateRequest(oldset, newset, ty, done)
-							}
-							mod = true
-						} else {
-							if apply {
-								this.Debugf("records type %s up to date for %s", ty, name)
-							}
-						}
-					} else {
+				olddns := oldset.Sets[ty]
+				newdns := newset.Sets[ty]
+				if olddns.Match(newdns) {
+					if !curset.Match(rset) || !reflect.DeepEqual(spec.RoutingPolicy(), oldset.RoutingPolicy) {
 						if apply {
-							view.addCreateRequest(newset, ty, done)
-							view.addDeleteRequest(oldset, ty, this.wrappedDoneHandler(name, nil))
+							view.addUpdateRequest(oldset, newset, ty, done)
 						}
 						mod = true
+					} else {
+						if apply {
+							this.Debugf("records type %s up to date for %s", ty, name)
+						}
 					}
-				}
-			}
-			for ty := range oldset.Sets {
-				if _, ok := newset.Sets[ty]; !ok {
+				} else {
 					if apply {
-						view.addDeleteRequest(oldset, ty, done)
+						view.addCreateRequest(newset, ty, done)
+						view.addDeleteRequest(oldset, ty, this.wrappedDoneHandler(name, nil))
 					}
 					mod = true
 				}
+			}
+		}
+		for ty := range oldset.Sets {
+			if _, ok := newset.Sets[ty]; !ok {
+				if apply {
+					view.addDeleteRequest(oldset, ty, done)
+				}
+				mod = true
 			}
 		}
 	} else {
 		if !delete {
 			if apply {
 				this.Infof("no existing entry found for %s", name)
-				this.setOwner(newset, spec.OwnerId())
 				for ty := range newset.Sets {
 					view.addCreateRequest(newset, ty, done)
 				}
@@ -492,49 +515,12 @@ func (this *changeModelDoneHandler) Throttled() {
 /////////////////////////////////////////////////////////////////////////////////
 // DNSSets
 
-func (this *ChangeModel) Owns(set *dns.DNSSet) bool {
-	return set.IsOwnedBy(this.ownership)
-}
-
-func (this *ChangeModel) IsForeign(set *dns.DNSSet) bool {
-	return set.IsForeign(this.ownership)
-}
-
-func (this *ChangeModel) setOwner(set *dns.DNSSet, id string) bool {
-	if id == "" {
-		id = this.config.Ident
-	}
-	if id != "" {
-		set.SetOwner(id)
-		return true
-	}
-	return false
-}
-
-func (this *ChangeModel) ApplySpec(set *dns.DNSSet, base *dns.DNSSet, provider DNSProvider, spec TargetSpec) *dns.DNSSet {
-	set.SetKind(spec.Kind())
-	if base == nil || !this.IsForeign(base) {
-		if this.setOwner(set, spec.OwnerId()) {
-			set.SetMetaAttr(dns.ATTR_PREFIX, dns.TxtPrefix)
-		}
-	}
-
-	targetsets := set.Sets
+func (this *ChangeModel) ApplySpec(set *dns.DNSSet, provider DNSProvider, spec TargetSpec) *dns.DNSSet {
 	targets := provider.MapTargets(set.Name.DNSName, spec.Targets())
 	for _, t := range targets {
-		AddRecord(targetsets, t.GetRecordType(), t.GetHostName(), t.GetTTL())
+		set.Sets.AddRecord(t.GetRecordType(), t.GetHostName(), t.GetTTL())
 	}
-	set.Sets = targetsets
 	return set
-}
-
-func AddRecord(targetsets dns.RecordSets, ty string, host string, ttl int64) {
-	rs := targetsets[ty]
-	if rs == nil {
-		rs = dns.NewRecordSet(ty, ttl, nil)
-		targetsets[ty] = rs
-	}
-	rs.Records = append(rs.Records, &dns.Record{Value: host})
 }
 
 func atMost(s string, maxlen int) string {

--- a/pkg/dns/provider/changemodel.go
+++ b/pkg/dns/provider/changemodel.go
@@ -391,9 +391,9 @@ func (this *ChangeModel) Exec(apply bool, delete bool, name dns.DNSSetName, upda
 				}
 				mod = true
 			} else {
-				olddns := oldset.Sets[recordType]
-				newdns := newset.Sets[recordType]
-				if olddns.Match(newdns) {
+				olddns := oldset.Name
+				newdns := newset.Name
+				if olddns == newdns {
 					if !curset.Match(recordSet) || !reflect.DeepEqual(spec.RoutingPolicy(), oldset.RoutingPolicy) {
 						if apply {
 							view.addUpdateRequest(oldset, newset, recordType, done)

--- a/pkg/dns/provider/const.go
+++ b/pkg/dns/provider/const.go
@@ -26,6 +26,8 @@ const (
 	OPT_DISABLE_ZONE_STATE_CACHING = "disable-zone-state-caching"
 	OPT_DISABLE_DNSNAME_VALIDATION = "disable-dnsname-validation"
 
+	OPT_MAX_METADATA_RECORD_DELETIONS_PER_RECONCILIATION = "max-metadata-record-deletions-per-reconciliation"
+
 	OPT_REMOTE_ACCESS_PORT               = "remote-access-port"
 	OPT_REMOTE_ACCESS_CACERT             = "remote-access-cacert"
 	OPT_REMOTE_ACCESS_SERVER_SECRET_NAME = "remote-access-server-secret-name"
@@ -42,7 +44,6 @@ const (
 	OPT_ADVANCED_BLOCKED_ZONE = "blocked-zone"
 
 	CMD_HOSTEDZONE_PREFIX = "hostedzone:"
-	CMD_STATISTIC         = "statistic"
 
 	MSG_THROTTLING = "provider throttled"
 )

--- a/pkg/dns/provider/errors/errors.go
+++ b/pkg/dns/provider/errors/errors.go
@@ -6,10 +6,8 @@ package errors
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/gardener/controller-manager-library/pkg/resources"
-	"github.com/gardener/external-dns-management/pkg/dns"
 )
 
 type AlreadyBusyForEntry struct {
@@ -19,16 +17,6 @@ type AlreadyBusyForEntry struct {
 
 func (e *AlreadyBusyForEntry) Error() string {
 	return fmt.Sprintf("DNS name %q already busy for entry %q", e.DNSName, e.ObjectName)
-}
-
-type AlreadyBusyForOwner struct {
-	Name           dns.DNSSetName
-	EntryCreatedAt time.Time
-	Owner          string
-}
-
-func (e *AlreadyBusyForOwner) Error() string {
-	return fmt.Sprintf("DNS name %q already busy for owner %q", e.Name, e.Owner)
 }
 
 type NoSuchHostedZone struct {

--- a/pkg/dns/provider/interface.go
+++ b/pkg/dns/provider/interface.go
@@ -23,19 +23,20 @@ import (
 )
 
 type Config struct {
-	TTL                      int64
-	CacheTTL                 time.Duration
-	RescheduleDelay          time.Duration
-	StatusCheckPeriod        time.Duration
-	Ident                    string
-	Dryrun                   bool
-	ZoneStateCaching         bool
-	DisableDNSNameValidation bool
-	Delay                    time.Duration
-	EnabledTypes             utils.StringSet
-	Options                  *FactoryOptions
-	Factory                  DNSHandlerFactory
-	RemoteAccessConfig       *embed.RemoteAccessServerConfig
+	TTL                                         int64
+	CacheTTL                                    time.Duration
+	RescheduleDelay                             time.Duration
+	StatusCheckPeriod                           time.Duration
+	Ident                                       string
+	Dryrun                                      bool
+	ZoneStateCaching                            bool
+	DisableDNSNameValidation                    bool
+	Delay                                       time.Duration
+	EnabledTypes                                utils.StringSet
+	Options                                     *FactoryOptions
+	Factory                                     DNSHandlerFactory
+	RemoteAccessConfig                          *embed.RemoteAccessServerConfig
+	MaxMetadataRecordDeletionsPerReconciliation int
 }
 
 func NewConfigForController(c controller.Interface, factory DNSHandlerFactory) (*Config, error) {
@@ -80,6 +81,8 @@ func NewConfigForController(c controller.Interface, factory DNSHandlerFactory) (
 	disableZoneStateCaching, _ := c.GetBoolOption(OPT_DISABLE_ZONE_STATE_CACHING)
 	disableDNSNameValidation, _ := c.GetBoolOption(OPT_DISABLE_DNSNAME_VALIDATION)
 
+	maxMetadataRecordDeletionsPerReconciliation, _ := c.GetIntOption(OPT_MAX_METADATA_RECORD_DELETIONS_PER_RECONCILIATION)
+
 	enabled := utils.StringSet{}
 	types, err := c.GetStringOption(OPT_PROVIDERTYPES)
 	if err != nil || types == "" {
@@ -115,6 +118,7 @@ func NewConfigForController(c controller.Interface, factory DNSHandlerFactory) (
 		Options:                  fopts,
 		Factory:                  factory,
 		RemoteAccessConfig:       remoteAccessConfig,
+		MaxMetadataRecordDeletionsPerReconciliation: maxMetadataRecordDeletionsPerReconciliation,
 	}, nil
 }
 

--- a/pkg/dns/provider/interface.go
+++ b/pkg/dns/provider/interface.go
@@ -195,7 +195,6 @@ type DNSHandler interface {
 	ProviderType() string
 	GetZones() (DNSHostedZones, error)
 	GetZoneState(DNSHostedZone) (DNSZoneState, error)
-	ReportZoneStateConflict(zone DNSHostedZone, err error) bool
 	ExecuteRequests(logger logger.LogContext, zone DNSHostedZone, state DNSZoneState, reqs []*ChangeRequest) error
 	MapTargets(dnsName string, targets []Target) []Target
 	Release()
@@ -255,10 +254,6 @@ type DNSProvider interface {
 
 	AccountHash() string
 	MapTargets(dnsName string, targets []Target) []Target
-
-	// ReportZoneStateConflict is used to report a conflict because of stale data.
-	// It returns true if zone data will be updated and a retry may resolve the conflict
-	ReportZoneStateConflict(zone DNSHostedZone, err error) bool
 }
 
 type DoneHandler interface {

--- a/pkg/dns/provider/provider.go
+++ b/pkg/dns/provider/provider.go
@@ -141,10 +141,6 @@ func (this *DNSAccount) GetZoneState(zone DNSHostedZone) (DNSZoneState, error) {
 	return state, err
 }
 
-func (this *DNSAccount) ReportZoneStateConflict(zone DNSHostedZone, err error) bool {
-	return this.handler.ReportZoneStateConflict(zone, err)
-}
-
 func (this *DNSAccount) ExecuteRequests(logger logger.LogContext, zone DNSHostedZone, state DNSZoneState, reqs []*ChangeRequest) error {
 	return this.handler.ExecuteRequests(logger, zone, state, reqs)
 }
@@ -599,10 +595,6 @@ func (this *dnsProviderVersion) succeeded(logger logger.LogContext, modified boo
 
 func (this *dnsProviderVersion) GetZoneState(zone DNSHostedZone) (DNSZoneState, error) {
 	return this.account.GetZoneState(zone)
-}
-
-func (this *dnsProviderVersion) ReportZoneStateConflict(zone DNSHostedZone, err error) bool {
-	return this.account.ReportZoneStateConflict(zone, err)
 }
 
 func (this *dnsProviderVersion) ExecuteRequests(logger logger.LogContext, zone DNSHostedZone, state DNSZoneState, reqs []*ChangeRequest) error {

--- a/pkg/dns/provider/raw/execution.go
+++ b/pkg/dns/provider/raw/execution.go
@@ -60,10 +60,12 @@ func (this *Execution) AddChange(req *provider.ChangeRequest) {
 	var newset, oldset *dns.RecordSet
 
 	if req.Addition != nil {
-		name, newset = dns.MapToProvider(req.Type, req.Addition, this.domain)
+		name = req.Addition.Name
+		newset = req.Addition.Sets[req.Type]
 	}
 	if req.Deletion != nil {
-		name, oldset = dns.MapToProvider(req.Type, req.Deletion, this.domain)
+		name = req.Deletion.Name
+		oldset = req.Deletion.Sets[req.Type]
 	}
 	if name.DNSName == "" || (newset.Length() == 0 && oldset.Length() == 0) {
 		return

--- a/pkg/dns/provider/state_owner.go
+++ b/pkg/dns/provider/state_owner.go
@@ -11,10 +11,7 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/utils"
-	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
-	"github.com/gardener/external-dns-management/pkg/dns/provider/statistic"
 	dnsutils "github.com/gardener/external-dns-management/pkg/dns/utils"
-	"github.com/gardener/external-dns-management/pkg/server/metrics"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -62,7 +59,6 @@ func (this *state) UpdateOwner(logger logger.LogContext, owner *dnsutils.DNSOwne
 	logger.Debugf("       active owner ids %s", active)
 	if len(changed) > 0 {
 		this.TriggerEntriesByOwner(logger, changed)
-		this.TriggerHostedZonesByChangedOwners(logger, changed)
 	}
 	if statusActive := owner.Status().Active; statusActive == nil || *statusActive != owner.IsActive() {
 		isActive := owner.IsActive()
@@ -83,78 +79,6 @@ func (this *state) OwnerDeleted(logger logger.LogContext, key resources.ClusterO
 	logger.Debugf("       active owner ids %s", active)
 	if len(changed) > 0 {
 		this.TriggerEntriesByOwner(logger, changed)
-		this.TriggerHostedZonesByChangedOwners(logger, changed)
 	}
 	return reconcile.Succeeded(logger)
-}
-
-func (this *state) UpdateOwnerCounts(log logger.LogContext) {
-	if !this.initialized {
-		return
-	}
-	log.Infof("update owner statistic")
-	statistic := statistic.NewEntryStatistic()
-	this.UpdateStatistic(statistic)
-	types := this.GetHandlerFactory().TypeCodes()
-	metrics.UpdateOwnerStatistic(statistic, types)
-	changes := this.ownerCache.UpdateCountsWith(statistic.Owners, types)
-	if len(changes) > 0 {
-		log.Infof("found %d changes for owner usages", len(changes))
-		this.ownerupd <- changes
-	}
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-func startOwnerUpdater(pctx ProviderContext, ownerresc resources.Interface) chan OwnerCounts {
-	log := pctx.AddIndent("updater: ")
-
-	requests := make(chan OwnerCounts, 2)
-	go func() {
-		log.Infof("starting owner count updater")
-		for {
-			select {
-			case <-pctx.GetContext().Done():
-				log.Infof("stopping owner updater")
-				return
-			case changes := <-requests:
-				log.Infof("starting owner update for %d changes", len(changes))
-				for n, counts := range changes {
-					log.Infof("  updating owner counts %v for %s", counts, n)
-					_, _, err := ownerresc.ModifyStatusByName(resources.NewObjectName(string(n)), func(data resources.ObjectData) (bool, error) {
-						owner, ok := data.(*v1alpha1.DNSOwner)
-						if !ok {
-							return false, fmt.Errorf("invalid owner object type %T", data)
-						}
-						mod := false
-						if owner.Status.Entries.ByType == nil {
-							owner.Status.Entries.ByType = ProviderTypeCounts{}
-						}
-						for t, v := range counts {
-							if owner.Status.Entries.ByType[t] != v {
-								mod = true
-								owner.Status.Entries.ByType[t] = v
-							}
-							if v == 0 {
-								delete(owner.Status.Entries.ByType, t)
-							}
-						}
-						sum := 0
-						for _, v := range owner.Status.Entries.ByType {
-							sum += v
-						}
-						if owner.Status.Entries.Amount != sum {
-							owner.Status.Entries.Amount = sum
-							mod = true
-						}
-						return mod, nil
-					})
-					if err != nil {
-						log.Errorf("update failed: %s", err)
-					}
-				}
-			}
-		}
-	}()
-	return requests
 }

--- a/pkg/dns/provider/state_zone.go
+++ b/pkg/dns/provider/state_zone.go
@@ -174,10 +174,10 @@ func (this *state) reconcileZone(logger logger.LogContext, req *zoneReconciliati
 		spec := e.object.GetTargetSpec(e)
 		statusUpdate := NewStatusUpdate(logger, e, this.GetContext())
 		if e.IsDeleting() {
-			changeResult = changes.Delete(e.DNSSetName(), e.ObjectName().Namespace(), e.CreatedAt(), statusUpdate, spec)
+			changeResult = changes.Delete(e.DNSSetName(), e.ObjectName().Namespace(), statusUpdate, spec)
 		} else {
 			if !e.NotRateLimited() {
-				changeResult = changes.Check(e.DNSSetName(), e.ObjectName().Namespace(), e.CreatedAt(), statusUpdate, spec)
+				changeResult = changes.Check(e.DNSSetName(), e.ObjectName().Namespace(), statusUpdate, spec)
 				if changeResult.Modified {
 					if accepted, delay := this.tryAcceptProviderRateLimiter(logger, e); !accepted {
 						req.zone.nextTrigger = delay
@@ -191,7 +191,7 @@ func (this *state) reconcileZone(logger logger.LogContext, req *zoneReconciliati
 					}
 				}
 			}
-			changeResult = changes.Apply(e.DNSSetName(), e.ObjectName().Namespace(), e.CreatedAt(), statusUpdate, spec)
+			changeResult = changes.Apply(e.DNSSetName(), e.ObjectName().Namespace(), statusUpdate, spec)
 			if changeResult.Error != nil && changeResult.Retry {
 				conflictErr = changeResult.Error
 			}

--- a/pkg/dns/provider/statistic/statistic.go
+++ b/pkg/dns/provider/statistic/statistic.go
@@ -78,50 +78,10 @@ func (this ProviderTypeStatistic) Walk(state WalkingState, walker OwnerWalker, o
 
 ////////////////////////////////////////////////////////////////////////////////
 
-type OwnerStatistic map[string]ProviderTypeStatistic
-
-func (this OwnerStatistic) Inc(owner, ptype string, pname resources.ObjectName) {
-	this.Assure(owner).Inc(ptype, pname)
-}
-
-func (this OwnerStatistic) Count() int {
-	sum := 0
-	for _, e := range this {
-		sum += e.Count()
-	}
-	return sum
-}
-
-func (this OwnerStatistic) Get(owner string) ProviderTypeStatistic {
-	if pts := this[owner]; pts != nil {
-		return pts
-	}
-	return ProviderTypeStatistic{}
-}
-
-func (this OwnerStatistic) Assure(owner string) ProviderTypeStatistic {
-	cur := this[owner]
-	if cur == nil {
-		cur = ProviderTypeStatistic{}
-		this[owner] = cur
-	}
-	return cur
-}
-
-func (this OwnerStatistic) Walk(state WalkingState, walker OwnerWalker) WalkingState {
-	for o, os := range this {
-		state = os.Walk(state, walker, o)
-	}
-	return state
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
 type EntryStatistic struct {
 	Providers ProviderTypeStatistic
-	Owners    OwnerStatistic
 }
 
 func NewEntryStatistic() *EntryStatistic {
-	return &EntryStatistic{ProviderTypeStatistic{}, OwnerStatistic{}}
+	return &EntryStatistic{ProviderTypeStatistic{}}
 }

--- a/pkg/dns/provider/zone.go
+++ b/pkg/dns/provider/zone.go
@@ -24,7 +24,6 @@ type dnsHostedZone struct {
 	zone        DNSHostedZone
 	next        time.Time
 	nextTrigger time.Duration
-	owners      utils.StringSet
 	policy      *dnsHostedZonePolicy
 }
 
@@ -32,7 +31,6 @@ func newDNSHostedZone(min time.Duration, zone DNSHostedZone) *dnsHostedZone {
 	return &dnsHostedZone{
 		zone:        zone,
 		RateLimiter: dnsutils.NewRateLimiter(min, 10*time.Minute),
-		owners:      utils.StringSet{},
 	}
 }
 
@@ -86,18 +84,6 @@ func (this *dnsHostedZone) IsPrivate() bool {
 
 func (this *dnsHostedZone) Match(dnsname string) int {
 	return Match(this, dnsname)
-}
-
-func (this *dnsHostedZone) SetOwners(owners utils.StringSet) {
-	this.lock.Lock()
-	defer this.lock.Unlock()
-	this.owners = owners
-}
-
-func (this *dnsHostedZone) IntersectOwners(owners utils.StringSet) utils.StringSet {
-	this.lock.Lock()
-	defer this.lock.Unlock()
-	return this.owners.Intersect(owners)
 }
 
 func (this *dnsHostedZone) GetNext() time.Time {

--- a/pkg/dns/provider/zonecache.go
+++ b/pkg/dns/provider/zonecache.go
@@ -250,23 +250,7 @@ func (s *zoneStates) GetZoneState(zone DNSHostedZone, cache *defaultZoneCache) (
 	return state, true, nil
 }
 
-func (s *zoneStates) ReportZoneStateConflict(zoneID dns.ZoneID, err error) bool {
-	proxy := s.getProxy(zoneID)
-	proxy.lock.Lock()
-	defer proxy.lock.Unlock()
-
-	if !proxy.lastUpdateStart.IsZero() {
-		ownerConflict, ok := err.(*errors.AlreadyBusyForOwner)
-		if ok {
-			if ownerConflict.EntryCreatedAt.After(proxy.lastUpdateStart) {
-				// If a DNSEntry ownership is moved to another DNS controller manager (e.g. shoot recreation on another seed)
-				// the zone cache may have stale owner information. In this case the cache is invalidated
-				// if the entry is newer than the last cache refresh.
-				s.cleanZoneState(zoneID, proxy)
-				return true
-			}
-		}
-	}
+func (s *zoneStates) ReportZoneStateConflict(_ dns.ZoneID, _ error) bool {
 	return false
 }
 

--- a/pkg/dns/provider/zonecache.go
+++ b/pkg/dns/provider/zonecache.go
@@ -71,7 +71,6 @@ type ZoneCache interface {
 	GetZoneState(zone DNSHostedZone) (DNSZoneState, error)
 	ApplyRequests(logctx logger.LogContext, err error, zone DNSHostedZone, reqs []*ChangeRequest)
 	Release()
-	ReportZoneStateConflict(zone DNSHostedZone, err error) bool
 }
 
 type onlyZonesCache struct {
@@ -133,10 +132,6 @@ func (c *onlyZonesCache) GetZoneState(zone DNSHostedZone) (DNSZoneState, error) 
 func (c *onlyZonesCache) ApplyRequests(_ logger.LogContext, _ error, _ DNSHostedZone, _ []*ChangeRequest) {
 }
 
-func (c *onlyZonesCache) ReportZoneStateConflict(_ DNSHostedZone, _ error) bool {
-	return false
-}
-
 func (c *onlyZonesCache) Release() {
 }
 
@@ -162,10 +157,6 @@ func (c *defaultZoneCache) GetZoneState(zone DNSHostedZone) (DNSZoneState, error
 		c.metrics.AddZoneRequests(zone.Id().ID, M_CACHED_GETZONESTATE, 1)
 	}
 	return state, err
-}
-
-func (c *defaultZoneCache) ReportZoneStateConflict(zone DNSHostedZone, err error) bool {
-	return c.zoneStates.ReportZoneStateConflict(zone.Id(), err)
 }
 
 func (c *defaultZoneCache) cleanZoneState(zoneID dns.ZoneID) {
@@ -248,10 +239,6 @@ func (s *zoneStates) GetZoneState(zone DNSHostedZone, cache *defaultZoneCache) (
 		return nil, true, err
 	}
 	return state, true, nil
-}
-
-func (s *zoneStates) ReportZoneStateConflict(_ dns.ZoneID, _ error) bool {
-	return false
 }
 
 func (s *zoneStates) ExecuteRequests(zoneID dns.ZoneID, reqs []*ChangeRequest) {

--- a/pkg/dns/provider/zonetxn/change.go
+++ b/pkg/dns/provider/zonetxn/change.go
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package zonetxn
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/external-dns-management/pkg/dns"
+)
+
+type PendingTransaction struct {
+	lock sync.Mutex
+
+	zoneID             dns.ZoneID
+	pendingGenerations map[client.ObjectKey]int64
+
+	oldItems map[dns.DNSSetName][]*dns.DNSSet
+	newItems dns.DNSSets
+}
+
+func NewZoneTransaction(zoneID dns.ZoneID) *PendingTransaction {
+	return &PendingTransaction{
+		zoneID:             zoneID,
+		pendingGenerations: map[client.ObjectKey]int64{},
+		oldItems:           map[dns.DNSSetName][]*dns.DNSSet{},
+		newItems:           dns.DNSSets{},
+	}
+}
+
+func (t *PendingTransaction) ZoneID() dns.ZoneID {
+	return t.zoneID
+}
+
+func (t *PendingTransaction) AddEntryChange(key client.ObjectKey, generation int64, old, new *dns.DNSSet) {
+	if old.Match(new) {
+		return
+	}
+
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	t.pendingGenerations[key] = generation
+
+	if old != nil {
+		t.oldItems[old.Name] = append(t.oldItems[old.Name], old)
+	}
+	if new != nil {
+		if other := t.newItems[new.Name]; other != nil {
+			t.oldItems[new.Name] = append(t.oldItems[new.Name], other)
+		}
+		t.newItems[new.Name] = new
+	}
+}
+
+func (t *PendingTransaction) AllChanges() map[dns.DNSSetName]Change {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	changes := map[dns.DNSSetName]Change{}
+	for name, oldSets := range t.oldItems {
+		change := Change{
+			old: oldSets,
+		}
+		change.new = t.newItems[name]
+		changes[name] = change
+	}
+	for name, newSet := range t.newItems {
+		if _, found := changes[name]; !found {
+			changes[name] = Change{new: newSet}
+		}
+	}
+	return changes
+}
+
+func (t *PendingTransaction) OldDNSSets() dns.DNSSets {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	sets := dns.DNSSets{}
+	for name, oldSetList := range t.oldItems {
+		for _, set := range oldSetList {
+			for _, recordset := range set.Sets {
+				sets.AddRecordSet(name, set.RoutingPolicy, recordset)
+			}
+		}
+	}
+	return sets
+}
+
+type Change struct {
+	old []*dns.DNSSet
+	new *dns.DNSSet
+}
+
+func (c Change) String() string {
+	var buf bytes.Buffer
+	for _, old := range c.old {
+		fmt.Fprintf(&buf, "old: %+v,", old)
+	}
+	if c.new != nil {
+		fmt.Fprintf(&buf, "new: %+v", c.new)
+	}
+	return buf.String()
+}

--- a/pkg/dns/provider/zonetxn/mapping.go
+++ b/pkg/dns/provider/zonetxn/mapping.go
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package zonetxn
+
+import (
+	"github.com/gardener/external-dns-management/pkg/controller/provider/aws/mapping"
+	"github.com/gardener/external-dns-management/pkg/dns"
+	"github.com/gardener/external-dns-management/pkg/dns/utils"
+)
+
+func ApplySpec(set *dns.DNSSet, providerType string, spec utils.TargetSpec) *dns.DNSSet {
+	targets := spec.Targets()
+	if providerType == "aws-route53" {
+		targets = mapping.MapTargets(spec.Targets())
+	}
+	for _, t := range targets {
+		set.Sets.AddRecord(t.GetRecordType(), t.GetHostName(), t.GetTTL())
+	}
+	return set
+}

--- a/pkg/dns/records.go
+++ b/pkg/dns/records.go
@@ -11,7 +11,6 @@ import (
 )
 
 const (
-	RS_META       = "META"
 	RS_ALIAS_A    = "ALIAS"      // provider specific alias for CNAME record (AWS alias target A)
 	RS_ALIAS_AAAA = "ALIAS_AAAA" // provider specific alias for CNAME record (AWS alias target AAAA)
 )
@@ -130,7 +129,7 @@ func (rs *RecordSet) Match(set *RecordSet) bool {
 }
 
 func (rs *RecordSet) GetAttr(name string) string {
-	if rs.Type == RS_TXT || rs.Type == RS_META {
+	if rs.Type == RS_TXT {
 		prefix := newAttrKeyPrefix(name)
 		for _, r := range rs.Records {
 			if strings.HasPrefix(r.Value, prefix) {

--- a/pkg/dns/records_test.go
+++ b/pkg/dns/records_test.go
@@ -17,15 +17,15 @@ func TestMatch(t *testing.T) {
 		recordSetsAreEqual bool
 	}{
 		// Equal Sets
-		{RecordSet{Type: RS_META, TTL: 600, Records: []*Record{{"\"owner=test\""}}}, RecordSet{Type: RS_META, TTL: 600, Records: []*Record{{"\"owner=test\""}}}, true},
-		// RecordSet type not equal TTL & records equal = equal
-		{RecordSet{Type: RS_META, TTL: 600, Records: []*Record{{"\"owner=test\""}}}, RecordSet{Type: RS_TXT, TTL: 600, Records: []*Record{{"\"owner=test\""}}}, true},
+		{RecordSet{Type: RS_TXT, TTL: 600, Records: []*Record{{"\"foo\""}}}, RecordSet{Type: RS_TXT, TTL: 600, Records: []*Record{{"\"foo\""}}}, true},
 		// One record value different = not equal
-		{RecordSet{Type: RS_META, TTL: 600, Records: []*Record{{"\"owner=test\""}}}, RecordSet{Type: RS_META, TTL: 600, Records: []*Record{{"xx.xx.xx.xx"}}}, false},
+		{RecordSet{Type: RS_TXT, TTL: 600, Records: []*Record{{"\"foo\""}}}, RecordSet{Type: RS_TXT, TTL: 600, Records: []*Record{{"xx.xx.xx.xx"}}}, false},
 		// Equal except for TTL = not equal
-		{RecordSet{Type: RS_META, TTL: 600, Records: []*Record{{"\"owner=test\""}}}, RecordSet{Type: RS_TXT, TTL: 800, Records: []*Record{{"\"owner=test\""}}}, false},
+		{RecordSet{Type: RS_TXT, TTL: 600, Records: []*Record{{"\"foo\""}}}, RecordSet{Type: RS_TXT, TTL: 800, Records: []*Record{{"\"foo\""}}}, false},
 		// different amount of records = not equal
-		{RecordSet{Type: RS_META, TTL: 600, Records: []*Record{{"\"owner=test\""}}}, RecordSet{Type: RS_TXT, TTL: 600, Records: []*Record{{"\"owner=test\""}, {"\"owner=test\""}}}, false},
+		{RecordSet{Type: RS_TXT, TTL: 600, Records: []*Record{{"\"foo\""}}}, RecordSet{Type: RS_TXT, TTL: 600, Records: []*Record{{"\"foo\""}, {"\"foo\""}}}, false},
+		// different type = not equal
+		{RecordSet{Type: RS_A, TTL: 600, Records: []*Record{{"1.2.3.4"}}}, RecordSet{Type: RS_TXT, TTL: 600, Records: []*Record{{"\"foo\""}}}, false},
 	}
 
 	for _, entry := range table {

--- a/pkg/dns/source/controller.go
+++ b/pkg/dns/source/controller.go
@@ -91,7 +91,7 @@ func DNSSourceController(source DNSSourceType, reconcilerType controller.Reconci
 		Cluster(cluster.DEFAULT). // first one used as MAIN cluster
 		DefaultWorkerPool(2, 120*time.Second).
 		MainResource(gk.Group, gk.Kind).
-		Reconciler(reconcilers.SlaveReconcilerTypeByFunction(SlaveReconcilerType, SlaveAccessSpecCreatorForSource(source)), "entries").
+		Reconciler(reconcilerTypeFilterByKind(gk.Kind, reconcilers.SlaveReconcilerTypeByFunction(SlaveReconcilerType, SlaveAccessSpecCreatorForSource(source))), "entries").
 		Reconciler(OwnerReconciler, "owner").
 		Cluster(TARGET_CLUSTER, cluster.DEFAULT).
 		CustomResourceDefinitions(entryGroupKind).

--- a/pkg/dns/source/filterbykindreonciler.go
+++ b/pkg/dns/source/filterbykindreonciler.go
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package source
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
+	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile"
+	"github.com/gardener/controller-manager-library/pkg/logger"
+	"github.com/gardener/controller-manager-library/pkg/resources"
+)
+
+func reconcilerTypeFilterByKind(kind string, reconcilerType controller.ReconcilerType) controller.ReconcilerType {
+	return func(c controller.Interface) (reconcile.Interface, error) {
+		reconciler, err := reconcilerType(c)
+		if err != nil {
+			return nil, err
+		}
+		return &filterByKindReconciler{
+			nested:        reconciler,
+			kindSubstring: fmt.Sprintf("-%s-", strings.ToLower(kind)),
+		}, nil
+	}
+}
+
+// filterByKindReconciler is a reconciler that filters out entries by kind.
+type filterByKindReconciler struct {
+	nested        reconcile.Interface
+	kindSubstring string
+}
+
+var _ reconcile.Interface = &filterByKindReconciler{}
+var _ reconcile.StartInterface = &filterByKindReconciler{}
+var _ reconcile.SetupInterface = &filterByKindReconciler{}
+var _ reconcile.CleanupInterface = &filterByKindReconciler{}
+
+func (f filterByKindReconciler) Start() error {
+	if itf, ok := f.nested.(reconcile.StartInterface); ok {
+		return itf.Start()
+	}
+	return nil
+}
+
+func (f filterByKindReconciler) Setup() error {
+	if itf, ok := f.nested.(reconcile.SetupInterface); ok {
+		return itf.Setup()
+	}
+	return nil
+}
+
+func (f filterByKindReconciler) Cleanup() error {
+	if itf, ok := f.nested.(reconcile.CleanupInterface); ok {
+		return itf.Cleanup()
+	}
+	return nil
+}
+
+func (f filterByKindReconciler) Reconcile(logger logger.LogContext, object resources.Object) reconcile.Status {
+	if !f.isRelevantByHeuristic(object.GetName()) {
+		return reconcile.Succeeded(logger)
+	}
+	return f.nested.Reconcile(logger, object)
+}
+
+func (f filterByKindReconciler) Delete(logger logger.LogContext, object resources.Object) reconcile.Status {
+	if !f.isRelevantByHeuristic(object.GetName()) {
+		return reconcile.Succeeded(logger)
+	}
+	return f.nested.Delete(logger, object)
+}
+
+func (f filterByKindReconciler) Deleted(logger logger.LogContext, key resources.ClusterObjectKey) reconcile.Status {
+	if !f.isRelevantByHeuristic(key.Name()) {
+		return reconcile.Succeeded(logger)
+	}
+	return f.nested.Deleted(logger, key)
+}
+
+func (f filterByKindReconciler) Command(logger logger.LogContext, cmd string) reconcile.Status {
+	return f.nested.Command(logger, cmd)
+}
+
+// isRelevantByHeuristic returns true if the entry name contains the kind substring.
+// This is a heuristic which relies on the fact that the SourceReconciler adds the kind to the entry name.
+func (this *filterByKindReconciler) isRelevantByHeuristic(objectName string) bool {
+	return strings.Contains(objectName, this.kindSubstring)
+}

--- a/pkg/dns/utils/target.go
+++ b/pkg/dns/utils/target.go
@@ -84,44 +84,25 @@ func (t *target) String() string {
 ////////////////////////////////////////////////////////////////////////////////
 
 type TargetSpec interface {
-	Kind() string
-	OwnerId() string
 	Targets() []Target
 	RoutingPolicy() *dns.RoutingPolicy
-	Responsible(set *dns.DNSSet, ownership dns.Ownership) bool
 }
 
 type targetSpec struct {
-	kind          string
-	ownerId       string
 	targets       []Target
 	routingPolicy *dns.RoutingPolicy
 }
 
 func BaseTargetSpec(entry *DNSEntryObject, p TargetProvider) TargetSpec {
 	spec := &targetSpec{
-		kind:          entry.GroupKind().Kind,
-		ownerId:       p.OwnerId(),
 		targets:       p.Targets(),
 		routingPolicy: p.RoutingPolicy(),
 	}
 	return spec
 }
 
-func (this *targetSpec) Kind() string {
-	return this.kind
-}
-
-func (this *targetSpec) OwnerId() string {
-	return this.ownerId
-}
-
 func (this *targetSpec) Targets() []Target {
 	return this.targets
-}
-
-func (this *targetSpec) Responsible(set *dns.DNSSet, ownership dns.Ownership) bool {
-	return !set.IsForeign(ownership)
 }
 
 func (this *targetSpec) RoutingPolicy() *dns.RoutingPolicy {

--- a/pkg/dns/utils/target.go
+++ b/pkg/dns/utils/target.go
@@ -93,7 +93,7 @@ type targetSpec struct {
 	routingPolicy *dns.RoutingPolicy
 }
 
-func BaseTargetSpec(entry *DNSEntryObject, p TargetProvider) TargetSpec {
+func BaseTargetSpec(p TargetProvider) TargetSpec {
 	spec := &targetSpec{
 		targets:       p.Targets(),
 		routingPolicy: p.RoutingPolicy(),

--- a/pkg/dns/utils/utils_dns.go
+++ b/pkg/dns/utils/utils_dns.go
@@ -11,7 +11,6 @@ import (
 type TargetProvider interface {
 	Targets() Targets
 	TTL() int64
-	OwnerId() string
 	RoutingPolicy() *dns.RoutingPolicy
 }
 

--- a/pkg/dns/utils/utils_entry.go
+++ b/pkg/dns/utils/utils_entry.go
@@ -133,7 +133,7 @@ func (this *DNSEntryObject) AcknowledgeCNAMELookupInterval(interval int64) bool 
 }
 
 func (this *DNSEntryObject) GetTargetSpec(p TargetProvider) TargetSpec {
-	return BaseTargetSpec(this, p)
+	return BaseTargetSpec(p)
 }
 
 func DNSSetName(entry *api.DNSEntry) dns.DNSSetName {

--- a/pkg/dns/validation.go
+++ b/pkg/dns/validation.go
@@ -32,16 +32,6 @@ func ValidateDomainName(name string) error {
 		return fmt.Errorf("%q is no valid dns name (%v)", name, errs)
 	}
 
-	metaCheck := CalcMetaRecordDomainNameForValidation(check)
-	if strings.HasPrefix(metaCheck, "*.") {
-		errs = validation.IsWildcardDNS1123Subdomain(metaCheck)
-	} else {
-		errs = validation.IsDNS1123Subdomain(metaCheck)
-	}
-	if len(errs) > 0 {
-		return fmt.Errorf("metadata record %q of %q is no valid dns name (%v)", metaCheck, name, errs)
-	}
-
 	labels := strings.Split(strings.TrimPrefix(check, "*."), ".")
 	for i, label := range labels {
 		if i == 0 && label == "@" {
@@ -51,10 +41,6 @@ func ValidateDomainName(name string) error {
 		if errs = validation.IsDNS1123Label(label); len(errs) > 0 {
 			return fmt.Errorf("%d. label %q of %q is not valid (%v)", i+1, label, name, errs)
 		}
-	}
-	metaLabels := strings.SplitN(strings.TrimPrefix(metaCheck, "*."), ".", 2)
-	if errs = validation.IsDNS1123Label(metaLabels[0]); len(errs) > 0 {
-		return fmt.Errorf("1. label %q of metadata record of %q is not valid (%v)", metaLabels[0], name, errs)
 	}
 
 	return nil

--- a/pkg/dns/validation_test.go
+++ b/pkg/dns/validation_test.go
@@ -32,10 +32,7 @@ func TestValidation(t *testing.T) {
 		{"a123456789012345678901234567890123456789012345678901234567890abc.b", false},   // label too long
 		{"a.a123456789012345678901234567890123456789012345678901234567890abc.b", false}, // label too long
 		{"a12345678901234567890123456789012345678901234567890abcd.b", true},
-		{"a12345678901234567890123456789012345678901234567890abcde.b", false}, // meta data label too long
-		{"abc.a123456789." + name239, false},                                  // name too long
-		{"abcde." + name239, true},                                            // comment-abcde... has 253 chars
-		{"abcdef." + name239, false},                                          // meta data name too long
+		{"abc.a123456789." + name239, false}, // name too long
 	}
 	for _, entry := range table {
 		err := ValidateDomainName(entry.input)

--- a/pkg/server/metrics/metrics.go
+++ b/pkg/server/metrics/metrics.go
@@ -17,7 +17,6 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/server"
 	"github.com/gardener/controller-manager-library/pkg/utils"
 	"github.com/gardener/external-dns-management/pkg/dns"
-	"github.com/gardener/external-dns-management/pkg/dns/provider/statistic"
 )
 
 func init() {
@@ -291,57 +290,6 @@ func ReportRemoteAccessCertificates(count int) {
 func DeleteZone(zoneid dns.ZoneID) {
 	zoneProviders.Remove(zoneid)
 	Entries.DeleteLabelValues(zoneid.ProviderType, zoneid.ID)
-}
-
-var (
-	currentStatistic = statistic.NewEntryStatistic()
-	lock             sync.Mutex
-)
-
-func deleteOwnerStatistic(state statistic.WalkingState, owner, ptype string, pname resources.ObjectName, _ int) statistic.WalkingState {
-	types := state.(utils.StringSet)
-	if types.Contains(ptype) {
-		Owners.DeleteLabelValues(owner, ptype, pname.String())
-	}
-	return state
-}
-
-func UpdateOwnerStatistic(statistic *statistic.EntryStatistic, types utils.StringSet) {
-	lock.Lock()
-	defer lock.Unlock()
-
-	for o := range currentStatistic.Owners {
-		statistic.Owners.Assure(o)
-	}
-	for o, pts := range statistic.Owners {
-		old_pts := currentStatistic.Owners.Assure(o)
-		for pt := range types {
-			ps := pts.Get(pt)
-			old_ps := old_pts.Assure(pt)
-			for p, c := range ps {
-				Owners.WithLabelValues(o, pt, p.String()).Set(float64(c))
-				old_ps[p] = c
-			}
-			for p := range old_ps {
-				if _, ok := ps[p]; !ok {
-					Owners.DeleteLabelValues(o, pt, p.String())
-					delete(old_ps, p)
-				}
-			}
-			if len(old_ps) == 0 {
-				delete(old_pts, pt)
-			}
-		}
-		for pt, ps := range old_pts {
-			if pts[pt] == nil && types.Contains(pt) {
-				ps.Walk(types, deleteOwnerStatistic, o, pt)
-				delete(old_pts, pt)
-			}
-		}
-		if len(old_pts) == 0 {
-			delete(currentStatistic.Owners, o)
-		}
-	}
 }
 
 func ReportLookupProcessorIncrSkipped() {

--- a/pkg/server/remote/conversion/conversion_test.go
+++ b/pkg/server/remote/conversion/conversion_test.go
@@ -76,15 +76,13 @@ func doTestMarshalChangeRequest(t *testing.T, withPolicy bool) {
 	}
 	set := dns.NewDNSSet(dns.DNSSetName{DNSName: "b.a", SetIdentifier: setIdentifier}, routingPolicy)
 	set.UpdateGroup = "group1"
-	set.SetMetaAttr(dns.ATTR_OWNER, "owner1")
-	set.SetMetaAttr(dns.ATTR_PREFIX, "comment-")
 	set.SetRecordSet(dns.RS_A, 100, "1.1.1.1", "1.1.1.2")
 	table := []struct {
 		name    string
 		request *provider.ChangeRequest
 	}{
 		{"create", provider.NewChangeRequest(provider.R_CREATE, dns.RS_A, nil, set, nil)},
-		{"update", provider.NewChangeRequest(provider.R_UPDATE, dns.RS_META, nil, set, nil)},
+		{"update", provider.NewChangeRequest(provider.R_UPDATE, dns.RS_A, nil, set, nil)},
 		{"delete", provider.NewChangeRequest(provider.R_DELETE, dns.RS_A, set, nil, nil)},
 	}
 

--- a/test/integration/testenv.go
+++ b/test/integration/testenv.go
@@ -429,17 +429,6 @@ func (te *TestEnv) CreateEntryGeneric(index int, specSetter EntrySpecSetter) (re
 	return obj, err
 }
 
-func (te *TestEnv) UpdateEntryOwner(obj resources.Object, ownerID *string) (resources.Object, error) {
-	obj, err := te.GetEntry(obj.GetName())
-	if err != nil {
-		return nil, err
-	}
-	e := UnwrapEntry(obj)
-	e.Spec.OwnerId = ownerID
-	err = obj.Update()
-	return obj, err
-}
-
 func (te *TestEnv) UpdateEntryDomain(obj resources.Object, domain string) (resources.Object, error) {
 	obj, err := te.GetEntry(obj.GetName())
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
The creation and management of metadata DNS records holding the owner identifier for each `DNSEntry` has been removed.
These metadata DNS records will be removed automatically. To avoid running into rate limits, this removals will happen only during updates or with low batch size during the periodic reconciliation.
Depending on the size of the hosted zone the cleanup can take multiple days for very large hosted zone.
To ensure the correct work of the cleanup of these special `TXT` DNS records, the owner identifier provided via the `--identifier` command line option and the `DNSOwner` custom resources must still be provided.

These identifiers are only used for cleanup, but not for any other purposes.
These ownership information was used to several purposes:
- detect conflicts (i.e. same DNS record written by multiple dns-controller-manager instances)
-  handing over responsibility of DNS records from one to another controller instance
- detection of orphan DNS records and their cleanup

Please note that these edge cases are not supported anymore.
For handing over responsibility of DNS record, please use the `dns.gardener.cloud/ignore=true` annotation on `DNSEntries` or the annotated source objects (like `Ingress`, `Service`, etc.)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
The creation and management of metadata DNS records holding the owner identifier for each `DNSEntry` has been removed. These metadata DNS records will be removed automatically.
For more details, please see https://github.com/gardener/external-dns-management/tree/master?tab=readme-ov-file#important-note-support-for-owner-identifiers-is-discontinued
```
