### PR TITLE
ci: Unify `make format`

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -29,6 +29,8 @@ external-dns-management:
         image: golang:1.24
       test:
         image: golang:1.24
+      verify:
+        image: golang:1.24
     traits:
       publish:
         oci-builder: docker-buildx

--- a/.ci/verify
+++ b/.ci/verify
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+cd "$(dirname $0)/.."
+
+git config --global user.email "gardener@sap.com"
+git config --global user.name "Gardener CI/CD"
+
+export GOTOOLCHAIN=auto
+make verify-extended

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ generate: $(VGOPATH) $(CONTROLLER_GEN) $(HELM)
 	@CONTROLLER_MANAGER_LIB_HACK_DIR=$(CONTROLLER_MANAGER_LIB_HACK_DIR) CONTROLLER_GEN=$(shell realpath $(CONTROLLER_GEN))  HELM=$(shell realpath $(HELM)) go generate ./charts/external-dns-management
 	@./hack/copy-crds.sh
 	@GARDENER_HACK_DIR=$(GARDENER_HACK_DIR) VGOPATH=$(VGOPATH) REPO_ROOT=$(REPO_ROOT) CONTROLLER_GEN=$(shell realpath $(CONTROLLER_GEN)) go generate ./pkg/dnsman2/apis/...
-	@go fmt ./pkg/...
+	@(MAKE) format
 	@go mod tidy
 
 alltests: $(GINKGO)

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,10 @@ clean:
 .PHONY: check
 check: sast-report fastcheck
 
+.PHONY: check-generate
+check-generate:
+	@bash $(GARDENER_HACK_DIR)/check-generate.sh $(REPO_ROOT)
+
 .PHONY: fastcheck
 fastcheck: format $(GOIMPORTS) $(GOLANGCI_LINT)
 	@TOOLS_BIN_DIR="$(TOOLS_BIN_DIR)" bash $(CONTROLLER_MANAGER_LIB_HACK_DIR)/check.sh --golangci-lint-config=./.golangci.yaml ./cmd/... ./pkg/... ./test/...
@@ -121,3 +125,9 @@ sast: $(GOSEC)
 .PHONY: sast-report
 sast-report: $(GOSEC)
 	@./hack/sast.sh --gosec-report true
+
+.PHONY: verify
+verify: check format test sast
+
+.PHONY: verify-extended
+verify-extended: check-generate check format test sast-report

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ generate: $(VGOPATH) $(CONTROLLER_GEN) $(HELM)
 	@CONTROLLER_MANAGER_LIB_HACK_DIR=$(CONTROLLER_MANAGER_LIB_HACK_DIR) CONTROLLER_GEN=$(shell realpath $(CONTROLLER_GEN))  HELM=$(shell realpath $(HELM)) go generate ./charts/external-dns-management
 	@./hack/copy-crds.sh
 	@GARDENER_HACK_DIR=$(GARDENER_HACK_DIR) VGOPATH=$(VGOPATH) REPO_ROOT=$(REPO_ROOT) CONTROLLER_GEN=$(shell realpath $(CONTROLLER_GEN)) go generate ./pkg/dnsman2/apis/...
-	@(MAKE) format
+	$(MAKE) format
 	@go mod tidy
 
 alltests: $(GINKGO)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

This PR intends to unify how `make format` works between the Cert- & DNS-management repositories.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @MartinWeindel 

Related PRs:
* https://github.com/gardener/cert-management/pull/442
* https://github.com/gardener/gardener-extension-shoot-cert-service/pull/360
* https://github.com/gardener/gardener-extension-shoot-dns-service/pull/451
 
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
