### PR TITLE
Remove reconcile annotation on reconciliation

### DIFF
--- a/test/integration/compound/compound_test.go
+++ b/test/integration/compound/compound_test.go
@@ -422,7 +422,7 @@ var _ = Describe("Compound controller tests", func() {
 
 		By("Set reconcile annotation on DNS entry")
 		e1.Annotations = map[string]string{
-			constants.GardenerOperation: "Reconcile",
+			constants.GardenerOperation: constants.GardenerOperationReconcile,
 		}
 		Expect(testClient.Update(ctx, e1)).To(Succeed())
 
@@ -430,7 +430,7 @@ var _ = Describe("Compound controller tests", func() {
 		Eventually(func(g Gomega) {
 			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(e1), e1)).To(Succeed())
 			g.Expect(e1.Annotations).NotTo(HaveKey(constants.GardenerOperation))
-		})
+		}).Should(Succeed())
 	})
 })
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, there is no reliable way to check if a `DNSEntry` has been reconciled.
With this PR, if the entry is annotated with the standard Gardener annotation `gardener.cloud/operation=reconcile`, this annotation is removed during reconciliation again.
This can be used to verify that a `DNSEntry` resource has been reconciled at least once. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This is needed for a bug fix for the restore step of the control plane migration. See https://github.com/gardener/gardener-extension-shoot-dns-service/pull/408

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Remove annotation `gardener.cloud/operation=reconcile` on reconciliation
```
