### PR TITLE
Add standard validation for `DNSProvider` in CRD

### DIFF
--- a/charts/external-dns-management/templates/crds.yaml
+++ b/charts/external-dns-management/templates/crds.yaml
@@ -426,6 +426,7 @@ spec:
               defaultTTL:
                 description: default TTL used for DNS entries if not specified explicitly
                 format: int64
+                maximum: 8640000
                 minimum: 1
                 type: integer
               domains:

--- a/pkg/apis/dns/crds/dns.gardener.cloud_dnsproviders.yaml
+++ b/pkg/apis/dns/crds/dns.gardener.cloud_dnsproviders.yaml
@@ -67,6 +67,7 @@ spec:
               defaultTTL:
                 description: default TTL used for DNS entries if not specified explicitly
                 format: int64
+                maximum: 8640000
                 minimum: 1
                 type: integer
               domains:

--- a/pkg/apis/dns/crds/zz_generated_crds.go
+++ b/pkg/apis/dns/crds/zz_generated_crds.go
@@ -559,6 +559,7 @@ spec:
               defaultTTL:
                 description: default TTL used for DNS entries if not specified explicitly
                 format: int64
+                maximum: 8640000
                 minimum: 1
                 type: integer
               domains:

--- a/pkg/apis/dns/v1alpha1/dnsprovider.go
+++ b/pkg/apis/dns/v1alpha1/dnsprovider.go
@@ -63,6 +63,7 @@ type DNSProviderSpec struct {
 	Zones *DNSSelection `json:"zones,omitempty"`
 	// default TTL used for DNS entries if not specified explicitly
 	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=8640000
 	// +optional
 	DefaultTTL *int64 `json:"defaultTTL,omitempty"`
 	// rate limit for create/update operations on DNSEntries assigned to this provider

--- a/pkg/dnsman2/apis/dns/crd-dns.gardener.cloud_dnsproviders.yaml
+++ b/pkg/dnsman2/apis/dns/crd-dns.gardener.cloud_dnsproviders.yaml
@@ -67,6 +67,7 @@ spec:
               defaultTTL:
                 description: default TTL used for DNS entries if not specified explicitly
                 format: int64
+                maximum: 8640000
                 minimum: 1
                 type: integer
               domains:


### PR DESCRIPTION
**What this PR does / why we need it**:
Add standard Open-API validations for `DNSProvider` `spec` section in CRD

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Part of #556 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add validation for `DNSProvider` field `.spec.type` to restrict it to known types. Additional standard validations have been added for fields like `.spec.defaultTTL`, `domains.include`, `domains.exclude`, `zones.include`, `zones.exclude`.
```
