### PR TITLE
Remove tests from make target `verify-extended`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,4 +138,4 @@ sast-report: $(GOSEC)
 verify: fastcheck format sast
 
 .PHONY: verify-extended
-verify-extended: check-generate fastcheck format unittests new-test-integration sast-report
+verify-extended: check-generate fastcheck format sast-report


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove tests from make target `verify-extended` as they are executed in the prow jobs `pull-external-dns-management-unit` and `pull-external-dns-management-integration`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
