### PR TITLE
Fix field name LastUpdateTime

### DIFF
--- a/pkg/apis/dns/v1alpha1/dnsentry.go
+++ b/pkg/apis/dns/v1alpha1/dnsentry.go
@@ -89,7 +89,7 @@ type DNSEntryStatus struct {
 	Message *string `json:"message,omitempty"`
 	// lastUpdateTime contains the timestamp of the last status update
 	// +optional
-	LastUptimeTime *metav1.Time `json:"lastUpdateTime,omitempty"`
+	LastUpdateTime *metav1.Time `json:"lastUpdateTime,omitempty"`
 	// provider type used for the entry
 	// +optional
 	ProviderType *string `json:"providerType,omitempty"`

--- a/pkg/apis/dns/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/dns/v1alpha1/zz_generated.deepcopy.go
@@ -240,8 +240,8 @@ func (in *DNSEntryStatus) DeepCopyInto(out *DNSEntryStatus) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.LastUptimeTime != nil {
-		in, out := &in.LastUptimeTime, &out.LastUptimeTime
+	if in.LastUpdateTime != nil {
+		in, out := &in.LastUpdateTime, &out.LastUpdateTime
 		*out = (*in).DeepCopy()
 	}
 	if in.ProviderType != nil {

--- a/pkg/dns/provider/entry.go
+++ b/pkg/dns/provider/entry.go
@@ -571,7 +571,7 @@ func (this *EntryVersion) Setup(logger logger.LogContext, state *state, p *Entry
 			AssureStringPtrPtr(&status.Zone, this.status.Zone).
 			AssureStringPtrPtr(&status.Provider, this.status.Provider)
 		if mod.IsModified() {
-			dnsutils.SetLastUpdateTime(&status.LastUptimeTime)
+			dnsutils.SetLastUpdateTime(&status.LastUpdateTime)
 			logmsg.Infof(logger)
 		}
 		mod.Modify(dnsutils.DNSEntry(obj).AcknowledgeCNAMELookupInterval(this.interval))
@@ -662,7 +662,7 @@ func (this *EntryVersion) UpdateStatus(logger logger.LogContext, state string, m
 		mod.AssureStringValue(&b.State, state)
 		this.status.State = state
 		if mod.IsModified() {
-			dnsutils.SetLastUpdateTime(&b.LastUptimeTime)
+			dnsutils.SetLastUpdateTime(&b.LastUpdateTime)
 			logger.Infof("update state of '%s/%s' to %s (%s)", o.GetNamespace(), o.GetName(), state, msg)
 		}
 		return mod.IsModified(), nil
@@ -685,7 +685,7 @@ func (this *EntryVersion) UpdateState(logger logger.LogContext, state, msg strin
 		mod.AssureStringValue(&b.State, state)
 		this.status.State = state
 		if mod.IsModified() {
-			dnsutils.SetLastUpdateTime(&b.LastUptimeTime)
+			dnsutils.SetLastUpdateTime(&b.LastUpdateTime)
 			logger.Infof("update state of '%s/%s' to %s (%s)", o.GetNamespace(), o.GetName(), state, msg)
 		}
 		return mod.IsModified(), nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Change field name `LastUptimeTime` to `LastUpdateTime` to match the JSON field name.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
