### PR TITLE
Fix the `linux/arm64` image build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,12 +56,6 @@ fastcheck: format $(GOIMPORTS) $(GOLANGCI_LINT)
 format: $(GOIMPORTS) $(GOIMPORTSREVISER)
 	@bash $(GARDENER_HACK_DIR)/format.sh ./cmd ./pkg ./test
 
-.PHONY: build
-build:
-	@CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $(EXECUTABLE) \
-	    -ldflags "-X main.Version=$(VERSION)-$(shell git rev-parse HEAD)"\
-	    ./cmd/compound
-
 .PHONY: build-local
 build-local:
 	@CGO_ENABLED=1 go build -o $(EXECUTABLE) \


### PR DESCRIPTION
**What this PR does / why we need it**:
The image for `linux/arm64` wrongly contains a `linux/amd64` executable.
This PR provides a fix.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix the `linux/arm64` image build.
```
