### PR TITLE
Make stale status more robust for resolved targets on DNS server failure

### DIFF
--- a/pkg/dns/provider/entry.go
+++ b/pkg/dns/provider/entry.go
@@ -489,8 +489,10 @@ func (this *EntryVersion) Setup(logger logger.LogContext, state *state, p *Entry
 			}
 			if lookupResults != nil {
 				state.UpsertLookupJob(this.object.ObjectName(), *lookupResults, time.Duration(this.interval)*time.Second)
+				state.SetUpdateOperationsBlocked(this.object.ObjectName(), lookupResults.HasTemporaryError())
 			} else {
 				state.DeleteLookupJob(this.object.ObjectName())
+				state.SetUpdateOperationsBlocked(this.object.ObjectName(), false)
 			}
 			if len(targets) == 0 || (lookupResults != nil && lookupResults.HasTemporaryError()) {
 				msg := "targets cannot be resolved to any valid IPv4 address"
@@ -517,6 +519,7 @@ func (this *EntryVersion) Setup(logger logger.LogContext, state *state, p *Entry
 		} else {
 			state.DeleteLookupJob(this.object.ObjectName())
 			this.interval = 0
+			state.SetUpdateOperationsBlocked(this.object.ObjectName(), false)
 		}
 
 		this.targets = targets

--- a/pkg/dns/provider/entry.go
+++ b/pkg/dns/provider/entry.go
@@ -494,21 +494,21 @@ func (this *EntryVersion) Setup(logger logger.LogContext, state *state, p *Entry
 			}
 			if len(targets) == 0 || (lookupResults != nil && lookupResults.HasTemporaryError()) {
 				msg := "targets cannot be resolved to any valid IPv4 address"
+				state := api.STATE_INVALID
+				if this.status.State == api.STATE_STALE {
+					state = api.STATE_STALE
+				}
 				if lookupResults == nil {
 					msg = "too many targets"
 					this.interval = int64(84600)
 				} else if lookupResults.HasTemporaryError() {
 					msg = "temporary error in DNS lookup"
+					state = api.STATE_STALE
 				}
 
 				verr := fmt.Errorf("%s", msg)
 				hello.Infof(logger, msg)
 
-				state := api.STATE_INVALID
-				// if DNS lookup fails temporarily, go to state STALE
-				if this.status.State == api.STATE_READY || this.status.State == api.STATE_STALE {
-					state = api.STATE_STALE
-				}
 				if _, err := this.UpdateStatus(logger, state, verr.Error()); err != nil {
 					return reconcile.Failed(logger, err)
 				}

--- a/pkg/dns/provider/entry.go
+++ b/pkg/dns/provider/entry.go
@@ -492,11 +492,13 @@ func (this *EntryVersion) Setup(logger logger.LogContext, state *state, p *Entry
 			} else {
 				state.DeleteLookupJob(this.object.ObjectName())
 			}
-			if len(targets) == 0 {
+			if len(targets) == 0 || (lookupResults != nil && lookupResults.HasTemporaryError()) {
 				msg := "targets cannot be resolved to any valid IPv4 address"
 				if lookupResults == nil {
 					msg = "too many targets"
 					this.interval = int64(84600)
+				} else if lookupResults.HasTemporaryError() {
+					msg = "temporary error in DNS lookup"
 				}
 
 				verr := fmt.Errorf("%s", msg)

--- a/pkg/dns/provider/lookupprocessor.go
+++ b/pkg/dns/provider/lookupprocessor.go
@@ -64,7 +64,7 @@ func (j *lookupJob) updateWithLock(newResults lookupAllResults, interval time.Du
 func (j *lookupJob) updateLookupResult(newResults lookupAllResults) bool {
 	changed := !j.oldLookupResults.allIPAddrs.Equal(newResults.allIPAddrs)
 	j.oldLookupResults = newResults
-	return changed
+	return changed && !newResults.HasTemporaryError()
 }
 
 type lookupQueue []*lookupJob

--- a/pkg/dns/provider/state_entry.go
+++ b/pkg/dns/provider/state_entry.go
@@ -306,7 +306,7 @@ func (this *state) HandleUpdateEntry(logger logger.LogContext, op string, object
 	status := v.Setup(logger, this, p, op, err, this.config)
 	new, status := this.addEntryVersion(logger, v, status)
 
-	if new != nil {
+	if new != nil && status.Error == nil {
 		if new.IsModified() && !new.ZoneId().IsEmpty() {
 			this.smartInfof(logger, "trigger zone %q", new.ZoneId())
 			this.triggerHostedZone(new.ZoneId())

--- a/pkg/dns/provider/state_entry.go
+++ b/pkg/dns/provider/state_entry.go
@@ -401,6 +401,25 @@ func (this *state) UpsertLookupJob(entryName resources.ObjectName, results looku
 	this.lookupProcessor.Upsert(entryName, results, interval)
 }
 
+func (this *state) SetUpdateOperationsBlocked(entryName resources.ObjectName, blocked bool) {
+	this.updateEntryBlockedLock.Lock()
+	defer this.updateEntryBlockedLock.Unlock()
+
+	if blocked {
+		this.updateEntryBlocked[entryName] = struct{}{}
+	} else {
+		delete(this.updateEntryBlocked, entryName)
+	}
+}
+
+func (this *state) IsUpdateOperationsBlocked(entryName resources.ObjectName) bool {
+	this.updateEntryBlockedLock.Lock()
+	defer this.updateEntryBlockedLock.Unlock()
+
+	_, blocked := this.updateEntryBlocked[entryName]
+	return blocked
+}
+
 func ignoredByAnnotation(object *dnsutils.DNSEntryObject) (bool, string) {
 	if !object.IsDeleting() && object.GetAnnotations()[dns.AnnotationIgnore] == "true" {
 		return true, dns.AnnotationIgnore

--- a/pkg/dns/provider/state_entry.go
+++ b/pkg/dns/provider/state_entry.go
@@ -109,6 +109,10 @@ func (this *state) addEntryVersion(logger logger.LogContext, v *EntryVersion, st
 	if old == nil {
 		new = NewEntry(v, this)
 	} else {
+		if this.IsUpdateOperationsBlocked(v.ObjectName()) {
+			this.smartInfof(logger, "update operations blocked temporarily")
+			return old, status
+		}
 		oldDNSSet = this.dnsSetFromEntry(old)
 		new = old.Update(logger, v)
 	}
@@ -306,7 +310,7 @@ func (this *state) HandleUpdateEntry(logger logger.LogContext, op string, object
 	status := v.Setup(logger, this, p, op, err, this.config)
 	new, status := this.addEntryVersion(logger, v, status)
 
-	if new != nil && status.Error == nil {
+	if new != nil {
 		if new.IsModified() && !new.ZoneId().IsEmpty() {
 			this.smartInfof(logger, "trigger zone %q", new.ZoneId())
 			this.triggerHostedZone(new.ZoneId())


### PR DESCRIPTION
**What this PR does / why we need it**:
For `DNSEntries` using resolved targets, i.e. multiple domain names as targets or with `.spec.resolveTargetsToAddresses=true`, the IP addresses are looked up periodically.
If the DNS server is not reachable or misbehaving, the `DNSEntry` must go to status `Stale` and the DNS records should be kept untouched. Sporadically, the record could be deleted for a few seconds. The handling in this case is improved and made more robust. 

**Which issue(s) this PR fixes**:
Fixes #431 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Make stale status more robust for resolved targets on DNS server failure.
```
