### PR TITLE
chore: Deprecate DNSEntry reference

### DIFF
--- a/charts/external-dns-management/templates/crds.yaml
+++ b/charts/external-dns-management/templates/crds.yaml
@@ -114,7 +114,9 @@ spec:
                   removed in a future release.'
                 type: string
               reference:
-                description: reference to base entry used to inherit attributes from
+                description: |-
+                  Deprecated: This field will be removed in a future release.
+                  Until removed, it references a base entry used to inherit attributes from.
                 properties:
                   name:
                     description: name of the referenced DNSEntry object

--- a/pkg/apis/dns/crds/dns.gardener.cloud_dnsentries.yaml
+++ b/pkg/apis/dns/crds/dns.gardener.cloud_dnsentries.yaml
@@ -108,7 +108,9 @@ spec:
                   removed in a future release.'
                 type: string
               reference:
-                description: reference to base entry used to inherit attributes from
+                description: |-
+                  Deprecated: This field will be removed in a future release.
+                  Until removed, it references a base entry used to inherit attributes from.
                 properties:
                   name:
                     description: name of the referenced DNSEntry object

--- a/pkg/apis/dns/crds/zz_generated_crds.go
+++ b/pkg/apis/dns/crds/zz_generated_crds.go
@@ -235,7 +235,9 @@ spec:
                   removed in a future release.'
                 type: string
               reference:
-                description: reference to base entry used to inherit attributes from
+                description: |-
+                  Deprecated: This field will be removed in a future release.
+                  Until removed, it references a base entry used to inherit attributes from.
                 properties:
                   name:
                     description: name of the referenced DNSEntry object

--- a/pkg/apis/dns/v1alpha1/dnsentry.go
+++ b/pkg/apis/dns/v1alpha1/dnsentry.go
@@ -48,7 +48,9 @@ type DNSEntry struct {
 type DNSEntrySpec struct {
 	// full qualified domain name
 	DNSName string `json:"dnsName"`
-	// reference to base entry used to inherit attributes from
+	// Deprecated: This field will be removed in a future release.
+	// Until removed, it references a base entry used to inherit attributes from.
+	// +kubebuilder:validation:Deprecated
 	// +optional
 	Reference *EntryReference `json:"reference,omitempty"`
 	// Deprecated: This field is no longer used and will be removed in a future release.

--- a/pkg/dnsman2/apis/dns/crd-dns.gardener.cloud_dnsentries.yaml
+++ b/pkg/dnsman2/apis/dns/crd-dns.gardener.cloud_dnsentries.yaml
@@ -108,7 +108,9 @@ spec:
                   removed in a future release.'
                 type: string
               reference:
-                description: reference to base entry used to inherit attributes from
+                description: |-
+                  Deprecated: This field will be removed in a future release.
+                  Until removed, it references a base entry used to inherit attributes from.
                 properties:
                   name:
                     description: name of the referenced DNSEntry object


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR deprecates the field `DNSEntry.spec.reference`. It will be removed with a future release.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @MartinWeindel 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Deprecated `DNSEntry.spec.reference`. The field will be removed with a future release.
```
