### PR TITLE
feat: Build `linux/arm64` image

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -31,6 +31,10 @@ external-dns-management:
         image: golang:1.23.2
     traits:
       publish:
+        oci-builder: docker-buildx
+        platforms:
+        - linux/amd64
+        - linux/arm64
         dockerimages:
           dns-controller-manager:
             dockerfile: 'Dockerfile'


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces a multi-arch build for the Docker image to publish a `linux/arm64` image.
Currently, it's not possible to use `external-dns-management` on `arm64` machines.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @MartinWeindel 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Introduce multi-arch build for `linux/arm64` images.
```
