### PR TITLE
introduce `dns.gardener.cloud/target-hard-ignore` annotation

### DIFF
--- a/pkg/dns/const.go
+++ b/pkg/dns/const.go
@@ -32,4 +32,8 @@ const (
 
 	// AnnotationIgnore is an optional annotation for DNSEntries and source resources to ignore them on reconciliation.
 	AnnotationIgnore = ANNOTATION_GROUP + "/ignore"
+	// AnnotationHardIgnore is an optional annotation for a generated target DNSEntry to ignore it on reconciliation.
+	// This annotation is not propagated from source objects to the target DNSEntry.
+	// IMPORTANT NOTE: The entry is even ignored on deletion, so use with caution to avoid orphaned entries.
+	AnnotationHardIgnore = ANNOTATION_GROUP + "/target-hard-ignore"
 )

--- a/pkg/dns/provider/state_entry.go
+++ b/pkg/dns/provider/state_entry.go
@@ -250,12 +250,12 @@ func (this *state) HandleUpdateEntry(logger logger.LogContext, op string, object
 		defer old.lock.Unlock()
 	}
 
-	if !object.IsDeleting() && object.GetAnnotations()[dns.AnnotationIgnore] == "true" {
+	if ignored, annotation := ignoredByAnnotation(object); ignored {
 		_, err := object.ModifyStatus(func(data resources.ObjectData) (bool, error) {
 			status := &data.(*api.DNSEntry).Status
 			mod := utils.ModificationState{}
 			mod.AssureStringValue(&status.State, api.STATE_IGNORED)
-			mod.AssureStringPtrPtr(&status.Message, ptr.To("entry is ignored as annotated with "+dns.AnnotationIgnore))
+			mod.AssureStringPtrPtr(&status.Message, ptr.To(fmt.Sprintf("entry is ignored as annotated with %s", annotation)))
 			return mod.IsModified(), nil
 		})
 		if err != nil {
@@ -369,4 +369,14 @@ func (this *state) DeleteLookupJob(entryName resources.ObjectName) {
 
 func (this *state) UpsertLookupJob(entryName resources.ObjectName, results lookupAllResults, interval time.Duration) {
 	this.lookupProcessor.Upsert(entryName, results, interval)
+}
+
+func ignoredByAnnotation(object *dnsutils.DNSEntryObject) (bool, string) {
+	if !object.IsDeleting() && object.GetAnnotations()[dns.AnnotationIgnore] == "true" {
+		return true, dns.AnnotationIgnore
+	}
+	if object.GetAnnotations()[dns.AnnotationHardIgnore] == "true" {
+		return true, dns.AnnotationHardIgnore
+	}
+	return false, ""
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
If source controller creates a `DNSEntry` in the target cluster, it is not possible to set the `dns.gardener.cloud/ignore` annotation on the created `DNSEntry`. It is overwritten by the source controller to keep it in-sync with the source object.
Therefore a second annotation is introduced `dns.gardener.cloud/target-hard-ignore` with the similar behaviour. Additionally, the deletion of the `DNSEntry` is also ignored to make usage future-proof if there are no `DNSOwners` anymore.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
introduce `dns.gardener.cloud/target-hard-ignore` annotation
```
