### PR TITLE
Makefile: use standard way for `test` and `format` tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,10 @@ tidy:
 
 .PHONY: clean
 clean:
+	bash $(GARDENER_HACK_DIR)/clean.sh ./cmd/... ./pkg/...
 	@rm -f charts/external-dns-management/templates/crds.yaml
 	@rm -f pkg/apis/dns/crds/*
 	@rm -rf /pkg/client/dns
-	@rm -f pkg/apis/dns/v1alpha1/zz_generated*
 
 .PHONY: check
 check: sast-report fastcheck
@@ -44,8 +44,8 @@ fastcheck: format $(GOIMPORTS) $(GOLANGCI_LINT)
 	@go vet ./cmd/... ./pkg/... ./test/...
 
 .PHONY: format
-format:
-	@go fmt ./cmd/... ./pkg/... ./test/...
+format: $(GOIMPORTS) $(GOIMPORTSREVISER)
+	@bash $(GARDENER_HACK_DIR)/format.sh ./cmd ./pkg ./test
 
 .PHONY: build
 build:
@@ -69,7 +69,7 @@ release:
 
 .PHONY: unittests
 unittests: $(GINKGO)
-	$(GINKGO) -r ./pkg
+	go test -race -timeout=3m ./pkg/... | grep -v 'no test files'
 
 .PHONY: new-test-integration
 new-test-integration: $(REPORT_COLLECTOR) $(SETUP_ENVTEST)

--- a/pkg/apis/dns/v1alpha1/register.go
+++ b/pkg/apis/dns/v1alpha1/register.go
@@ -5,10 +5,11 @@
 package v1alpha1
 
 import (
-	"github.com/gardener/external-dns-management/pkg/apis/dns"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/gardener/external-dns-management/pkg/apis/dns"
 )
 
 const (

--- a/pkg/controller/annotation/annotations/state.go
+++ b/pkg/controller/annotation/annotations/state.go
@@ -15,11 +15,11 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/resources/abstract"
 	"github.com/gardener/controller-manager-library/pkg/utils"
-	"github.com/gardener/external-dns-management/pkg/dns"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/gardener/external-dns-management/pkg/dns"
 )
 
 const KEY_STATE = "key-watches"

--- a/pkg/controller/annotation/controller.go
+++ b/pkg/controller/annotation/controller.go
@@ -8,13 +8,12 @@ import (
 	"time"
 
 	"github.com/gardener/controller-manager-library/pkg/config"
-	"github.com/gardener/controller-manager-library/pkg/resources/apiextensions"
-	"k8s.io/apimachinery/pkg/labels"
-
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile"
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
+	"github.com/gardener/controller-manager-library/pkg/resources/apiextensions"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/gardener/external-dns-management/pkg/apis/dns/crds"
 	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"

--- a/pkg/controller/provider/alicloud/handler.go
+++ b/pkg/controller/provider/alicloud/handler.go
@@ -7,6 +7,7 @@ package alicloud
 import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/alidns"
 	"github.com/gardener/controller-manager-library/pkg/logger"
+
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 	perrs "github.com/gardener/external-dns-management/pkg/dns/provider/errors"
 	"github.com/gardener/external-dns-management/pkg/dns/provider/raw"

--- a/pkg/controller/provider/aws/handler.go
+++ b/pkg/controller/provider/aws/handler.go
@@ -16,8 +16,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
 	route53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
-
 	"github.com/gardener/controller-manager-library/pkg/logger"
+
 	"github.com/gardener/external-dns-management/pkg/controller/provider/aws/mapping"
 	"github.com/gardener/external-dns-management/pkg/dns"
 	"github.com/gardener/external-dns-management/pkg/dns/provider"

--- a/pkg/controller/provider/azure/execution.go
+++ b/pkg/controller/provider/azure/execution.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns"
 	"github.com/gardener/controller-manager-library/pkg/logger"
-	"github.com/gardener/external-dns-management/pkg/controller/provider/azure/utils"
 
+	"github.com/gardener/external-dns-management/pkg/controller/provider/azure/utils"
 	"github.com/gardener/external-dns-management/pkg/dns"
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 )

--- a/pkg/controller/provider/azure/utils/utils.go
+++ b/pkg/controller/provider/azure/utils/utils.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 	perrs "github.com/gardener/external-dns-management/pkg/dns/provider/errors"
 )

--- a/pkg/controller/provider/cloudflare/handler.go
+++ b/pkg/controller/provider/cloudflare/handler.go
@@ -7,6 +7,7 @@ package cloudflare
 import (
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/gardener/controller-manager-library/pkg/logger"
+
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 	"github.com/gardener/external-dns-management/pkg/dns/provider/raw"
 )

--- a/pkg/controller/provider/google/execution_test.go
+++ b/pkg/controller/provider/google/execution_test.go
@@ -8,14 +8,15 @@ import (
 	"fmt"
 
 	"github.com/gardener/controller-manager-library/pkg/logger"
-	"github.com/gardener/external-dns-management/pkg/dns"
-	"github.com/gardener/external-dns-management/pkg/dns/provider"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	"github.com/onsi/gomega/types"
 	googledns "google.golang.org/api/dns/v1"
 	"google.golang.org/api/googleapi"
+
+	"github.com/gardener/external-dns-management/pkg/dns"
+	"github.com/gardener/external-dns-management/pkg/dns/provider"
 )
 
 var _ = Describe("Execution", func() {

--- a/pkg/controller/provider/google/handler.go
+++ b/pkg/controller/provider/google/handler.go
@@ -11,18 +11,14 @@ import (
 	"strconv"
 	"strings"
 
-	"k8s.io/client-go/util/flowcontrol"
-
-	"github.com/gardener/external-dns-management/pkg/dns/provider"
-
+	"github.com/gardener/controller-manager-library/pkg/logger"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-
-	"github.com/gardener/controller-manager-library/pkg/logger"
+	googledns "google.golang.org/api/dns/v1"
+	"k8s.io/client-go/util/flowcontrol"
 
 	"github.com/gardener/external-dns-management/pkg/dns"
-
-	googledns "google.golang.org/api/dns/v1"
+	"github.com/gardener/external-dns-management/pkg/dns/provider"
 )
 
 type Handler struct {

--- a/pkg/controller/provider/google/routingpolicy.go
+++ b/pkg/controller/provider/google/routingpolicy.go
@@ -10,8 +10,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gardener/external-dns-management/pkg/dns"
 	googledns "google.golang.org/api/dns/v1"
+
+	"github.com/gardener/external-dns-management/pkg/dns"
 )
 
 const routingPolicyMaxIndices = 5

--- a/pkg/controller/provider/infoblox/handler.go
+++ b/pkg/controller/provider/infoblox/handler.go
@@ -13,11 +13,11 @@ import (
 	"strconv"
 
 	"github.com/gardener/controller-manager-library/pkg/logger"
+	ibclient "github.com/infobloxopen/infoblox-go-client/v2"
+
 	"github.com/gardener/external-dns-management/pkg/dns"
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 	"github.com/gardener/external-dns-management/pkg/dns/provider/raw"
-
-	ibclient "github.com/infobloxopen/infoblox-go-client/v2"
 )
 
 type Handler struct {

--- a/pkg/controller/provider/infoblox/state.go
+++ b/pkg/controller/provider/infoblox/state.go
@@ -5,11 +5,11 @@
 package infoblox
 
 import (
-	"github.com/gardener/external-dns-management/pkg/dns/utils"
 	ibclient "github.com/infobloxopen/infoblox-go-client/v2"
 
 	"github.com/gardener/external-dns-management/pkg/dns"
 	"github.com/gardener/external-dns-management/pkg/dns/provider/raw"
+	"github.com/gardener/external-dns-management/pkg/dns/utils"
 )
 
 type Record interface {

--- a/pkg/controller/provider/openstack/designateclient.go
+++ b/pkg/controller/provider/openstack/designateclient.go
@@ -13,13 +13,14 @@ import (
 	"time"
 
 	"github.com/gardener/controller-manager-library/pkg/logger"
-	"github.com/gardener/external-dns-management/pkg/dns/provider"
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/dns/v2/recordsets"
 	"github.com/gophercloud/gophercloud/openstack/dns/v2/zones"
 	"github.com/gophercloud/gophercloud/pagination"
 	"github.com/gophercloud/utils/openstack/clientconfig"
+
+	"github.com/gardener/external-dns-management/pkg/dns/provider"
 )
 
 // interface between provider and OpenStack DNS API

--- a/pkg/controller/provider/openstack/handler_test.go
+++ b/pkg/controller/provider/openstack/handler_test.go
@@ -11,15 +11,13 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/onsi/gomega"
-
 	"github.com/gardener/controller-manager-library/pkg/logger"
+	"github.com/gophercloud/gophercloud/openstack/dns/v2/recordsets"
+	"github.com/gophercloud/gophercloud/openstack/dns/v2/zones"
+	. "github.com/onsi/gomega"
 
 	"github.com/gardener/external-dns-management/pkg/dns"
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
-
-	"github.com/gophercloud/gophercloud/openstack/dns/v2/recordsets"
-	"github.com/gophercloud/gophercloud/openstack/dns/v2/zones"
 )
 
 type testzone struct {

--- a/pkg/controller/provider/powerdns/execution.go
+++ b/pkg/controller/provider/powerdns/execution.go
@@ -8,11 +8,11 @@ import (
 	"fmt"
 
 	"github.com/gardener/controller-manager-library/pkg/logger"
-	"github.com/gardener/external-dns-management/pkg/dns/utils"
 	"github.com/joeig/go-powerdns/v3"
 
 	"github.com/gardener/external-dns-management/pkg/dns"
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
+	"github.com/gardener/external-dns-management/pkg/dns/utils"
 )
 
 type RecordSet struct {

--- a/pkg/controller/provider/powerdns/handler.go
+++ b/pkg/controller/provider/powerdns/handler.go
@@ -11,9 +11,9 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/joeig/go-powerdns/v3"
 
-	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/external-dns-management/pkg/dns"
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 )

--- a/pkg/controller/provider/remote/handler.go
+++ b/pkg/controller/provider/remote/handler.go
@@ -14,18 +14,19 @@ import (
 	"time"
 
 	"github.com/gardener/controller-manager-library/pkg/logger"
-	"github.com/gardener/external-dns-management/pkg/controller/provider/aws"
-	"github.com/gardener/external-dns-management/pkg/controller/provider/aws/mapping"
-	"github.com/gardener/external-dns-management/pkg/dns"
-	"github.com/gardener/external-dns-management/pkg/dns/provider"
-	"github.com/gardener/external-dns-management/pkg/server/remote/common"
-	"github.com/gardener/external-dns-management/pkg/server/remote/conversion"
 	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/gardener/external-dns-management/pkg/controller/provider/aws"
+	"github.com/gardener/external-dns-management/pkg/controller/provider/aws/mapping"
+	"github.com/gardener/external-dns-management/pkg/dns"
+	"github.com/gardener/external-dns-management/pkg/dns/provider"
+	"github.com/gardener/external-dns-management/pkg/server/remote/common"
+	"github.com/gardener/external-dns-management/pkg/server/remote/conversion"
 )
 
 type Handler struct {

--- a/pkg/controller/provider/rfc2136/execution.go
+++ b/pkg/controller/provider/rfc2136/execution.go
@@ -11,11 +11,11 @@ import (
 	"time"
 
 	"github.com/gardener/controller-manager-library/pkg/logger"
-	"github.com/gardener/external-dns-management/pkg/dns/utils"
 	miekgdns "github.com/miekg/dns"
 
 	"github.com/gardener/external-dns-management/pkg/dns"
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
+	"github.com/gardener/external-dns-management/pkg/dns/utils"
 )
 
 type Change struct {

--- a/pkg/controller/provider/rfc2136/handler.go
+++ b/pkg/controller/provider/rfc2136/handler.go
@@ -11,10 +11,11 @@ import (
 	"time"
 
 	"github.com/gardener/controller-manager-library/pkg/logger"
+	miekgdns "github.com/miekg/dns"
+
 	"github.com/gardener/external-dns-management/pkg/dns"
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 	"github.com/gardener/external-dns-management/pkg/dns/provider/raw"
-	miekgdns "github.com/miekg/dns"
 )
 
 const (

--- a/pkg/controller/replication/dnsprovider/controller.go
+++ b/pkg/controller/replication/dnsprovider/controller.go
@@ -12,11 +12,11 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile/reconcilers"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/resources/apiextensions"
-	"github.com/gardener/external-dns-management/pkg/apis/dns/crds"
-	"github.com/gardener/external-dns-management/pkg/dns"
 	"k8s.io/apimachinery/pkg/util/runtime"
 
+	"github.com/gardener/external-dns-management/pkg/apis/dns/crds"
 	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/gardener/external-dns-management/pkg/dns"
 	"github.com/gardener/external-dns-management/pkg/dns/source"
 )
 

--- a/pkg/controller/replication/dnsprovider/handler.go
+++ b/pkg/controller/replication/dnsprovider/handler.go
@@ -16,13 +16,14 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/resources/access"
 	"github.com/gardener/controller-manager-library/pkg/utils"
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"github.com/gardener/external-dns-management/pkg/dns"
 	"github.com/gardener/external-dns-management/pkg/dns/source"
 	dnsutils "github.com/gardener/external-dns-management/pkg/dns/utils"
-	core "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const AnnotationSecretResourceVersion = dns.ANNOTATION_GROUP + "/secretResourceVersion"

--- a/pkg/controller/replication/dnsprovider/slaves.go
+++ b/pkg/controller/replication/dnsprovider/slaves.go
@@ -14,13 +14,12 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	utils2 "github.com/gardener/controller-manager-library/pkg/utils"
-	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
-	"github.com/gardener/external-dns-management/pkg/dns/source"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/gardener/external-dns-management/pkg/dns/source"
 	"github.com/gardener/external-dns-management/pkg/dns/utils"
-
-	"k8s.io/apimachinery/pkg/api/errors"
 )
 
 const RemotePrefix = "remote: "

--- a/pkg/controller/source/dnsentry/handler.go
+++ b/pkg/controller/source/dnsentry/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/utils"
+
 	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"github.com/gardener/external-dns-management/pkg/dns"
 	"github.com/gardener/external-dns-management/pkg/dns/source"

--- a/pkg/controller/source/gateways/crdwatch/controller.go
+++ b/pkg/controller/source/gateways/crdwatch/controller.go
@@ -12,10 +12,11 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile"
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
-	"github.com/gardener/external-dns-management/pkg/dns/source"
-	dnsutils "github.com/gardener/external-dns-management/pkg/dns/utils"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/gardener/external-dns-management/pkg/dns/source"
+	dnsutils "github.com/gardener/external-dns-management/pkg/dns/utils"
 )
 
 const CONTROLLER = "watch-gateways-crds"

--- a/pkg/controller/source/gateways/istio/controller.go
+++ b/pkg/controller/source/gateways/istio/controller.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/cluster"
 	"github.com/gardener/controller-manager-library/pkg/resources"
+
 	"github.com/gardener/external-dns-management/pkg/controller/source/ingress"
 	"github.com/gardener/external-dns-management/pkg/controller/source/service"
-
 	"github.com/gardener/external-dns-management/pkg/dns/source"
 )
 

--- a/pkg/controller/source/ingress/controller.go
+++ b/pkg/controller/source/ingress/controller.go
@@ -6,6 +6,7 @@ package ingress
 
 import (
 	"github.com/gardener/controller-manager-library/pkg/resources"
+
 	"github.com/gardener/external-dns-management/pkg/dns/source"
 )
 

--- a/pkg/controller/source/ingress/handler.go
+++ b/pkg/controller/source/ingress/handler.go
@@ -11,11 +11,12 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/utils"
-	"github.com/gardener/external-dns-management/pkg/dns"
-	"github.com/gardener/external-dns-management/pkg/dns/source"
 	networkingv1 "k8s.io/api/networking/v1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/utils/ptr"
+
+	"github.com/gardener/external-dns-management/pkg/dns"
+	"github.com/gardener/external-dns-management/pkg/dns/source"
 )
 
 type IngressSource struct {

--- a/pkg/controller/source/service/controller.go
+++ b/pkg/controller/source/service/controller.go
@@ -6,6 +6,7 @@ package service
 
 import (
 	"github.com/gardener/controller-manager-library/pkg/resources"
+
 	"github.com/gardener/external-dns-management/pkg/dns/source"
 )
 

--- a/pkg/controller/source/service/handler.go
+++ b/pkg/controller/source/service/handler.go
@@ -10,10 +10,11 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/utils"
-	"github.com/gardener/external-dns-management/pkg/dns"
-	"github.com/gardener/external-dns-management/pkg/dns/source"
 	api "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
+
+	"github.com/gardener/external-dns-management/pkg/dns"
+	"github.com/gardener/external-dns-management/pkg/dns/source"
 )
 
 func GetTargets(_ logger.LogContext, obj resources.ObjectData, names dns.DNSNameSet) (*source.TargetExtraction, error) {

--- a/pkg/dns/provider/changemodel.go
+++ b/pkg/dns/provider/changemodel.go
@@ -10,12 +10,12 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/gardener/controller-manager-library/pkg/logger"
+	"github.com/gardener/controller-manager-library/pkg/utils"
+
 	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"github.com/gardener/external-dns-management/pkg/dns"
 	dnsutils "github.com/gardener/external-dns-management/pkg/dns/utils"
-
-	"github.com/gardener/controller-manager-library/pkg/logger"
-	"github.com/gardener/controller-manager-library/pkg/utils"
 )
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/pkg/dns/provider/context.go
+++ b/pkg/dns/provider/context.go
@@ -8,12 +8,11 @@ import (
 	"context"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/pkg/dns/provider/controller.go
+++ b/pkg/dns/provider/controller.go
@@ -9,15 +9,6 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/gardener/external-dns-management/pkg/apis/dns/crds"
-	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
-	"github.com/gardener/external-dns-management/pkg/dns"
-	"github.com/gardener/external-dns-management/pkg/dns/source"
-	dnsutils "github.com/gardener/external-dns-management/pkg/dns/utils"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	"github.com/gardener/controller-manager-library/pkg/config"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile"
@@ -25,10 +16,17 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/resources/apiextensions"
-	"github.com/gardener/controller-manager-library/pkg/utils"
-
-	// register 1.16
 	_ "github.com/gardener/controller-manager-library/pkg/resources/defaultscheme/v1.18"
+	"github.com/gardener/controller-manager-library/pkg/utils"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/external-dns-management/pkg/apis/dns/crds"
+	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/gardener/external-dns-management/pkg/dns"
+	"github.com/gardener/external-dns-management/pkg/dns/source"
+	dnsutils "github.com/gardener/external-dns-management/pkg/dns/utils"
 )
 
 const CONTROLLER_GROUP_DNS_CONTROLLERS = dns.CONTROLLER_GROUP_DNS_CONTROLLERS

--- a/pkg/dns/provider/dedicatedrecord.go
+++ b/pkg/dns/provider/dedicatedrecord.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/gardener/controller-manager-library/pkg/logger"
+
 	"github.com/gardener/external-dns-management/pkg/dns"
 )
 

--- a/pkg/dns/provider/entry.go
+++ b/pkg/dns/provider/entry.go
@@ -19,15 +19,15 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/resources/access"
 	"github.com/gardener/controller-manager-library/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"github.com/gardener/external-dns-management/pkg/dns"
 	"github.com/gardener/external-dns-management/pkg/dns/provider/statistic"
 	dnsutils "github.com/gardener/external-dns-management/pkg/dns/utils"
-	"k8s.io/utils/ptr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 )
 
 const MSG_PRESERVED = "errorneous entry preserved in provider"

--- a/pkg/dns/provider/factory.go
+++ b/pkg/dns/provider/factory.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/extension"
 	"github.com/gardener/controller-manager-library/pkg/utils"
+
 	dnsutils "github.com/gardener/external-dns-management/pkg/dns/utils"
 )
 

--- a/pkg/dns/provider/foreign.go
+++ b/pkg/dns/provider/foreign.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/utils"
+
 	dnsutils "github.com/gardener/external-dns-management/pkg/dns/utils"
 )
 

--- a/pkg/dns/provider/inmemory.go
+++ b/pkg/dns/provider/inmemory.go
@@ -8,9 +8,10 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/gardener/external-dns-management/pkg/dns"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	yaml "sigs.k8s.io/yaml/goyaml.v3"
+
+	"github.com/gardener/external-dns-management/pkg/dns"
 )
 
 type zonedata struct {

--- a/pkg/dns/provider/interface.go
+++ b/pkg/dns/provider/interface.go
@@ -14,12 +14,12 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/utils"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/flowcontrol"
+
 	"github.com/gardener/external-dns-management/pkg/dns"
 	dnsutils "github.com/gardener/external-dns-management/pkg/dns/utils"
 	"github.com/gardener/external-dns-management/pkg/server/remote/embed"
-
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/util/flowcontrol"
 )
 
 type Config struct {

--- a/pkg/dns/provider/lookupprocessor.go
+++ b/pkg/dns/provider/lookupprocessor.go
@@ -15,9 +15,10 @@ import (
 
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
-	"github.com/gardener/external-dns-management/pkg/server/metrics"
 	"go.uber.org/atomic"
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/gardener/external-dns-management/pkg/server/metrics"
 )
 
 type lookupHostConfig struct {

--- a/pkg/dns/provider/lookupprocessor.go
+++ b/pkg/dns/provider/lookupprocessor.go
@@ -21,6 +21,7 @@ import (
 )
 
 type lookupHostConfig struct {
+	lock                       sync.Mutex
 	lookupHost                 func(string) ([]net.IP, error)
 	maxConcurrentLookupsPerJob int
 	maxLookupRetries           int
@@ -365,8 +366,11 @@ func lookupIPs(hostname string) lookupIPsResult {
 		ips []net.IP
 		err error
 	)
+	lookupHost.lock.Lock()
+	lookupFunc := lookupHost.lookupHost
+	lookupHost.lock.Unlock()
 	for i := 1; i <= lookupHost.maxLookupRetries; i++ {
-		ips, err = lookupHost.lookupHost(hostname)
+		ips, err = lookupFunc(hostname)
 		if err == nil || i == lookupHost.maxLookupRetries {
 			break
 		}

--- a/pkg/dns/provider/ownercache.go
+++ b/pkg/dns/provider/ownercache.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/utils"
+
 	"github.com/gardener/external-dns-management/pkg/dns"
 	dnsutils "github.com/gardener/external-dns-management/pkg/dns/utils"
 )

--- a/pkg/dns/provider/provider.go
+++ b/pkg/dns/provider/provider.go
@@ -14,6 +14,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile"
+	"github.com/gardener/controller-manager-library/pkg/logger"
+	"github.com/gardener/controller-manager-library/pkg/resources"
+	"github.com/gardener/controller-manager-library/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -23,11 +27,6 @@ import (
 	"github.com/gardener/external-dns-management/pkg/dns/provider/selection"
 	dnsutils "github.com/gardener/external-dns-management/pkg/dns/utils"
 	"github.com/gardener/external-dns-management/pkg/server/metrics"
-
-	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile"
-	"github.com/gardener/controller-manager-library/pkg/logger"
-	"github.com/gardener/controller-manager-library/pkg/resources"
-	"github.com/gardener/controller-manager-library/pkg/utils"
 )
 
 const ZoneCachePrefix = "zc-"

--- a/pkg/dns/provider/remote.go
+++ b/pkg/dns/provider/remote.go
@@ -12,8 +12,9 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
-	"github.com/gardener/external-dns-management/pkg/server/remote/embed"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/gardener/external-dns-management/pkg/server/remote/embed"
 )
 
 var _ LightDNSHandler = &dnsProviderVersionLightHandler{}

--- a/pkg/dns/provider/selection/selection.go
+++ b/pkg/dns/provider/selection/selection.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/gardener/controller-manager-library/pkg/utils"
+
 	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"github.com/gardener/external-dns-management/pkg/dns"
 	dnsutils "github.com/gardener/external-dns-management/pkg/dns/utils"

--- a/pkg/dns/provider/selection/selection_test.go
+++ b/pkg/dns/provider/selection/selection_test.go
@@ -5,10 +5,10 @@
 package selection_test
 
 import (
+	"github.com/gardener/controller-manager-library/pkg/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/gardener/controller-manager-library/pkg/utils"
 	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"github.com/gardener/external-dns-management/pkg/dns"
 	. "github.com/gardener/external-dns-management/pkg/dns/provider/selection"

--- a/pkg/dns/provider/state.go
+++ b/pkg/dns/provider/state.go
@@ -11,20 +11,19 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/gardener/external-dns-management/pkg/dns/provider/zonetxn"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/util/flowcontrol"
-
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/resources/access"
 	"github.com/gardener/controller-manager-library/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/flowcontrol"
 
 	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"github.com/gardener/external-dns-management/pkg/dns"
+	"github.com/gardener/external-dns-management/pkg/dns/provider/zonetxn"
 	dnsutils "github.com/gardener/external-dns-management/pkg/dns/utils"
 	"github.com/gardener/external-dns-management/pkg/server/remote/embed"
 )

--- a/pkg/dns/provider/state_entry.go
+++ b/pkg/dns/provider/state_entry.go
@@ -13,13 +13,14 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/utils"
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"k8s.io/utils/ptr"
+
 	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"github.com/gardener/external-dns-management/pkg/dns"
 	perrs "github.com/gardener/external-dns-management/pkg/dns/provider/errors"
 	"github.com/gardener/external-dns-management/pkg/dns/provider/zonetxn"
 	dnsutils "github.com/gardener/external-dns-management/pkg/dns/utils"
-	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"k8s.io/utils/ptr"
 )
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/pkg/dns/provider/state_owner.go
+++ b/pkg/dns/provider/state_owner.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/utils"
+
 	dnsutils "github.com/gardener/external-dns-management/pkg/dns/utils"
 )
 

--- a/pkg/dns/provider/state_provider.go
+++ b/pkg/dns/provider/state_provider.go
@@ -11,11 +11,12 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/flowcontrol"
+
 	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	perrs "github.com/gardener/external-dns-management/pkg/dns/provider/errors"
 	dnsutils "github.com/gardener/external-dns-management/pkg/dns/utils"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/util/flowcontrol"
 )
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/pkg/dns/provider/state_zone.go
+++ b/pkg/dns/provider/state_zone.go
@@ -12,12 +12,12 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile"
 	"github.com/gardener/controller-manager-library/pkg/ctxutil"
 	"github.com/gardener/controller-manager-library/pkg/logger"
-	"github.com/gardener/external-dns-management/pkg/dns/provider/zonetxn"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/gardener/external-dns-management/pkg/dns"
 	perrs "github.com/gardener/external-dns-management/pkg/dns/provider/errors"
+	"github.com/gardener/external-dns-management/pkg/dns/provider/zonetxn"
 	"github.com/gardener/external-dns-management/pkg/server/metrics"
 )
 

--- a/pkg/dns/provider/state_zonepolicy.go
+++ b/pkg/dns/provider/state_zonepolicy.go
@@ -15,10 +15,10 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	utils2 "github.com/gardener/controller-manager-library/pkg/utils"
-	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
-	"github.com/gardener/external-dns-management/pkg/dns"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/gardener/external-dns-management/pkg/dns"
 	dnsutils "github.com/gardener/external-dns-management/pkg/dns/utils"
 )
 

--- a/pkg/dns/provider/statusupdate.go
+++ b/pkg/dns/provider/statusupdate.go
@@ -7,6 +7,7 @@ package provider
 import (
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
+
 	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 )
 

--- a/pkg/dns/provider/utils.go
+++ b/pkg/dns/provider/utils.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 
 	"github.com/gardener/controller-manager-library/pkg/resources"
+
 	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"github.com/gardener/external-dns-management/pkg/dns"
 )

--- a/pkg/dns/provider/zone.go
+++ b/pkg/dns/provider/zone.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gardener/controller-manager-library/pkg/utils"
+
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"github.com/gardener/external-dns-management/pkg/dns"
 	dnsutils "github.com/gardener/external-dns-management/pkg/dns/utils"

--- a/pkg/dns/provider/zonecache.go
+++ b/pkg/dns/provider/zonecache.go
@@ -14,10 +14,10 @@ import (
 	"time"
 
 	"github.com/gardener/controller-manager-library/pkg/logger"
-	"github.com/gardener/external-dns-management/pkg/server/metrics"
 
 	"github.com/gardener/external-dns-management/pkg/dns"
 	"github.com/gardener/external-dns-management/pkg/dns/provider/errors"
+	"github.com/gardener/external-dns-management/pkg/server/metrics"
 )
 
 type StateTTLGetter func(zoneid dns.ZoneID) time.Duration

--- a/pkg/dns/source/controller.go
+++ b/pkg/dns/source/controller.go
@@ -8,21 +8,19 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/watches"
-	"github.com/gardener/controller-manager-library/pkg/resources/apiextensions"
-	"k8s.io/apimachinery/pkg/util/runtime"
-
-	"github.com/gardener/external-dns-management/pkg/apis/dns/crds"
-	"github.com/gardener/external-dns-management/pkg/controller/annotation"
-	"github.com/gardener/external-dns-management/pkg/dns"
-
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/cluster"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile/reconcilers"
+	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/watches"
 	"github.com/gardener/controller-manager-library/pkg/resources"
+	"github.com/gardener/controller-manager-library/pkg/resources/apiextensions"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/runtime"
 
+	"github.com/gardener/external-dns-management/pkg/apis/dns/crds"
 	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/gardener/external-dns-management/pkg/controller/annotation"
+	"github.com/gardener/external-dns-management/pkg/dns"
 )
 
 const (

--- a/pkg/dns/source/defaults.go
+++ b/pkg/dns/source/defaults.go
@@ -8,12 +8,12 @@ import (
 	"sync"
 
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller"
-	"github.com/gardener/external-dns-management/pkg/dns"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile"
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/gardener/external-dns-management/pkg/dns"
 )
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/pkg/dns/source/dnsinfo.go
+++ b/pkg/dns/source/dnsinfo.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/utils"
+
 	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"github.com/gardener/external-dns-management/pkg/dns"
 )

--- a/pkg/dns/source/interface.go
+++ b/pkg/dns/source/interface.go
@@ -10,11 +10,11 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/utils"
-	"github.com/gardener/external-dns-management/pkg/dns"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/gardener/external-dns-management/pkg/dns"
 )
 
 type DNSInfo struct {

--- a/pkg/dns/source/ownerreconciler.go
+++ b/pkg/dns/source/ownerreconciler.go
@@ -15,8 +15,9 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/ctxutil"
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
-	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 )
 
 var keyOwnerState = ctxutil.SimpleKey("owner-state")

--- a/pkg/dns/source/reconciler.go
+++ b/pkg/dns/source/reconciler.go
@@ -17,13 +17,13 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/resources/access"
 	"github.com/gardener/controller-manager-library/pkg/utils"
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+
 	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"github.com/gardener/external-dns-management/pkg/controller/annotation/annotations"
 	"github.com/gardener/external-dns-management/pkg/dns"
 	dnsutils "github.com/gardener/external-dns-management/pkg/dns/utils"
-
-	core "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 )
 
 // NewSlaveAccessSpec creates a new SlaveAccessSpec.

--- a/pkg/dns/source/slaves.go
+++ b/pkg/dns/source/slaves.go
@@ -12,12 +12,11 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/controllermanager/controller/reconcile/reconcilers"
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
-	"github.com/gardener/external-dns-management/pkg/dns"
+	"k8s.io/apimachinery/pkg/api/errors"
 
 	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/gardener/external-dns-management/pkg/dns"
 	"github.com/gardener/external-dns-management/pkg/dns/utils"
-
-	"k8s.io/apimachinery/pkg/api/errors"
 )
 
 func SlaveReconcilerType(c controller.Interface) (reconcile.Interface, error) {

--- a/pkg/dns/utils/utils_entry.go
+++ b/pkg/dns/utils/utils_entry.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/utils"
-	"github.com/gardener/external-dns-management/pkg/dns"
 
 	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/gardener/external-dns-management/pkg/dns"
 )
 
 var DNSEntryType = (*api.DNSEntry)(nil)

--- a/pkg/dns/utils/utils_owner.go
+++ b/pkg/dns/utils/utils_owner.go
@@ -6,6 +6,7 @@ package utils
 
 import (
 	"github.com/gardener/controller-manager-library/pkg/resources"
+
 	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 )
 

--- a/pkg/dns/utils/utils_provider.go
+++ b/pkg/dns/utils/utils_provider.go
@@ -8,10 +8,9 @@ import (
 	"errors"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/utils"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	dnserrors "github.com/gardener/external-dns-management/pkg/dns/provider/errors"

--- a/pkg/dns/utils/utils_zonepolicy.go
+++ b/pkg/dns/utils/utils_zonepolicy.go
@@ -6,6 +6,7 @@ package utils
 
 import (
 	"github.com/gardener/controller-manager-library/pkg/resources"
+
 	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 )
 

--- a/pkg/dnsman2/client/scheme.go
+++ b/pkg/dnsman2/client/scheme.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	dnsmanv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	istionetworkingv1 "istio.io/client-go/pkg/apis/networking/v1"
 	istionetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
@@ -14,6 +13,8 @@ import (
 	gatewayapisv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapisv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapisv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	dnsmanv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 )
 
 var (

--- a/pkg/server/metrics/metrics.go
+++ b/pkg/server/metrics/metrics.go
@@ -9,13 +9,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gardener/controller-manager-library/pkg/resources"
+	"github.com/gardener/controller-manager-library/pkg/server"
+	"github.com/gardener/controller-manager-library/pkg/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"github.com/gardener/controller-manager-library/pkg/resources"
-	"github.com/gardener/controller-manager-library/pkg/server"
-	"github.com/gardener/controller-manager-library/pkg/utils"
 	"github.com/gardener/external-dns-management/pkg/dns"
 )
 

--- a/pkg/server/remote/embed/dynamictransportcreds.go
+++ b/pkg/server/remote/embed/dynamictransportcreds.go
@@ -14,10 +14,11 @@ import (
 	"time"
 
 	"github.com/gardener/controller-manager-library/pkg/logger"
-	"github.com/gardener/external-dns-management/pkg/server/metrics"
 	atomic2 "go.uber.org/atomic"
 	"google.golang.org/grpc/credentials"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/gardener/external-dns-management/pkg/server/metrics"
 )
 
 type dynamicTransportCredentials struct {

--- a/pkg/server/remote/embed/remoteserver.go
+++ b/pkg/server/remote/embed/remoteserver.go
@@ -13,10 +13,11 @@ import (
 
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
-	"github.com/gardener/external-dns-management/pkg/server/remote/common"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/gardener/external-dns-management/pkg/server/remote/common"
 )
 
 // ServerSecretUpdateHandler is called on updated server secret

--- a/pkg/server/remote/memorylogger.go
+++ b/pkg/server/remote/memorylogger.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gardener/controller-manager-library/pkg/logger"
+
 	"github.com/gardener/external-dns-management/pkg/server/remote/common"
 )
 

--- a/pkg/server/remote/server.go
+++ b/pkg/server/remote/server.go
@@ -14,14 +14,15 @@ import (
 
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
-	"github.com/gardener/external-dns-management/pkg/dns/provider"
-	"github.com/gardener/external-dns-management/pkg/server/metrics"
-	"github.com/gardener/external-dns-management/pkg/server/remote/common"
-	"github.com/gardener/external-dns-management/pkg/server/remote/conversion"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
+
+	"github.com/gardener/external-dns-management/pkg/dns/provider"
+	"github.com/gardener/external-dns-management/pkg/server/metrics"
+	"github.com/gardener/external-dns-management/pkg/server/remote/common"
+	"github.com/gardener/external-dns-management/pkg/server/remote/conversion"
 )
 
 type server struct {

--- a/pkg/server/remote/state.go
+++ b/pkg/server/remote/state.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gardener/controller-manager-library/pkg/logger"
+
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 	dnsutils "github.com/gardener/external-dns-management/pkg/dns/utils"
 	"github.com/gardener/external-dns-management/pkg/server/remote/common"

--- a/test/functional/routingpolicies.go
+++ b/test/functional/routingpolicies.go
@@ -9,10 +9,11 @@ import (
 	"os"
 	"text/template"
 
-	"github.com/gardener/external-dns-management/test/functional/config"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+
+	"github.com/gardener/external-dns-management/test/functional/config"
 )
 
 var routingPolicyTemplate = `

--- a/test/integration/compound/compound_test.go
+++ b/test/integration/compound/compound_test.go
@@ -10,8 +10,7 @@ import (
 	"time"
 
 	"github.com/gardener/controller-manager-library/pkg/controllermanager"
-	"github.com/gardener/external-dns-management/pkg/dns"
-	"github.com/gardener/external-dns-management/pkg/dns/provider"
+	"github.com/gardener/controller-manager-library/pkg/ctxutil"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	. "github.com/onsi/ginkgo/v2"
@@ -24,9 +23,10 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/gardener/controller-manager-library/pkg/ctxutil"
 	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"github.com/gardener/external-dns-management/pkg/controller/provider/mock"
+	"github.com/gardener/external-dns-management/pkg/dns"
+	"github.com/gardener/external-dns-management/pkg/dns/provider"
 )
 
 var debug = false

--- a/test/integration/entryLivecycle_test.go
+++ b/test/integration/entryLivecycle_test.go
@@ -10,10 +10,11 @@ import (
 	"time"
 
 	"github.com/gardener/controller-manager-library/pkg/utils"
-	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
+
+	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 )
 
 var _ = Describe("EntryLivecycle", func() {

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -6,8 +6,9 @@ package integration
 
 import (
 	"github.com/gardener/controller-manager-library/pkg/resources"
-	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	. "github.com/onsi/gomega"
+
+	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 )
 
 func checkHasFinalizer(obj resources.Object) {

--- a/test/integration/ingressAnnotation_test.go
+++ b/test/integration/ingressAnnotation_test.go
@@ -5,10 +5,11 @@
 package integration
 
 import (
-	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
+
+	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 )
 
 var _ = Describe("IngressAnnotation", func() {

--- a/test/integration/privateZones_test.go
+++ b/test/integration/privateZones_test.go
@@ -9,11 +9,12 @@ import (
 	"time"
 
 	"github.com/gardener/controller-manager-library/pkg/resources"
-	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
-	"github.com/gardener/external-dns-management/pkg/controller/provider/mock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/gardener/external-dns-management/pkg/controller/provider/mock"
 )
 
 var _ = Describe("PrivateZones", func() {

--- a/test/integration/providerSecret_test.go
+++ b/test/integration/providerSecret_test.go
@@ -7,11 +7,12 @@ package integration
 import (
 	"fmt"
 
-	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
-	"github.com/gardener/external-dns-management/pkg/controller/provider/mock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/gardener/external-dns-management/pkg/controller/provider/mock"
 )
 
 var _ = Describe("ProviderSecret", func() {

--- a/test/integration/remoteAccess_test.go
+++ b/test/integration/remoteAccess_test.go
@@ -16,13 +16,13 @@ import (
 
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/utils/pkiutil"
-	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
-	"github.com/gardener/external-dns-management/pkg/controller/remoteaccesscertificates"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/gardener/external-dns-management/pkg/controller/remoteaccesscertificates"
 )
 
 type certFileAndSecret struct {

--- a/test/integration/serviceAnnotation_test.go
+++ b/test/integration/serviceAnnotation_test.go
@@ -6,11 +6,12 @@ package integration
 
 import (
 	"github.com/gardener/controller-manager-library/pkg/resources"
-	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
+
+	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 )
 
 var _ = Describe("ServiceAnnotation", func() {

--- a/test/integration/source/dnsentry_test.go
+++ b/test/integration/source/dnsentry_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gardener/controller-manager-library/pkg/controllermanager"
+	"github.com/gardener/controller-manager-library/pkg/ctxutil"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -20,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/json"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/gardener/controller-manager-library/pkg/ctxutil"
 	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"github.com/gardener/external-dns-management/pkg/controller/provider/mock"
 )

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -12,14 +12,6 @@ import (
 
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/utils"
-	_ "github.com/gardener/external-dns-management/pkg/controller/provider/compound/controller"
-	_ "github.com/gardener/external-dns-management/pkg/controller/provider/mock"
-	_ "github.com/gardener/external-dns-management/pkg/controller/provider/remote"
-	_ "github.com/gardener/external-dns-management/pkg/controller/source/gateways/gatewayapi"
-	_ "github.com/gardener/external-dns-management/pkg/controller/source/gateways/istio"
-	_ "github.com/gardener/external-dns-management/pkg/controller/source/ingress"
-	_ "github.com/gardener/external-dns-management/pkg/controller/source/service"
-	_ "github.com/gardener/external-dns-management/pkg/server/pprof"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	istionetworkingv1 "istio.io/client-go/pkg/apis/networking/v1"
@@ -30,6 +22,15 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	gatewayapisv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	_ "github.com/gardener/external-dns-management/pkg/controller/provider/compound/controller"
+	_ "github.com/gardener/external-dns-management/pkg/controller/provider/mock"
+	_ "github.com/gardener/external-dns-management/pkg/controller/provider/remote"
+	_ "github.com/gardener/external-dns-management/pkg/controller/source/gateways/gatewayapi"
+	_ "github.com/gardener/external-dns-management/pkg/controller/source/gateways/istio"
+	_ "github.com/gardener/external-dns-management/pkg/controller/source/ingress"
+	_ "github.com/gardener/external-dns-management/pkg/controller/source/service"
+	_ "github.com/gardener/external-dns-management/pkg/server/pprof"
 )
 
 var (

--- a/test/integration/testenv.go
+++ b/test/integration/testenv.go
@@ -25,14 +25,6 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/resources/apiextensions"
 	"github.com/gardener/controller-manager-library/pkg/utils"
-	v1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
-	"github.com/gardener/external-dns-management/pkg/controller/provider/mock"
-	"github.com/gardener/external-dns-management/pkg/controller/source/gateways/istio"
-	"github.com/gardener/external-dns-management/pkg/dns"
-	dnsprovider "github.com/gardener/external-dns-management/pkg/dns/provider"
-	dnssource "github.com/gardener/external-dns-management/pkg/dns/source"
-	"github.com/gardener/external-dns-management/pkg/server/remote"
-	"github.com/gardener/external-dns-management/pkg/server/remote/embed"
 	istioapinetworkingv1 "istio.io/api/networking/v1"
 	istionetworkingv1 "istio.io/client-go/pkg/apis/networking/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -45,6 +37,15 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/utils/ptr"
 	gatewayapisv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	v1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/gardener/external-dns-management/pkg/controller/provider/mock"
+	"github.com/gardener/external-dns-management/pkg/controller/source/gateways/istio"
+	"github.com/gardener/external-dns-management/pkg/dns"
+	dnsprovider "github.com/gardener/external-dns-management/pkg/dns/provider"
+	dnssource "github.com/gardener/external-dns-management/pkg/dns/source"
+	"github.com/gardener/external-dns-management/pkg/server/remote"
+	"github.com/gardener/external-dns-management/pkg/server/remote/embed"
 )
 
 type ProviderTestOption int


### PR DESCRIPTION
**What this PR does / why we need it**:
Makefile: use standard way for `test` and `format` tasks.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
