### PR TITLE
Fine tuning for verify and verify-extended targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ sast-report: $(GOSEC)
 	@./hack/sast.sh --gosec-report true
 
 .PHONY: verify
-verify: fastcheck format test sast
+verify: fastcheck format sast
 
 .PHONY: verify-extended
 verify-extended: check-generate fastcheck format unittests new-test-integration sast-report

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ sast-report: $(GOSEC)
 	@./hack/sast.sh --gosec-report true
 
 .PHONY: verify
-verify: check format test sast
+verify: fastcheck format test sast
 
 .PHONY: verify-extended
-verify-extended: check-generate check format test sast-report
+verify-extended: check-generate fastcheck format unittests new-test-integration sast-report


### PR DESCRIPTION
**What this PR does / why we need it**:
Reduce load make targets:
- `verify` and `verifyExtended` run `check` targets which includes `sast-report`  => replace with `fastcheck` to avoid duplicate execution of sast checks
- `verifyExtended`  runs `test` target which runs partial integration-test => replace with `unittests` and `new-test-integration` targets as integrations test run separately in CI/CD.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
