### PR TITLE
Ignore TTL on comparing alias records for remote provider

### DIFF
--- a/pkg/dns/records.go
+++ b/pkg/dns/records.go
@@ -109,8 +109,11 @@ func (rs *RecordSet) Match(set *RecordSet) bool {
 		return false
 	}
 
-	if !rs.IgnoreTTL && !set.IgnoreTTL && rs.TTL != set.TTL {
-		return false
+	if rs.Type != RS_ALIAS_A && rs.Type != RS_ALIAS_AAAA {
+		// ignore TTL for alias records
+		if !rs.IgnoreTTL && !set.IgnoreTTL && rs.TTL != set.TTL {
+			return false
+		}
 	}
 
 	for _, r := range rs.Records {

--- a/pkg/dns/records_test.go
+++ b/pkg/dns/records_test.go
@@ -26,6 +26,10 @@ func TestMatch(t *testing.T) {
 		{RecordSet{Type: RS_TXT, TTL: 600, Records: []*Record{{"\"foo\""}}}, RecordSet{Type: RS_TXT, TTL: 600, Records: []*Record{{"\"foo\""}, {"\"foo\""}}}, false},
 		// different type = not equal
 		{RecordSet{Type: RS_A, TTL: 600, Records: []*Record{{"1.2.3.4"}}}, RecordSet{Type: RS_TXT, TTL: 600, Records: []*Record{{"\"foo\""}}}, false},
+		// alias type: ignore TTL as ignored in AWS Route53 anyway
+		{RecordSet{Type: RS_ALIAS_A, TTL: 60, Records: []*Record{{"foo.example.com"}}}, RecordSet{Type: RS_ALIAS_A, TTL: 0, Records: []*Record{{"foo.example.com"}}}, true},
+		// alias_a type: ignore TTL as ignored in AWS Route53 anyway
+		{RecordSet{Type: RS_ALIAS_AAAA, TTL: 60, Records: []*Record{{"foo.example.com"}}}, RecordSet{Type: RS_ALIAS_AAAA, TTL: 0, Records: []*Record{{"foo.example.com"}}}, true},
 	}
 
 	for _, entry := range table {


### PR DESCRIPTION
**What this PR does / why we need it**:
This is an edge case for `Alias` records on AWS Route53, if used with a DNS provider of type `remote`.
In this case, the `ignoreTTL` is not set for a record set and the TTL value is undefined, i.e. zero in the received zone state.
The `RecordSet.Match` method now ignores TTL explicitly if it is an alias record type.
This avoids unneeded `UPSERTS` requests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Ignore TTL on comparing alias records for remote provider
```
