### PR TITLE
chore: Add make target check-imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,15 @@ clean:
 	@rm -rf /pkg/client/dns
 
 .PHONY: check
-check: sast-report fastcheck
+check: sast-report fastcheck check-imports
 
 .PHONY: check-generate
 check-generate:
 	@bash $(GARDENER_HACK_DIR)/check-generate.sh $(REPO_ROOT)
+
+.PHONY: check-imports
+check-imports: $(IMPORT_BOSS)
+	$(IMPORT_BOSS) ./cmd/... ./pkg/... ./test/...
 
 .PHONY: fastcheck
 fastcheck: format $(GOIMPORTS) $(GOLANGCI_LINT)

--- a/cmd/compound/.import-restrictions
+++ b/cmd/compound/.import-restrictions
@@ -1,0 +1,7 @@
+rules:
+  - selectorRegexp: github[.]com/gardener/external-dns-management
+    allowedPrefixes:
+      - ''
+    forbiddenPrefixes:
+      - github.com/gardener/external-dns-management/cmd/dnsman2
+      - github.com/gardener/external-dns-management/pkg/dnsman2

--- a/cmd/dnsman2/.import-restrictions
+++ b/cmd/dnsman2/.import-restrictions
@@ -1,0 +1,9 @@
+rules:
+  - selectorRegexp: github[.]com/gardener/external-dns-management
+    allowedPrefixes:
+      - github.com/gardener/external-dns-management/cmd/dnsman2
+      - github.com/gardener/external-dns-management/pkg/apis
+      - github.com/gardener/external-dns-management/pkg/dnsman2
+  - selectorRegexp: github[.]com/gardener/controller-manager-library
+    forbiddenPrefixes:
+      - ''

--- a/pkg/apis/.import-restrictions
+++ b/pkg/apis/.import-restrictions
@@ -1,0 +1,8 @@
+rules:
+  - selectorRegexp: github[.]com/gardener/external-dns-management
+    allowedPrefixes:
+      - github.com/gardener/external-dns-management/pkg/apis
+# TODO(marc1404): controller-manager-library references should be removed
+#  - selectorRegexp: github[.]com/gardener/controller-manager-library
+#    forbiddenPrefixes:
+#      - ''

--- a/pkg/client/.import-restrictions
+++ b/pkg/client/.import-restrictions
@@ -1,0 +1,7 @@
+rules:
+  - selectorRegexp: github[.]com/gardener/external-dns-management
+    allowedPrefixes:
+      - ''
+    forbiddenPrefixes:
+      - github.com/gardener/external-dns-management/cmd/dnsman2
+      - github.com/gardener/external-dns-management/pkg/dnsman2

--- a/pkg/controller/.import-restrictions
+++ b/pkg/controller/.import-restrictions
@@ -1,0 +1,7 @@
+rules:
+  - selectorRegexp: github[.]com/gardener/external-dns-management
+    allowedPrefixes:
+      - ''
+    forbiddenPrefixes:
+      - github.com/gardener/external-dns-management/cmd/dnsman2
+      - github.com/gardener/external-dns-management/pkg/dnsman2

--- a/pkg/dns/.import-restrictions
+++ b/pkg/dns/.import-restrictions
@@ -1,0 +1,7 @@
+rules:
+  - selectorRegexp: github[.]com/gardener/external-dns-management
+    allowedPrefixes:
+      - ''
+    forbiddenPrefixes:
+      - github.com/gardener/external-dns-management/cmd/dnsman2
+      - github.com/gardener/external-dns-management/pkg/dnsman2

--- a/pkg/dnsman2/.import-restrictions
+++ b/pkg/dnsman2/.import-restrictions
@@ -1,0 +1,9 @@
+rules:
+  - selectorRegexp: github[.]com/gardener/external-dns-management
+    allowedPrefixes:
+      - github.com/gardener/external-dns-management/pkg/apis
+      - github.com/gardener/external-dns-management/pkg/dns
+      - github.com/gardener/external-dns-management/pkg/dnsman2
+  - selectorRegexp: github[.]com/gardener/controller-manager-library
+    forbiddenPrefixes:
+      - ''

--- a/pkg/server/.import-restrictions
+++ b/pkg/server/.import-restrictions
@@ -1,0 +1,7 @@
+rules:
+  - selectorRegexp: github[.]com/gardener/external-dns-management
+    allowedPrefixes:
+      - ''
+    forbiddenPrefixes:
+      - github.com/gardener/external-dns-management/cmd/dnsman2
+      - github.com/gardener/external-dns-management/pkg/dnsman2


### PR DESCRIPTION
/kind enhancement
/kind task

**What this PR does / why we need it**:

This PR:
- Adds a new Make target `check-imports` that runs [import-boss](https://pkg.go.dev/k8s.io/gengo/examples/import-boss) to enforce rules set by `.import-restrictions` files.
  - It's integrated into Make `check`.
- It adds `.import-restrictions` to top-level folders in `cmd` and `pkg`.

**Which issue(s) this PR fixes**:
Fixes #451

**Special notes for your reviewer**:

/cc @MartinWeindel 

In comparison to https://github.com/gardener/cert-management/pull/494, I decided against adding `.import-restriction` files to `test/` (for now).

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
