### PR TITLE
Ensure ignored entries are not deleted on cleanup

### DIFF
--- a/pkg/dns/provider/entry.go
+++ b/pkg/dns/provider/entry.go
@@ -735,12 +735,13 @@ func normalizeTargets(logger logger.LogContext, object *dnsutils.DNSEntryObject,
 ///////////////////////////////////////////////////////////////////////////////
 
 type Entry struct {
-	lock       *dnsutils.TryLock
-	key        string
-	createdAt  time.Time
-	modified   bool
-	activezone dns.ZoneID
-	state      *state
+	lock               *dnsutils.TryLock
+	key                string
+	createdAt          time.Time
+	modified           bool
+	activezone         dns.ZoneID
+	state              *state
+	ignoredForDeletion bool
 
 	*EntryVersion
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
If a `DNSEntry` is ignored for deletion by the annotation `dns.gardener.cloud/ignore=full` or `dns.gardener.cloud/target-hard-ignore=true`, the DNS record should not be deleted.
Unfortunately, there is a second execution path if multiple entries are ignored which was not covered by the integration test. In this case there may be multiple zone reconciliations and the `deleted` reconcile may happen for an entry before it is cleaned up from the internal state.
This PR provides a fix and extends the integration test.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Ensure ignored entries are not deleted on cleanup in an edge case.
```
