### PR TITLE
Deletion of source DNSEntries has to wait for complete deletion of target entries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ unittests: $(GINKGO)
 .PHONY: new-test-integration
 new-test-integration: $(REPORT_COLLECTOR) $(SETUP_ENVTEST)
 	@bash $(GARDENER_HACK_DIR)/test-integration.sh ./test/integration/compound
+	@bash $(GARDENER_HACK_DIR)/test-integration.sh ./test/integration/source
 
 .PHONY: test
 test: $(GINKGO) unittests new-test-integration

--- a/pkg/controller/provider/mock/handler.go
+++ b/pkg/controller/provider/mock/handler.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"k8s.io/client-go/util/flowcontrol"
@@ -39,6 +40,7 @@ type MockConfig struct {
 	Zones           []MockZone `json:"zones"`
 	FailGetZones    bool       `json:"failGetZones"`
 	FailDeleteEntry bool       `json:"failDeleteEntry"`
+	LatencyMillis   int        `json:"latencyMillis"`
 }
 
 var _ provider.DNSHandler = &Handler{}
@@ -114,6 +116,9 @@ func (h *Handler) ReportZoneStateConflict(zone provider.DNSHostedZone, err error
 func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
 	err := h.executeRequests(logger, zone, state, reqs)
 	h.cache.ApplyRequests(logger, err, zone, reqs)
+	if h.mockConfig.LatencyMillis > 0 {
+		time.Sleep(time.Duration(h.mockConfig.LatencyMillis) * time.Millisecond)
+	}
 	return err
 }
 

--- a/pkg/dns/source/reconciler.go
+++ b/pkg/dns/source/reconciler.go
@@ -373,7 +373,7 @@ func (this *sourceReconciler) Delete(logger logger.LogContext, obj resources.Obj
 				if errors.IsNotFound(err) {
 					break
 				}
-				return reconcile.Delay(logger, fmt.Errorf("get dns entry failed %s: %s", s.ObjectName(), err))
+				return reconcile.Delay(logger, fmt.Errorf("get dns entry failed %s: %w", s.ObjectName(), err))
 			}
 			time.Sleep(500 * time.Millisecond)
 			if time.Since(start) > 30*time.Second {

--- a/test/integration/source/dnsentry_test.go
+++ b/test/integration/source/dnsentry_test.go
@@ -1,0 +1,234 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package source_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gardener/controller-manager-library/pkg/controllermanager"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/json"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/controller-manager-library/pkg/ctxutil"
+	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/gardener/external-dns-management/pkg/controller/provider/mock"
+)
+
+var debug = false
+
+var _ = Describe("DNSEntry source and DNSProvider replication controller tests", func() {
+	const (
+		entryCount = 5
+	)
+
+	var (
+		testRunID      string
+		testRunID2     string
+		testNamespace1 *corev1.Namespace
+		testNamespace2 *corev1.Namespace
+		provider       *v1alpha1.DNSProvider
+		entries        []*v1alpha1.DNSEntry
+
+		checkMockDatabaseSize = func(expected int) {
+			dump := mock.TestMock[testRunID].BuildFullDump()
+			for _, zoneDump := range dump.InMemory {
+				switch {
+				case zoneDump.HostedZone.Domain == "first.example.com":
+					ExpectWithOffset(1, zoneDump.DNSSets).To(HaveLen(expected), "unexpected number of DNS sets in first.example.com")
+				default:
+					Fail("unexpected zone domain " + zoneDump.HostedZone.Domain)
+				}
+			}
+		}
+
+		checkTargetEntry = func(entry *v1alpha1.DNSEntry) {
+			Eventually(func(g Gomega) {
+				g.ExpectWithOffset(1, tc1.client.Get(ctx, client.ObjectKeyFromObject(entry), entry)).To(Succeed())
+				g.ExpectWithOffset(1, entry.Status.State).To(Equal("Ready"))
+				g.ExpectWithOffset(1, entry.Status.Targets).To(Equal(entry.Spec.Targets))
+				g.ExpectWithOffset(1, entry.Status.ObservedGeneration).To(Equal(entry.Generation))
+
+				list := &v1alpha1.DNSEntryList{}
+				g.Expect(tc2.client.List(ctx, list, client.InNamespace(testRunID2))).To(Succeed())
+				var targetEntry *v1alpha1.DNSEntry
+				for _, e := range list.Items {
+					if strings.HasPrefix(e.Name, fmt.Sprintf("%s-dnsentry", entry.Name)) {
+						targetEntry = &e
+						break
+					}
+				}
+				g.Expect(targetEntry).NotTo(BeNil())
+				g.Expect(targetEntry.Spec.DNSName).To(Equal(entry.Spec.DNSName))
+				g.Expect(targetEntry.Spec.Targets).To(Equal(entry.Spec.Targets))
+			}).Should(Succeed())
+		}
+	)
+
+	BeforeEach(func() {
+		SetDefaultEventuallyTimeout(10 * time.Second)
+		if debug {
+			SetDefaultEventuallyTimeout(30 * time.Second)
+		}
+
+		ctxLocal := context.Background()
+		ctx0 := ctxutil.CancelContext(ctxutil.WaitGroupContext(context.Background(), "main"))
+		ctx = ctxutil.TickContext(ctx0, controllermanager.DeletionActivity)
+
+		By("Create test Namespace")
+		testNamespace1 = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "source-",
+			},
+		}
+		testNamespace2 = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "source-",
+			},
+		}
+		Expect(tc1.client.Create(ctxLocal, testNamespace1)).To(Succeed())
+		Expect(tc2.client.Create(ctxLocal, testNamespace2)).To(Succeed())
+		log.Info("Created Namespace for test", "namespaceName", testNamespace1.Name)
+		log.Info("Created Namespace for test in second cluster", "namespaceName", testNamespace2.Name)
+		testRunID = testNamespace1.Name
+		testRunID2 = testNamespace2.Name
+
+		DeferCleanup(func() {
+			By("Delete test Namespace")
+			Expect(tc1.client.Delete(ctxLocal, testNamespace1)).To(Or(Succeed(), BeNotFoundError()))
+			Expect(tc2.client.Delete(ctxLocal, testNamespace2)).To(Or(Succeed(), BeNotFoundError()))
+		})
+
+		By("Start manager")
+		go func() {
+			defer GinkgoRecover()
+			args := []string{
+				"--kubeconfig", tc1.kubeconfigFile,
+				"--kubeconfig.id=source-id",
+				"--target", tc2.kubeconfigFile,
+				"--target.id=target-id",
+				"--target.disable-deploy-crds",
+				"--controllers", "compound,dnsentry-source,dnsprovider-replication",
+				"--omit-lease",
+				"--dns-delay", "1s",
+				"--reschedule-delay", "2s",
+				"--lock-status-check-period", "5s",
+				"--pool.size", "2",
+				"--dns-target-class=gardendns",
+				"--dns-class=gardendns",
+				"--target-namespace", testRunID2,
+				"--disable-namespace-restriction",
+			}
+			runControllerManager(ctx, args)
+		}()
+
+		DeferCleanup(func() {
+			By("Stop manager")
+			if ctx != nil {
+				ctxutil.Cancel(ctx)
+			}
+		})
+
+		mcfg := mock.MockConfig{
+			Name: testRunID,
+			Zones: []mock.MockZone{
+				{ZonePrefix: testRunID + ":first:", DNSName: "first.example.com"},
+			},
+			LatencyMillis: 900,
+		}
+		bytes, err := json.Marshal(&mcfg)
+		Expect(err).NotTo(HaveOccurred())
+
+		providerSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testRunID,
+				Name:      "mock1-secret",
+			},
+			Data: map[string][]byte{},
+			Type: corev1.SecretTypeOpaque,
+		}
+		Expect(tc1.client.Create(ctx, providerSecret)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(tc1.client.Delete(ctx, providerSecret)).To(Succeed())
+		})
+		provider = &v1alpha1.DNSProvider{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testRunID,
+				Name:      "mock1",
+			},
+			Spec: v1alpha1.DNSProviderSpec{
+				Type:           "mock-inmemory",
+				ProviderConfig: &runtime.RawExtension{Raw: bytes},
+				SecretRef:      &corev1.SecretReference{Name: "mock1-secret", Namespace: testRunID},
+			},
+		}
+		Expect(tc1.client.Create(ctx, provider)).To(Succeed())
+
+		println("source kubeconfig:", tc1.kubeconfigFile)
+		println("target kubeconfig:", tc2.kubeconfigFile)
+
+		Eventually(func(g Gomega) {
+			g.Expect(tc1.client.Get(ctx, client.ObjectKeyFromObject(provider), provider)).To(Succeed())
+			g.Expect(provider.Status.State).To(Equal("Ready"))
+		}).Should(Succeed())
+
+		for i := 0; i < entryCount; i++ {
+			entries = append(entries, &v1alpha1.DNSEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testRunID,
+					Name:      fmt.Sprintf("e%d", i),
+				},
+				Spec: v1alpha1.DNSEntrySpec{
+					DNSName: fmt.Sprintf("e%d.first.example.com", i),
+					Targets: []string{fmt.Sprintf("1.1.1.%d", i)},
+				},
+			})
+		}
+	})
+
+	It("should create entries on target", func() {
+		for _, entry := range entries {
+			Expect(tc1.client.Create(ctx, entry)).To(Succeed())
+		}
+
+		By("check entries")
+		for _, entry := range entries {
+			checkTargetEntry(entry)
+		}
+
+		checkMockDatabaseSize(entryCount)
+
+		By("delete entries")
+		for _, entry := range entries {
+			Expect(tc1.client.Delete(ctx, entry)).To(Succeed())
+		}
+
+		By("wait for deletion")
+		for _, entry := range entries {
+			for {
+				if err := tc1.client.Get(ctx, client.ObjectKeyFromObject(entry), entry); err != nil {
+					if client.IgnoreNotFound(err) == nil {
+						break
+					}
+					Expect(err).NotTo(HaveOccurred())
+				}
+				time.Sleep(100 * time.Millisecond)
+			}
+		}
+
+		Expect(tc1.client.Delete(ctx, provider)).To(Succeed())
+
+		By("check mock database")
+		checkMockDatabaseSize(0)
+	})
+})

--- a/test/integration/source/source_suite_test.go
+++ b/test/integration/source/source_suite_test.go
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package source_test
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gardener/controller-manager-library/pkg/controllermanager"
+	"github.com/gardener/controller-manager-library/pkg/controllermanager/cluster"
+	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
+	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/mappings"
+	cmllogger "github.com/gardener/controller-manager-library/pkg/logger"
+	"github.com/gardener/controller-manager-library/pkg/resources"
+	"github.com/gardener/controller-manager-library/pkg/utils"
+	"github.com/gardener/gardener/pkg/logger"
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	_ "github.com/gardener/external-dns-management/pkg/controller/provider/compound/controller"
+	_ "github.com/gardener/external-dns-management/pkg/controller/provider/mock"
+	_ "github.com/gardener/external-dns-management/pkg/controller/replication/dnsprovider"
+	_ "github.com/gardener/external-dns-management/pkg/controller/source/dnsentry"
+	dnsprovider "github.com/gardener/external-dns-management/pkg/dns/provider"
+	dnssource "github.com/gardener/external-dns-management/pkg/dns/source"
+	dnsmanclient "github.com/gardener/external-dns-management/pkg/dnsman2/client"
+)
+
+func TestSourceController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Integration Source/Compound Controller Suite")
+}
+
+const testID = "source-controller-test"
+
+type testContext struct {
+	restConfig     *rest.Config
+	testEnv        *envtest.Environment
+	client         client.Client
+	kubeconfigFile string
+}
+
+var (
+	ctx context.Context
+	log logr.Logger
+
+	tc1 testContext
+	tc2 testContext
+
+	scheme *runtime.Scheme
+)
+
+var _ = BeforeSuite(func() {
+	// a lot of CPU-intensive stuff is happening in this test, so to
+	// prevent flakes we have to increase the timeout here manually
+	SetDefaultEventuallyTimeout(5 * time.Second)
+
+	cmllogger.SetOutput(GinkgoWriter)
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
+	log = logf.Log.WithName(testID)
+
+	By("Start test environments")
+	for i, tc := range []*testContext{&tc1, &tc2} {
+		tc.testEnv = &envtest.Environment{
+			CRDInstallOptions: envtest.CRDInstallOptions{
+				Paths: []string{
+					filepath.Join("..", "..", "..", "pkg", "apis", "dns", "crds", "dns.gardener.cloud_dnsentries.yaml"),
+					filepath.Join("..", "..", "..", "pkg", "apis", "dns", "crds", "dns.gardener.cloud_dnsproviders.yaml"),
+					filepath.Join("..", "..", "..", "pkg", "apis", "dns", "crds", "dns.gardener.cloud_dnsannotations.yaml"),
+					filepath.Join("..", "..", "..", "pkg", "apis", "dns", "crds", "dns.gardener.cloud_dnsowners.yaml"),
+					filepath.Join("..", "..", "..", "pkg", "apis", "dns", "crds", "dns.gardener.cloud_dnshostedzonepolicies.yaml"),
+				},
+			},
+			ErrorIfCRDPathMissing: true,
+		}
+
+		var err error
+		tc.restConfig, err = tc.testEnv.Start()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tc.restConfig).NotTo(BeNil())
+		tc.kubeconfigFile = createKubeconfigFile(tc.restConfig)
+		if i == 0 {
+			os.Setenv("KUBECONFIG", tc.kubeconfigFile)
+		}
+	}
+
+	doInit()
+
+	DeferCleanup(func() {
+		By("Stop test environments")
+		for _, tc := range []*testContext{&tc1, &tc2} {
+			Expect(tc.testEnv.Stop()).To(Succeed())
+			_ = os.Remove(tc.kubeconfigFile)
+		}
+	})
+
+	By("Create test client")
+	scheme = dnsmanclient.ClusterScheme
+
+	for _, tc := range []*testContext{&tc1, &tc2} {
+		var err error
+		tc.client, err = client.New(tc.restConfig, client.Options{Scheme: scheme})
+		Expect(err).NotTo(HaveOccurred())
+	}
+})
+
+func createKubeconfigFile(cfg *rest.Config) string {
+	template := `apiVersion: v1
+kind: Config
+clusters:
+  - name: testenv
+    cluster:
+      server: '%s'
+      certificate-authority-data: %s
+contexts:
+  - name: testenv
+    context:
+      cluster: testenv
+      user: testuser
+current-context: testenv
+users:
+  - name: testuser
+    user:
+      client-certificate-data: %s
+      client-key-data: %s`
+
+	tmpfile, err := os.CreateTemp("", "kubeconfig-integration-suite-test")
+	Expect(err).NotTo(HaveOccurred())
+	_, err = fmt.Fprintf(tmpfile, template, cfg.Host, base64.StdEncoding.EncodeToString(cfg.CAData),
+		base64.StdEncoding.EncodeToString(cfg.CertData), base64.StdEncoding.EncodeToString(cfg.KeyData))
+	Expect(err).NotTo(HaveOccurred())
+	err = tmpfile.Close()
+	Expect(err).NotTo(HaveOccurred())
+	return tmpfile.Name()
+}
+
+func doInit() {
+	cluster.Configure(
+		dnsprovider.PROVIDER_CLUSTER,
+		"providers",
+		"cluster to look for provider objects",
+	).Fallback(dnssource.TARGET_CLUSTER)
+
+	mappings.ForControllerGroup(dnsprovider.CONTROLLER_GROUP_DNS_CONTROLLERS).
+		Map(controller.CLUSTER_MAIN, dnssource.TARGET_CLUSTER).MustRegister()
+
+	utils.Must(resources.Register(v1alpha1.SchemeBuilder))
+	utils.Must(resources.Register(apiextensionsv1.SchemeBuilder))
+}
+
+func runControllerManager(ctx context.Context, args []string) {
+	use := "dns-controller-manager"
+	short := "integration-test"
+	c := controllermanager.PrepareStart(use, short)
+	def := c.Definition()
+	os.Args = args
+	controllermanager.DisableOptionSettingsLogging = true
+	command := controllermanager.NewCommand(ctx, use, short, short, def)
+	if err := command.Execute(); err != nil {
+		log.Error(err, "controllermanager command failed")
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
The deletion of source `DNSEntries` has to wait for complete deletion of target entries. Otherwise a following deletion of a source DNS provider may be performed too early and the credentials may already gone for finishing the deletion of the DNS records.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Deletion of source DNSEntries has to wait for complete deletion of target entries.
```
