### PR TITLE
increase powerdns apiKey max lenght

### DIFF
--- a/pkg/controller/provider/powerdns/factory.go
+++ b/pkg/controller/provider/powerdns/factory.go
@@ -38,7 +38,7 @@ func newAdapter() provider.DNSHandlerAdapter {
 	checks.Add(provider.RequiredProperty("Server", "server").
 		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.URLValidator("https", "http"), provider.MaxLengthValidator(256)))
 	checks.Add(provider.RequiredProperty("ApiKey", "apiKey").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(8192)).
+		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(8192)). // PowerDNS does not impose a maximum length for API keys. Therefore, the typical maximum length of HTTP headers is used.
 		HideValue())
 	checks.Add(provider.OptionalProperty("VirtualHost", "virtualHost").
 		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(128)))

--- a/pkg/controller/provider/powerdns/factory.go
+++ b/pkg/controller/provider/powerdns/factory.go
@@ -38,7 +38,7 @@ func newAdapter() provider.DNSHandlerAdapter {
 	checks.Add(provider.RequiredProperty("Server", "server").
 		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.URLValidator("https", "http"), provider.MaxLengthValidator(256)))
 	checks.Add(provider.RequiredProperty("ApiKey", "apiKey").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(1024)).
+		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(8192)).
 		HideValue())
 	checks.Add(provider.OptionalProperty("VirtualHost", "virtualHost").
 		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(128)))

--- a/pkg/controller/provider/powerdns/factory.go
+++ b/pkg/controller/provider/powerdns/factory.go
@@ -38,7 +38,7 @@ func newAdapter() provider.DNSHandlerAdapter {
 	checks.Add(provider.RequiredProperty("Server", "server").
 		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.URLValidator("https", "http"), provider.MaxLengthValidator(256)))
 	checks.Add(provider.RequiredProperty("ApiKey", "apiKey").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(128)).
+		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(1024)).
 		HideValue())
 	checks.Add(provider.OptionalProperty("VirtualHost", "virtualHost").
 		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(128)))


### PR DESCRIPTION
**How to categorize this PR?**
/kind bug

**What this PR does / why we need it**:
Increases the apiKey max length for powerdns

**Which issue(s) this PR fixes**:
Fixes #575

**Special notes for your reviewer**:

**Release note**:

<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Increased maximum length of PowerDNS provider `apiKey` to `8192`.
```
