### PR TITLE
Clean up google-clouddns handler initialisation

### DIFF
--- a/pkg/controller/provider/google/handler_test.go
+++ b/pkg/controller/provider/google/handler_test.go
@@ -50,7 +50,7 @@ var _ = Describe("ValidateServiceAccountJSON", func() {
 
 	for _, tt := range tests {
 		It(tt.name, func() {
-			err := validateServiceAccountJSON([]byte(tt.data))
+			_, err := validateServiceAccountJSON([]byte(tt.data))
 			if tt.wantErr {
 				Expect(err).To(HaveOccurred())
 			} else {


### PR DESCRIPTION
**What this PR does / why we need it**:
The code for the google-clouddns handler is cleaned up from commented out code.
Additionally, the method `google. JWTConfigFromJSON` is used, as it is sufficient.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
