### PR TITLE
[Controller-Runtime-Rewrite] Ensure no parallel updates on same domain name

### DIFF
--- a/pkg/dnsman2/dns/state/dnsnamelocking.go
+++ b/pkg/dnsman2/dns/state/dnsnamelocking.go
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package state
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type dnsNameLocking struct {
+	lock        sync.Mutex
+	lockedNames sets.Set[string]
+}
+
+// newDNSNameLocking creates a new instance of dnsNameLocking.
+func newDNSNameLocking() *dnsNameLocking {
+	return &dnsNameLocking{
+		lockedNames: sets.New[string](),
+	}
+}
+
+// Lock locks the given DNS names. It returns true if all names were successfully locked,
+// If true, they must be unlocked later using Unlock.
+func (d *dnsNameLocking) Lock(names ...string) bool {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	for _, name := range names {
+		if d.lockedNames.Has(name) {
+			return false // name is already locked
+		}
+	}
+
+	for _, name := range names {
+		d.lockedNames.Insert(name)
+	}
+	return true // Successfully locked all names
+}
+
+// Unlock unlocks the given DNS names.
+func (d *dnsNameLocking) Unlock(names ...string) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	for _, name := range names {
+		d.lockedNames.Delete(name)
+	}
+}

--- a/pkg/dnsman2/dns/state/state.go
+++ b/pkg/dnsman2/dns/state/state.go
@@ -32,8 +32,9 @@ func GetState() *State {
 	}
 
 	state = &State{
-		providers: newProviderMap(),
-		accounts:  provider.NewAccountMap(),
+		providers:      newProviderMap(),
+		accounts:       provider.NewAccountMap(),
+		dnsNameLocking: newDNSNameLocking(),
 	}
 	if instance.CompareAndSwap(nil, state) {
 		return state
@@ -46,6 +47,8 @@ type State struct {
 	providers providerMap
 	accounts  *provider.AccountMap
 	factory   atomic.Pointer[provider.DNSHandlerFactory]
+
+	dnsNameLocking *dnsNameLocking
 }
 
 type providerMap struct {
@@ -136,6 +139,11 @@ func (s *State) GetDNSQueryHandler(ctx context.Context, zoneID dns.ZoneID) (DNSQ
 		return nil, err
 	}
 	return newDNSCachesQueryHandler(dnscaches), nil
+}
+
+// GetDNSNameLocking returns the dnsNameLocking instance used for managing DNS name locks.
+func (s *State) GetDNSNameLocking() *dnsNameLocking {
+	return s.dnsNameLocking
 }
 
 // ClearState clears the singleton state instance (for testing purposes).


### PR DESCRIPTION
**What this PR does / why we need it**:
A reconciliation of a `DNSEntry` can perform changes on DNS records on the DNS server.
To avoid concurrency issues in edge cases (e.g. when updating multiple entries for the same domain name with routing policies), it is now ensured that such reconciliations are not performed in parallel.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
