### PR TITLE
Fix flaky lookup processor test

### DIFF
--- a/pkg/dns/provider/lookupprocessor_test.go
+++ b/pkg/dns/provider/lookupprocessor_test.go
@@ -333,7 +333,7 @@ var _ = ginkgov2.Describe("Lookup processor", func() {
 		stat3 := metrics.lookups[nameE3]
 		metrics.lock.Unlock()
 		expectCountBetween("stat3.count-count3a", stat3.count-count3a, -1, 1)
-		Expect(stat3.targetCount).To(Equal(count3a * 3))
+		Expect(stat3.targetCount).To(Equal(stat3.count * 3))
 		expectCountBetween("count not-existing-host", stat3.errorCount, 10, 30)
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
The "Lookup processor" test fails sometimes in the CI/CD pipeline with 

```
 [FAILED] [0.053 seconds]
Lookup processor [It] performs multiple lookup jobs and enqueues keys on lookup changes
/tmp/build/86a4261d/git-gardener.external-dns-management-master/pkg/dns/provider/lookupprocessor_test.go:296

  [FAILED] Expected
      <int>: 84
  to equal
      <int>: 87
  In [It] at: /tmp/build/86a4261d/git-gardener.external-dns-management-master/pkg/dns/provider/lookupprocessor_test.go:336
```

This change provides a fix.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
