### PR TITLE
Bump golang to 1.24 in CI/CD pipeline

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -21,14 +21,14 @@ external-dns-management:
             we use gosec for sast scanning. See attached log.
     steps:
       build:
-        image: golang:1.23.2
+        image: golang:1.24
         output_dir: binary
       check:
-        image: golang:1.23.2
+        image: golang:1.24
       integrationtest:
-        image: golang:1.23.2
+        image: golang:1.24
       test:
-        image: golang:1.23.2
+        image: golang:1.24
     traits:
       publish:
         oci-builder: docker-buildx


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump golang to 1.24 in CI/CD pipeline

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
