### PR TITLE
Remove OWNERID column for DNSEntry; remove other ownerId related code

### DIFF
--- a/charts/external-dns-management/templates/crds.yaml
+++ b/charts/external-dns-management/templates/crds.yaml
@@ -47,10 +47,6 @@ spec:
       jsonPath: .status.targets
       name: TARGETS
       type: string
-    - description: owner id used to tag entries in external DNS system
-      jsonPath: .spec.ownerId
-      name: OWNERID
-      type: string
     - description: time to live
       jsonPath: .status.ttl
       name: TTL

--- a/pkg/apis/dns/crds/dns.gardener.cloud_dnsentries.yaml
+++ b/pkg/apis/dns/crds/dns.gardener.cloud_dnsentries.yaml
@@ -41,10 +41,6 @@ spec:
       jsonPath: .status.targets
       name: TARGETS
       type: string
-    - description: owner id used to tag entries in external DNS system
-      jsonPath: .spec.ownerId
-      name: OWNERID
-      type: string
     - description: time to live
       jsonPath: .status.ttl
       name: TTL

--- a/pkg/apis/dns/crds/zz_generated_crds.go
+++ b/pkg/apis/dns/crds/zz_generated_crds.go
@@ -168,10 +168,6 @@ spec:
       jsonPath: .status.targets
       name: TARGETS
       type: string
-    - description: owner id used to tag entries in external DNS system
-      jsonPath: .spec.ownerId
-      name: OWNERID
-      type: string
     - description: time to live
       jsonPath: .status.ttl
       name: TTL

--- a/pkg/apis/dns/v1alpha1/dnsentry.go
+++ b/pkg/apis/dns/v1alpha1/dnsentry.go
@@ -28,7 +28,6 @@ type DNSEntryList struct {
 // +kubebuilder:printcolumn:name=STATUS,JSONPath=".status.state",type=string,description="entry status"
 // +kubebuilder:printcolumn:name=AGE,JSONPath=".metadata.creationTimestamp",type=date,description="entry creation timestamp"
 // +kubebuilder:printcolumn:name=TARGETS,JSONPath=".status.targets",type=string,description="effective targets"
-// +kubebuilder:printcolumn:name=OWNERID,JSONPath=".spec.ownerId",type=string,description="owner id used to tag entries in external DNS system"
 // +kubebuilder:printcolumn:name=TTL,JSONPath=".status.ttl",type=integer,priority=2000,description="time to live"
 // +kubebuilder:printcolumn:name=ZONE,JSONPath=".status.zone",type=string,priority=2000,description="zone id"
 // +kubebuilder:printcolumn:name=POLICY_TYPE,JSONPath=".status.routingPolicy.type",type=string,priority=2000,description="routing policy type"

--- a/pkg/dns/source/controller.go
+++ b/pkg/dns/source/controller.go
@@ -34,7 +34,6 @@ const (
 	PERIOD_ANNOTATION         = dns.ANNOTATION_GROUP + "/cname-lookup-interval"
 	ROUTING_POLICY_ANNOTATION = dns.ANNOTATION_GROUP + "/routing-policy"
 	CLASS_ANNOTATION          = dns.CLASS_ANNOTATION
-	OWNER_ID_ANNOTATION       = dns.ANNOTATION_GROUP + "/owner-id"
 	// RESOLVE_TARGETS_TO_ADDRS_ANNOTATION is the annotation key for source objects to set the `.spec.resolveTargetsToAddresses` in the DNSEntry.
 	RESOLVE_TARGETS_TO_ADDRS_ANNOTATION = dns.ANNOTATION_GROUP + "/resolve-targets-to-addresses"
 )

--- a/pkg/dns/source/dnsinfo.go
+++ b/pkg/dns/source/dnsinfo.go
@@ -81,12 +81,6 @@ func (this *sourceReconciler) getDNSInfo(logger logger.LogContext, obj resources
 			}
 		}
 	}
-	if info.OwnerId == nil {
-		a := annos[OWNER_ID_ANNOTATION]
-		if a != "" {
-			info.OwnerId = &a
-		}
-	}
 	if info.Interval == nil {
 		a := annos[PERIOD_ANNOTATION]
 		if a != "" {

--- a/pkg/dns/source/interface.go
+++ b/pkg/dns/source/interface.go
@@ -19,7 +19,6 @@ import (
 
 type DNSInfo struct {
 	Names                     dns.DNSNameSet
-	OwnerId                   *string
 	TTL                       *int64
 	Interval                  *int64
 	Targets                   utils.StringSet

--- a/pkg/dnsman2/apis/dns/crd-dns.gardener.cloud_dnsentries.yaml
+++ b/pkg/dnsman2/apis/dns/crd-dns.gardener.cloud_dnsentries.yaml
@@ -41,10 +41,6 @@ spec:
       jsonPath: .status.targets
       name: TARGETS
       type: string
-    - description: owner id used to tag entries in external DNS system
-      jsonPath: .spec.ownerId
-      name: OWNERID
-      type: string
     - description: time to live
       jsonPath: .status.ttl
       name: TTL


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove OWNERID column for DNSEntry; remove other ownerId related code

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Follow-up of #446 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
