### PR TITLE
fix: Conditionally required AWS provider secret values

### DIFF
--- a/pkg/controller/provider/aws/factory.go
+++ b/pkg/controller/provider/aws/factory.go
@@ -45,15 +45,18 @@ var regionRegex = regexp.MustCompile("^[a-z0-9-]*$") // empty string is explicit
 
 func newAdapter() provider.DNSHandlerAdapter {
 	checks := provider.NewDNSHandlerAdapterChecks()
-	checks.Add(provider.RequiredProperty("AWS_ACCESS_KEY_ID", "accessKeyID").
+	checks.Add(provider.OptionalProperty("AWS_ACCESS_KEY_ID", "accessKeyID").
+		RequiredIfUnset([]string{"AWS_USE_CREDENTIALS_CHAIN"}).
 		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericValidator, provider.MaxLengthValidator(128)))
-	checks.Add(provider.RequiredProperty("AWS_SECRET_ACCESS_KEY", "secretAccessKey").
+	checks.Add(provider.OptionalProperty("AWS_SECRET_ACCESS_KEY", "secretAccessKey").
+		RequiredIfUnset([]string{"AWS_USE_CREDENTIALS_CHAIN"}).
 		Validators(provider.NoTrailingWhitespaceValidator, provider.MaxLengthValidator(128)).
 		HideValue())
 	checks.Add(provider.OptionalProperty("AWS_REGION", "region").
 		Validators(provider.NoTrailingWhitespaceValidator, provider.MaxLengthValidator(32), provider.RegExValidator(regionRegex)).
 		AllowEmptyValue())
 	checks.Add(provider.OptionalProperty("AWS_USE_CREDENTIALS_CHAIN").
+		RequiredIfUnset([]string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"}).
 		Validators(provider.NoTrailingWhitespaceValidator, provider.BoolValidator))
 	checks.Add(provider.OptionalProperty("AWS_SESSION_TOKEN").
 		Validators(provider.MaxLengthValidator(512)).

--- a/pkg/dns/provider/dnshandleradapterchecks_test.go
+++ b/pkg/dns/provider/dnshandleradapterchecks_test.go
@@ -155,5 +155,44 @@ var _ = g.Describe("DNSHandlerAdapterChecks", func() {
 			Expect(err).ToNot(Succeed())
 			Expect(err.Error()).To(ContainSubstring("invalid secret: (hidden)"))
 		})
+
+		g.Context("RequiredIfUnset", func() {
+			g.It("should require a property if the depending property is not set", func() {
+				checks.Add(OptionalProperty("optprop").
+					RequiredIfUnset([]string{"baz"}))
+				props["foo"] = "good"
+				err := checks.ValidateProperties("test", props)
+				Expect(err).ToNot(Succeed())
+				Expect(err.Error()).To(ContainSubstring("property \"optprop\" is required if property \"baz\" is not set"))
+			})
+
+			g.It("should require a property if the depending property is empty", func() {
+				checks.Add(OptionalProperty("optprop").
+					RequiredIfUnset([]string{"baz"}))
+				props["foo"] = "good"
+				props["baz"] = ""
+				err := checks.ValidateProperties("test", props)
+				Expect(err).ToNot(Succeed())
+				Expect(err.Error()).To(ContainSubstring("property \"optprop\" is required if property \"baz\" is not set"))
+			})
+
+			g.It("should require a property if any depending property is not set", func() {
+				checks.Add(OptionalProperty("optprop").
+					RequiredIfUnset([]string{"baz", "qux"}))
+				props["foo"] = "good"
+				props["baz"] = "good"
+				err := checks.ValidateProperties("test", props)
+				Expect(err).ToNot(Succeed())
+				Expect(err.Error()).To(ContainSubstring("property \"optprop\" is required if property \"qux\" is not set"))
+			})
+
+			g.It("should not require a property if the depending property is set", func() {
+				checks.Add(OptionalProperty("optprop").
+					RequiredIfUnset([]string{"baz"}))
+				props["foo"] = "good"
+				props["baz"] = "good"
+				Expect(checks.ValidateProperties("test", props)).To(Succeed())
+			})
+		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug
/kind impediment
/kind task

**What this PR does / why we need it**:

This PR relaxes the validation introduced with:
* #573

The `DNSProvider` secret values `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are only required if `AWS_USE_CREDENTIALS_CHAIN` is not set (and the other way around).

**Which issue(s) this PR fixes**:

Fixes #573

**Special notes for your reviewer**:

/cc @MartinWeindel @siba-azab

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed conditionally requiring `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` only when `AWS_USE_CREDENTIALS_CHAIN` is not set (relevant for AWS Route53 `DNSProvider`).
```
