### PR TITLE
feat: Validate `DNSEntry` data fields

### DIFF
--- a/charts/external-dns-management/templates/crds.yaml
+++ b/charts/external-dns-management/templates/crds.yaml
@@ -105,6 +105,7 @@ spec:
                   lookup interval for CNAMEs that must be resolved to IP addresses.
                   Only used if `resolveTargetsToAddresses` is set to true or targets consists of multiple domain names.
                 format: int64
+                minimum: 30
                 type: integer
               dnsName:
                 description: full qualified domain name
@@ -147,6 +148,12 @@ spec:
                   type:
                     description: Policy is the policy type. Allowed values are provider
                       dependent, e.g. `weighted`
+                    enum:
+                    - weighted
+                    - latency
+                    - geolocation
+                    - ip-based
+                    - failover
                     type: string
                 required:
                 - parameters
@@ -157,16 +164,22 @@ spec:
                 description: target records (CNAME or A records), either text or targets
                   must be specified
                 items:
+                  minLength: 1
                   type: string
+                maxItems: 100
                 type: array
               text:
                 description: text records, either text or targets must be specified
                 items:
+                  minLength: 1
                   type: string
+                maxItems: 100
                 type: array
               ttl:
                 description: time to live for records in external DNS system
                 format: int64
+                maximum: 8640000
+                minimum: 1
                 type: integer
             required:
             - dnsName
@@ -212,6 +225,12 @@ spec:
                   type:
                     description: Policy is the policy type. Allowed values are provider
                       dependent, e.g. `weighted`
+                    enum:
+                    - weighted
+                    - latency
+                    - geolocation
+                    - ip-based
+                    - failover
                     type: string
                 required:
                 - parameters

--- a/pkg/apis/dns/crds/dns.gardener.cloud_dnsentries.yaml
+++ b/pkg/apis/dns/crds/dns.gardener.cloud_dnsentries.yaml
@@ -99,6 +99,7 @@ spec:
                   lookup interval for CNAMEs that must be resolved to IP addresses.
                   Only used if `resolveTargetsToAddresses` is set to true or targets consists of multiple domain names.
                 format: int64
+                minimum: 30
                 type: integer
               dnsName:
                 description: full qualified domain name
@@ -141,6 +142,12 @@ spec:
                   type:
                     description: Policy is the policy type. Allowed values are provider
                       dependent, e.g. `weighted`
+                    enum:
+                    - weighted
+                    - latency
+                    - geolocation
+                    - ip-based
+                    - failover
                     type: string
                 required:
                 - parameters
@@ -151,16 +158,22 @@ spec:
                 description: target records (CNAME or A records), either text or targets
                   must be specified
                 items:
+                  minLength: 1
                   type: string
+                maxItems: 100
                 type: array
               text:
                 description: text records, either text or targets must be specified
                 items:
+                  minLength: 1
                   type: string
+                maxItems: 100
                 type: array
               ttl:
                 description: time to live for records in external DNS system
                 format: int64
+                maximum: 8640000
+                minimum: 1
                 type: integer
             required:
             - dnsName
@@ -206,6 +219,12 @@ spec:
                   type:
                     description: Policy is the policy type. Allowed values are provider
                       dependent, e.g. `weighted`
+                    enum:
+                    - weighted
+                    - latency
+                    - geolocation
+                    - ip-based
+                    - failover
                     type: string
                 required:
                 - parameters

--- a/pkg/apis/dns/crds/zz_generated_crds.go
+++ b/pkg/apis/dns/crds/zz_generated_crds.go
@@ -226,6 +226,7 @@ spec:
                   lookup interval for CNAMEs that must be resolved to IP addresses.
                   Only used if ` + "`" + `resolveTargetsToAddresses` + "`" + ` is set to true or targets consists of multiple domain names.
                 format: int64
+                minimum: 30
                 type: integer
               dnsName:
                 description: full qualified domain name
@@ -268,6 +269,12 @@ spec:
                   type:
                     description: Policy is the policy type. Allowed values are provider
                       dependent, e.g. ` + "`" + `weighted` + "`" + `
+                    enum:
+                    - weighted
+                    - latency
+                    - geolocation
+                    - ip-based
+                    - failover
                     type: string
                 required:
                 - parameters
@@ -278,16 +285,22 @@ spec:
                 description: target records (CNAME or A records), either text or targets
                   must be specified
                 items:
+                  minLength: 1
                   type: string
+                maxItems: 100
                 type: array
               text:
                 description: text records, either text or targets must be specified
                 items:
+                  minLength: 1
                   type: string
+                maxItems: 100
                 type: array
               ttl:
                 description: time to live for records in external DNS system
                 format: int64
+                maximum: 8640000
+                minimum: 1
                 type: integer
             required:
             - dnsName
@@ -333,6 +346,12 @@ spec:
                   type:
                     description: Policy is the policy type. Allowed values are provider
                       dependent, e.g. ` + "`" + `weighted` + "`" + `
+                    enum:
+                    - weighted
+                    - latency
+                    - geolocation
+                    - ip-based
+                    - failover
                     type: string
                 required:
                 - parameters

--- a/pkg/apis/dns/v1alpha1/dnsentry.go
+++ b/pkg/apis/dns/v1alpha1/dnsentry.go
@@ -65,6 +65,7 @@ type DNSEntrySpec struct {
 	// lookup interval for CNAMEs that must be resolved to IP addresses.
 	// Only used if `resolveTargetsToAddresses` is set to true or targets consists of multiple domain names.
 	// +kubebuilder:validation:Minimum=30
+	// +kubebuilder:validation:Maximum=8640000
 	// +optional
 	CNameLookupInterval *int64 `json:"cnameLookupInterval,omitempty"`
 	// enables translation of a target domain name in the resolved IPv4 and IPv6 addresses.

--- a/pkg/apis/dns/v1alpha1/dnsentry.go
+++ b/pkg/apis/dns/v1alpha1/dnsentry.go
@@ -58,10 +58,13 @@ type DNSEntrySpec struct {
 	// +optional
 	OwnerId *string `json:"ownerId,omitempty"`
 	// time to live for records in external DNS system
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=8640000
 	// +optional
 	TTL *int64 `json:"ttl,omitempty"`
 	// lookup interval for CNAMEs that must be resolved to IP addresses.
 	// Only used if `resolveTargetsToAddresses` is set to true or targets consists of multiple domain names.
+	// +kubebuilder:validation:Minimum=30
 	// +optional
 	CNameLookupInterval *int64 `json:"cnameLookupInterval,omitempty"`
 	// enables translation of a target domain name in the resolved IPv4 and IPv6 addresses.
@@ -70,9 +73,13 @@ type DNSEntrySpec struct {
 	// +optional
 	ResolveTargetsToAddresses *bool `json:"resolveTargetsToAddresses,omitempty"`
 	// text records, either text or targets must be specified
+	// +kubebuilder:validation:items:MinLength=1
+	// +kubebuilder:validation:MaxItems=100
 	// +optional
 	Text []string `json:"text,omitempty"`
 	// target records (CNAME or A records), either text or targets must be specified
+	// +kubebuilder:validation:items:MinLength=1
+	// +kubebuilder:validation:MaxItems=100
 	// +optional
 	Targets []string `json:"targets,omitempty"`
 	// optional routing policy
@@ -128,6 +135,7 @@ type EntryReference struct {
 
 type RoutingPolicy struct {
 	// Policy is the policy type. Allowed values are provider dependent, e.g. `weighted`
+	// +kubebuilder:validation:Enum=weighted;latency;geolocation;ip-based;failover
 	Type string `json:"type"`
 	// SetIdentifier is the identifier of the record set
 	SetIdentifier string `json:"setIdentifier"`

--- a/pkg/dnsman2/apis/dns/crd-dns.gardener.cloud_dnsentries.yaml
+++ b/pkg/dnsman2/apis/dns/crd-dns.gardener.cloud_dnsentries.yaml
@@ -99,6 +99,7 @@ spec:
                   lookup interval for CNAMEs that must be resolved to IP addresses.
                   Only used if `resolveTargetsToAddresses` is set to true or targets consists of multiple domain names.
                 format: int64
+                minimum: 30
                 type: integer
               dnsName:
                 description: full qualified domain name
@@ -141,6 +142,12 @@ spec:
                   type:
                     description: Policy is the policy type. Allowed values are provider
                       dependent, e.g. `weighted`
+                    enum:
+                    - weighted
+                    - latency
+                    - geolocation
+                    - ip-based
+                    - failover
                     type: string
                 required:
                 - parameters
@@ -151,16 +158,22 @@ spec:
                 description: target records (CNAME or A records), either text or targets
                   must be specified
                 items:
+                  minLength: 1
                   type: string
+                maxItems: 100
                 type: array
               text:
                 description: text records, either text or targets must be specified
                 items:
+                  minLength: 1
                   type: string
+                maxItems: 100
                 type: array
               ttl:
                 description: time to live for records in external DNS system
                 format: int64
+                maximum: 8640000
+                minimum: 1
                 type: integer
             required:
             - dnsName
@@ -206,6 +219,12 @@ spec:
                   type:
                     description: Policy is the policy type. Allowed values are provider
                       dependent, e.g. `weighted`
+                    enum:
+                    - weighted
+                    - latency
+                    - geolocation
+                    - ip-based
+                    - failover
                     type: string
                 required:
                 - parameters

--- a/pkg/dnsman2/controller/dnsentry/reconciler_reconcile.go
+++ b/pkg/dnsman2/controller/dnsentry/reconciler_reconcile.go
@@ -71,7 +71,7 @@ func (r *entryReconciliation) reconcile() common.ReconcileResult {
 		return *res
 	}
 
-	if err := validateDNSEntry(r.EntryContext.Entry); err != nil {
+	if err := validateDNSEntry(r.Entry); err != nil {
 		return common.ReconcileResult{Err: err}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR extends the validation for `DNSEntry` data fields using kubebuilder validation rules and implements validation in the `dnsman2` code branch.

**Which issue(s) this PR fixes**:

Fixes #548

**Special notes for your reviewer**:

Runtime validation of `DNSEntry` was already present in the legacy controller implementation:
https://github.com/gardener/external-dns-management/blob/7d1ce2a85cb8df1b63983fab1b149a40bc68f6e2/pkg/dns/provider/entry.go#L284-L357

/cc @MartinWeindel 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Extended validation of `DNSEntry` data fields.
```
