### PR TITLE
Fix panic on startup if `DNSEntry` is annotated to be ignored

### DIFF
--- a/pkg/dns/provider/state_entry.go
+++ b/pkg/dns/provider/state_entry.go
@@ -258,7 +258,9 @@ func (this *state) HandleUpdateEntry(logger logger.LogContext, op string, object
 	}
 
 	if ignored, ignoredForDeletion, annotation := ignoredByAnnotation(object); ignored {
-		old.ignoredForDeletion = ignoredForDeletion
+		if old != nil {
+			old.ignoredForDeletion = ignoredForDeletion
+		}
 		var err error
 		if !object.IsDeleting() {
 			_, err = object.ModifyStatus(func(data resources.ObjectData) (bool, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix panic on controller startup if a `DNSEntry` is annotated with `dns.gardener.cloud/target-hard-ignore=true`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This bug was introduced with #505 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix panic on controller startup if a `DNSEntry` is annotated with `dns.gardener.cloud/target-hard-ignore=true`
```
