### PR TITLE
Refactor `DNSHandlerAdapter` implementations

### DIFF
--- a/charts/external-dns-management/templates/crds.yaml
+++ b/charts/external-dns-management/templates/crds.yaml
@@ -517,8 +517,10 @@ spec:
                 - azure-dns
                 - azure-private-dns
                 - cloudflare-dns
+                - gdch-dns
                 - google-clouddns
                 - infoblox-dns
+                - local
                 - mock-inmemory
                 - netlify-dns
                 - openstack-designate

--- a/pkg/apis/dns/crds/dns.gardener.cloud_dnsproviders.yaml
+++ b/pkg/apis/dns/crds/dns.gardener.cloud_dnsproviders.yaml
@@ -136,8 +136,10 @@ spec:
                 - azure-dns
                 - azure-private-dns
                 - cloudflare-dns
+                - gdch-dns
                 - google-clouddns
                 - infoblox-dns
+                - local
                 - mock-inmemory
                 - netlify-dns
                 - openstack-designate

--- a/pkg/apis/dns/crds/zz_generated_crds.go
+++ b/pkg/apis/dns/crds/zz_generated_crds.go
@@ -650,8 +650,10 @@ spec:
                 - azure-dns
                 - azure-private-dns
                 - cloudflare-dns
+                - gdch-dns
                 - google-clouddns
                 - infoblox-dns
+                - local
                 - mock-inmemory
                 - netlify-dns
                 - openstack-designate

--- a/pkg/apis/dns/v1alpha1/dnsprovider.go
+++ b/pkg/apis/dns/v1alpha1/dnsprovider.go
@@ -43,7 +43,7 @@ type DNSProvider struct {
 
 type DNSProviderSpec struct {
 	// type of the provider (selecting the responsible type of DNS controller)
-	// +kubebuilder:validation:Enum=aws-route53;alicloud-dns;azure-dns;azure-private-dns;cloudflare-dns;google-clouddns;infoblox-dns;mock-inmemory;netlify-dns;openstack-designate;powerdns;remote;rfc2136
+	// +kubebuilder:validation:Enum=aws-route53;alicloud-dns;azure-dns;azure-private-dns;cloudflare-dns;gdch-dns;google-clouddns;infoblox-dns;local;mock-inmemory;netlify-dns;openstack-designate;powerdns;remote;rfc2136
 	Type string `json:"type,omitempty"`
 	// optional additional provider specific configuration values
 	// +kubebuilder:validation:XPreserveUnknownFields

--- a/pkg/controller/provider/alicloud/factory.go
+++ b/pkg/controller/provider/alicloud/factory.go
@@ -5,16 +5,12 @@
 package alicloud
 
 import (
-	"fmt"
-
-	"github.com/gardener/controller-manager-library/pkg/utils"
-	"k8s.io/apimachinery/pkg/runtime"
-
+	"github.com/gardener/external-dns-management/pkg/controller/provider/alicloud/validation"
 	"github.com/gardener/external-dns-management/pkg/controller/provider/compound"
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 )
 
-const TYPE_CODE = "alicloud-dns"
+const TYPE_CODE = validation.ProviderType
 
 var rateLimiterDefaults = provider.RateLimiterOptions{
 	Enabled: true,
@@ -22,34 +18,9 @@ var rateLimiterDefaults = provider.RateLimiterOptions{
 	Burst:   1,
 }
 
-var Factory = provider.NewDNSHandlerFactory(TYPE_CODE, NewHandler, newAdapter(), true).
+var Factory = provider.NewDNSHandlerFactory(NewHandler, validation.NewAdapter(), true).
 	SetGenericFactoryOptionDefaults(provider.GenericFactoryOptionDefaults.SetRateLimiterOptions(rateLimiterDefaults))
 
 func init() {
 	compound.MustRegister(Factory)
-}
-
-type adapter struct {
-	checks *provider.DNSHandlerAdapterChecks
-}
-
-func newAdapter() provider.DNSHandlerAdapter {
-	checks := provider.NewDNSHandlerAdapterChecks()
-	checks.Add(provider.RequiredProperty("ACCESS_KEY_ID", "accessKeyID").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericValidator, provider.MaxLengthValidator(64)))
-	checks.Add(provider.RequiredProperty("ACCESS_KEY_SECRET", "accessKeySecret").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.MaxLengthValidator(64)).
-		HideValue())
-	return &adapter{checks: checks}
-}
-
-func (a *adapter) ProviderType() string {
-	return TYPE_CODE
-}
-
-func (a *adapter) ValidateCredentialsAndProviderConfig(properties utils.Properties, config *runtime.RawExtension) error {
-	if config != nil && len(config.Raw) > 0 {
-		return fmt.Errorf("provider config not supported for %s provider", a.ProviderType())
-	}
-	return a.checks.ValidateProperties(a.ProviderType(), properties)
 }

--- a/pkg/controller/provider/alicloud/validation/adapter.go
+++ b/pkg/controller/provider/alicloud/validation/adapter.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validation
+
+import (
+	"fmt"
+
+	"github.com/gardener/controller-manager-library/pkg/utils"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gardener/external-dns-management/pkg/dns/provider"
+)
+
+const ProviderType = "alicloud-dns"
+
+type adapter struct {
+	checks *provider.DNSHandlerAdapterChecks
+}
+
+// NewAdapter creates a new DNSHandlerAdapter for the Alicloud DNS provider.
+func NewAdapter() provider.DNSHandlerAdapter {
+	checks := provider.NewDNSHandlerAdapterChecks()
+	checks.Add(provider.RequiredProperty("ACCESS_KEY_ID", "accessKeyID").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericValidator, provider.MaxLengthValidator(64)))
+	checks.Add(provider.RequiredProperty("ACCESS_KEY_SECRET", "accessKeySecret").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.MaxLengthValidator(64)).
+		HideValue())
+	return &adapter{checks: checks}
+}
+
+func (a *adapter) ProviderType() string {
+	return ProviderType
+}
+
+func (a *adapter) ValidateCredentialsAndProviderConfig(properties utils.Properties, config *runtime.RawExtension) error {
+	if config != nil && len(config.Raw) > 0 {
+		return fmt.Errorf("provider config not supported for %s provider", a.ProviderType())
+	}
+	return a.checks.ValidateProperties(a.ProviderType(), properties)
+}

--- a/pkg/controller/provider/aws/config/config.go
+++ b/pkg/controller/provider/aws/config/config.go
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+type AWSConfig struct {
+	BatchSize int `json:"batchSize"`
+}

--- a/pkg/controller/provider/aws/factory.go
+++ b/pkg/controller/provider/aws/factory.go
@@ -5,18 +5,12 @@
 package aws
 
 import (
-	"encoding/json"
-	"fmt"
-	"regexp"
-
-	"github.com/gardener/controller-manager-library/pkg/utils"
-	"k8s.io/apimachinery/pkg/runtime"
-
+	"github.com/gardener/external-dns-management/pkg/controller/provider/aws/validation"
 	"github.com/gardener/external-dns-management/pkg/controller/provider/compound"
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 )
 
-const TYPE_CODE = "aws-route53"
+const TYPE_CODE = validation.ProviderType
 
 var rateLimiterDefaults = provider.RateLimiterOptions{
 	Enabled: true,
@@ -29,56 +23,10 @@ var advancedDefaults = provider.AdvancedOptions{
 	MaxRetries: 7,
 }
 
-var Factory = provider.NewDNSHandlerFactory(TYPE_CODE, NewHandler, newAdapter()).
+var Factory = provider.NewDNSHandlerFactory(NewHandler, validation.NewAdapter()).
 	SetGenericFactoryOptionDefaults(provider.GenericFactoryOptionDefaults.
 		SetRateLimiterOptions(rateLimiterDefaults).SetAdvancedOptions(advancedDefaults))
 
 func init() {
 	compound.MustRegister(Factory)
-}
-
-type adapter struct {
-	checks *provider.DNSHandlerAdapterChecks
-}
-
-var regionRegex = regexp.MustCompile("^[a-z0-9-]*$") // empty string is explicitly allowed to match the default region
-
-func newAdapter() provider.DNSHandlerAdapter {
-	checks := provider.NewDNSHandlerAdapterChecks()
-	checks.Add(provider.OptionalProperty("AWS_ACCESS_KEY_ID", "accessKeyID").
-		RequiredIfUnset([]string{"AWS_USE_CREDENTIALS_CHAIN"}).
-		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericValidator, provider.MaxLengthValidator(128)))
-	checks.Add(provider.OptionalProperty("AWS_SECRET_ACCESS_KEY", "secretAccessKey").
-		RequiredIfUnset([]string{"AWS_USE_CREDENTIALS_CHAIN"}).
-		Validators(provider.NoTrailingWhitespaceValidator, provider.MaxLengthValidator(128)).
-		HideValue())
-	checks.Add(provider.OptionalProperty("AWS_REGION", "region").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.MaxLengthValidator(32), provider.RegExValidator(regionRegex)).
-		AllowEmptyValue())
-	checks.Add(provider.OptionalProperty("AWS_USE_CREDENTIALS_CHAIN").
-		RequiredIfUnset([]string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"}).
-		Validators(provider.NoTrailingWhitespaceValidator, provider.BoolValidator))
-	checks.Add(provider.OptionalProperty("AWS_SESSION_TOKEN").
-		Validators(provider.MaxLengthValidator(512)).
-		HideValue())
-	return &adapter{checks: checks}
-}
-
-func (a *adapter) ProviderType() string {
-	return TYPE_CODE
-}
-
-func (a *adapter) ValidateCredentialsAndProviderConfig(properties utils.Properties, config *runtime.RawExtension) error {
-	if config != nil && len(config.Raw) > 0 {
-		var cfg AWSConfig
-		err := json.Unmarshal(config.Raw, &cfg)
-		if err != nil {
-			return fmt.Errorf("unmarshal providerConfig failed with: %w", err)
-		}
-		if cfg.BatchSize < 1 || cfg.BatchSize > 50 {
-			return fmt.Errorf("invalid batch size %d, must be between 1 and 50", cfg.BatchSize)
-		}
-		return nil
-	}
-	return a.checks.ValidateProperties(a.ProviderType(), properties)
 }

--- a/pkg/controller/provider/aws/handler.go
+++ b/pkg/controller/provider/aws/handler.go
@@ -19,6 +19,7 @@ import (
 	route53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
 	"github.com/gardener/controller-manager-library/pkg/logger"
 
+	"github.com/gardener/external-dns-management/pkg/controller/provider/aws/config"
 	"github.com/gardener/external-dns-management/pkg/controller/provider/aws/mapping"
 	"github.com/gardener/external-dns-management/pkg/dns"
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
@@ -28,14 +29,10 @@ import (
 type Handler struct {
 	provider.DefaultDNSHandler
 	config        provider.DNSHandlerConfig
-	awsConfig     AWSConfig
+	awsConfig     config.AWSConfig
 	cache         provider.ZoneCache
 	r53           route53.Client
 	policyContext *routingPolicyContext
-}
-
-type AWSConfig struct {
-	BatchSize int `json:"batchSize"`
 }
 
 var _ provider.DNSHandler = &Handler{}
@@ -44,7 +41,7 @@ func NewHandler(c *provider.DNSHandlerConfig) (provider.DNSHandler, error) {
 	advancedConfig := c.Options.GetAdvancedConfig()
 	c.Logger.Infof("advanced options: %s", advancedConfig)
 
-	awsConfig := AWSConfig{BatchSize: advancedConfig.BatchSize}
+	awsConfig := config.AWSConfig{BatchSize: advancedConfig.BatchSize}
 	if c.Config != nil {
 		err := json.Unmarshal(c.Config.Raw, &awsConfig)
 		if err != nil {

--- a/pkg/controller/provider/aws/validation/adapter.go
+++ b/pkg/controller/provider/aws/validation/adapter.go
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validation
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+
+	"github.com/gardener/controller-manager-library/pkg/utils"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gardener/external-dns-management/pkg/controller/provider/aws/config"
+	"github.com/gardener/external-dns-management/pkg/dns/provider"
+)
+
+// ProviderType is the type identifier for the AWS Route53 DNS provider.
+const ProviderType = "aws-route53"
+
+type adapter struct {
+	checks *provider.DNSHandlerAdapterChecks
+}
+
+var regionRegex = regexp.MustCompile("^[a-z0-9-]*$") // empty string is explicitly allowed to match the default region
+
+// NewAdapter creates a new DNSHandlerAdapter for the AWS Route53 provider.
+func NewAdapter() provider.DNSHandlerAdapter {
+	checks := provider.NewDNSHandlerAdapterChecks()
+	checks.Add(provider.OptionalProperty("AWS_ACCESS_KEY_ID", "accessKeyID").
+		RequiredIfUnset("AWS_USE_CREDENTIALS_CHAIN").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericValidator, provider.MaxLengthValidator(128)))
+	checks.Add(provider.OptionalProperty("AWS_SECRET_ACCESS_KEY", "secretAccessKey").
+		RequiredIfUnset("AWS_USE_CREDENTIALS_CHAIN").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.MaxLengthValidator(128)).
+		HideValue())
+	checks.Add(provider.OptionalProperty("AWS_REGION", "region").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.MaxLengthValidator(32), provider.RegExValidator(regionRegex)).
+		AllowEmptyValue())
+	checks.Add(provider.OptionalProperty("AWS_USE_CREDENTIALS_CHAIN").
+		RequiredIfUnset("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.BoolValidator))
+	checks.Add(provider.OptionalProperty("AWS_SESSION_TOKEN").
+		Validators(provider.MaxLengthValidator(512)).
+		HideValue())
+	return &adapter{checks: checks}
+}
+
+func (a *adapter) ProviderType() string {
+	return ProviderType
+}
+
+func (a *adapter) ValidateCredentialsAndProviderConfig(properties utils.Properties, raw *runtime.RawExtension) error {
+	if raw != nil && len(raw.Raw) > 0 {
+		var cfg config.AWSConfig
+		err := json.Unmarshal(raw.Raw, &cfg)
+		if err != nil {
+			return fmt.Errorf("unmarshal providerConfig failed with: %w", err)
+		}
+		if cfg.BatchSize < 1 || cfg.BatchSize > 50 {
+			return fmt.Errorf("invalid batch size %d, must be between 1 and 50", cfg.BatchSize)
+		}
+		return nil
+	}
+	return a.checks.ValidateProperties(a.ProviderType(), properties)
+}

--- a/pkg/controller/provider/azure-private/factory.go
+++ b/pkg/controller/provider/azure-private/factory.go
@@ -5,12 +5,12 @@
 package azureprivate
 
 import (
-	"github.com/gardener/external-dns-management/pkg/controller/provider/azure/utils"
+	"github.com/gardener/external-dns-management/pkg/controller/provider/azure/validation"
 	"github.com/gardener/external-dns-management/pkg/controller/provider/compound"
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 )
 
-const TYPE_CODE = utils.ProviderTypeAzurePrivateDNS
+const TYPE_CODE = validation.ProviderTypeAzurePrivateDNS
 
 var rateLimiterDefaults = provider.RateLimiterOptions{
 	Enabled: true,
@@ -18,7 +18,7 @@ var rateLimiterDefaults = provider.RateLimiterOptions{
 	Burst:   10,
 }
 
-var Factory = provider.NewDNSHandlerFactory(NewHandler, utils.NewAdapter(TYPE_CODE)).
+var Factory = provider.NewDNSHandlerFactory(NewHandler, validation.NewAdapter(TYPE_CODE)).
 	SetGenericFactoryOptionDefaults(provider.GenericFactoryOptionDefaults.SetRateLimiterOptions(rateLimiterDefaults))
 
 func init() {

--- a/pkg/controller/provider/azure-private/factory.go
+++ b/pkg/controller/provider/azure-private/factory.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 )
 
-const TYPE_CODE = "azure-private-dns"
+const TYPE_CODE = utils.ProviderTypeAzurePrivateDNS
 
 var rateLimiterDefaults = provider.RateLimiterOptions{
 	Enabled: true,
@@ -18,7 +18,7 @@ var rateLimiterDefaults = provider.RateLimiterOptions{
 	Burst:   10,
 }
 
-var Factory = provider.NewDNSHandlerFactory(TYPE_CODE, NewHandler, utils.NewAdapter(TYPE_CODE)).
+var Factory = provider.NewDNSHandlerFactory(NewHandler, utils.NewAdapter(TYPE_CODE)).
 	SetGenericFactoryOptionDefaults(provider.GenericFactoryOptionDefaults.SetRateLimiterOptions(rateLimiterDefaults))
 
 func init() {

--- a/pkg/controller/provider/azure/factory.go
+++ b/pkg/controller/provider/azure/factory.go
@@ -5,12 +5,12 @@
 package azure
 
 import (
-	"github.com/gardener/external-dns-management/pkg/controller/provider/azure/utils"
+	"github.com/gardener/external-dns-management/pkg/controller/provider/azure/validation"
 	"github.com/gardener/external-dns-management/pkg/controller/provider/compound"
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 )
 
-const TYPE_CODE = utils.ProviderTypeAzureDNS
+const TYPE_CODE = validation.ProviderTypeAzureDNS
 
 var rateLimiterDefaults = provider.RateLimiterOptions{
 	Enabled: true,
@@ -18,7 +18,7 @@ var rateLimiterDefaults = provider.RateLimiterOptions{
 	Burst:   10,
 }
 
-var Factory = provider.NewDNSHandlerFactory(NewHandler, utils.NewAdapter(TYPE_CODE)).
+var Factory = provider.NewDNSHandlerFactory(NewHandler, validation.NewAdapter(TYPE_CODE)).
 	SetGenericFactoryOptionDefaults(provider.GenericFactoryOptionDefaults.SetRateLimiterOptions(rateLimiterDefaults))
 
 func init() {

--- a/pkg/controller/provider/azure/factory.go
+++ b/pkg/controller/provider/azure/factory.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 )
 
-const TYPE_CODE = "azure-dns"
+const TYPE_CODE = utils.ProviderTypeAzureDNS
 
 var rateLimiterDefaults = provider.RateLimiterOptions{
 	Enabled: true,
@@ -18,7 +18,7 @@ var rateLimiterDefaults = provider.RateLimiterOptions{
 	Burst:   10,
 }
 
-var Factory = provider.NewDNSHandlerFactory(TYPE_CODE, NewHandler, utils.NewAdapter(TYPE_CODE)).
+var Factory = provider.NewDNSHandlerFactory(NewHandler, utils.NewAdapter(TYPE_CODE)).
 	SetGenericFactoryOptionDefaults(provider.GenericFactoryOptionDefaults.SetRateLimiterOptions(rateLimiterDefaults))
 
 func init() {

--- a/pkg/controller/provider/azure/utils/adapter.go
+++ b/pkg/controller/provider/azure/utils/adapter.go
@@ -14,6 +14,11 @@ import (
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 )
 
+const (
+	ProviderTypeAzureDNS        = "azure-dns"
+	ProviderTypeAzurePrivateDNS = "azure-private-dns"
+)
+
 type adapter struct {
 	providerType string
 	checks       *provider.DNSHandlerAdapterChecks

--- a/pkg/controller/provider/azure/validation/adapter.go
+++ b/pkg/controller/provider/azure/validation/adapter.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package utils
+package validation
 
 import (
 	"fmt"

--- a/pkg/controller/provider/cloudflare/factory.go
+++ b/pkg/controller/provider/cloudflare/factory.go
@@ -5,16 +5,12 @@
 package cloudflare
 
 import (
-	"fmt"
-
-	"github.com/gardener/controller-manager-library/pkg/utils"
-	"k8s.io/apimachinery/pkg/runtime"
-
+	"github.com/gardener/external-dns-management/pkg/controller/provider/cloudflare/validation"
 	"github.com/gardener/external-dns-management/pkg/controller/provider/compound"
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 )
 
-const TYPE_CODE = "cloudflare-dns"
+const TYPE_CODE = validation.ProviderType
 
 var rateLimiterDefaults = provider.RateLimiterOptions{
 	Enabled: true,
@@ -22,32 +18,9 @@ var rateLimiterDefaults = provider.RateLimiterOptions{
 	Burst:   10,
 }
 
-var Factory = provider.NewDNSHandlerFactory(TYPE_CODE, NewHandler, newAdapter()).
+var Factory = provider.NewDNSHandlerFactory(NewHandler, validation.NewAdapter()).
 	SetGenericFactoryOptionDefaults(provider.GenericFactoryOptionDefaults.SetRateLimiterOptions(rateLimiterDefaults))
 
 func init() {
 	compound.MustRegister(Factory)
-}
-
-type adapter struct {
-	checks *provider.DNSHandlerAdapterChecks
-}
-
-func newAdapter() provider.DNSHandlerAdapter {
-	checks := provider.NewDNSHandlerAdapterChecks()
-	checks.Add(provider.RequiredProperty("CLOUDFLARE_API_TOKEN").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(100)).
-		HideValue())
-	return &adapter{checks: checks}
-}
-
-func (a *adapter) ProviderType() string {
-	return TYPE_CODE
-}
-
-func (a *adapter) ValidateCredentialsAndProviderConfig(properties utils.Properties, config *runtime.RawExtension) error {
-	if config != nil && len(config.Raw) > 0 {
-		return fmt.Errorf("provider config not supported for %s provider", a.ProviderType())
-	}
-	return a.checks.ValidateProperties(a.ProviderType(), properties)
 }

--- a/pkg/controller/provider/cloudflare/validation/adapter.go
+++ b/pkg/controller/provider/cloudflare/validation/adapter.go
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validation
+
+import (
+	"fmt"
+
+	"github.com/gardener/controller-manager-library/pkg/utils"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gardener/external-dns-management/pkg/dns/provider"
+)
+
+// ProviderType is the type code for the Cloudflare DNS provider.
+const ProviderType = "cloudflare-dns"
+
+type adapter struct {
+	checks *provider.DNSHandlerAdapterChecks
+}
+
+// NewAdapter creates a new DNSHandlerAdapter for the Cloudflare DNS provider.
+func NewAdapter() provider.DNSHandlerAdapter {
+	checks := provider.NewDNSHandlerAdapterChecks()
+	checks.Add(provider.RequiredProperty("CLOUDFLARE_API_TOKEN").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(100)).
+		HideValue())
+	return &adapter{checks: checks}
+}
+
+func (a *adapter) ProviderType() string {
+	return ProviderType
+}
+
+func (a *adapter) ValidateCredentialsAndProviderConfig(properties utils.Properties, config *runtime.RawExtension) error {
+	if config != nil && len(config.Raw) > 0 {
+		return fmt.Errorf("provider config not supported for %s provider", a.ProviderType())
+	}
+	return a.checks.ValidateProperties(a.ProviderType(), properties)
+}

--- a/pkg/controller/provider/compound/validation/adaptors.go
+++ b/pkg/controller/provider/compound/validation/adaptors.go
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validation
+
+import (
+	alicloudvalidation "github.com/gardener/external-dns-management/pkg/controller/provider/alicloud/validation"
+	awsvalidation "github.com/gardener/external-dns-management/pkg/controller/provider/aws/validation"
+	azureutils "github.com/gardener/external-dns-management/pkg/controller/provider/azure/utils"
+	cloudflarevalidation "github.com/gardener/external-dns-management/pkg/controller/provider/cloudflare/validation"
+	googlevalidation "github.com/gardener/external-dns-management/pkg/controller/provider/google/validation"
+	infobloxvalidation "github.com/gardener/external-dns-management/pkg/controller/provider/infoblox/validation"
+	netlifyvalidation "github.com/gardener/external-dns-management/pkg/controller/provider/netlify/validation"
+	openstackvalidation "github.com/gardener/external-dns-management/pkg/controller/provider/openstack/validation"
+	powerdnsvalidation "github.com/gardener/external-dns-management/pkg/controller/provider/powerdns/validation"
+	remotevalidation "github.com/gardener/external-dns-management/pkg/controller/provider/remote/validation"
+	rfc2136validation "github.com/gardener/external-dns-management/pkg/controller/provider/rfc2136/validation"
+	"github.com/gardener/external-dns-management/pkg/dns/provider"
+)
+
+var adaptors map[string]provider.DNSHandlerAdapter
+
+func init() {
+	adaptors = make(map[string]provider.DNSHandlerAdapter)
+	for _, adaptor := range []provider.DNSHandlerAdapter{
+		alicloudvalidation.NewAdapter(),
+		awsvalidation.NewAdapter(),
+		azureutils.NewAdapter(azureutils.ProviderTypeAzureDNS),
+		azureutils.NewAdapter(azureutils.ProviderTypeAzurePrivateDNS),
+		cloudflarevalidation.NewAdapter(),
+		googlevalidation.NewAdapter(),
+		infobloxvalidation.NewAdapter(),
+		netlifyvalidation.NewAdapter(),
+		openstackvalidation.NewAdapter(),
+		powerdnsvalidation.NewAdapter(),
+		remotevalidation.NewAdapter(),
+		rfc2136validation.NewAdapter(),
+	} {
+		registerAdaptor(adaptor)
+	}
+}
+
+func registerAdaptor(adaptor provider.DNSHandlerAdapter) {
+	if _, exists := adaptors[adaptor.ProviderType()]; exists {
+		panic("dns handler adaptor already registered for code: " + adaptor.ProviderType())
+	}
+	adaptors[adaptor.ProviderType()] = adaptor
+}
+
+// GetAdaptor returns the DNSHandlerAdapter for the given provider type.
+// Used for validation by the shoot-dns-service extension.
+func GetAdaptor(providerType string) provider.DNSHandlerAdapter {
+	return adaptors[providerType]
+}

--- a/pkg/controller/provider/compound/validation/adaptors.go
+++ b/pkg/controller/provider/compound/validation/adaptors.go
@@ -7,7 +7,7 @@ package validation
 import (
 	alicloudvalidation "github.com/gardener/external-dns-management/pkg/controller/provider/alicloud/validation"
 	awsvalidation "github.com/gardener/external-dns-management/pkg/controller/provider/aws/validation"
-	azureutils "github.com/gardener/external-dns-management/pkg/controller/provider/azure/utils"
+	azurevalidation "github.com/gardener/external-dns-management/pkg/controller/provider/azure/validation"
 	cloudflarevalidation "github.com/gardener/external-dns-management/pkg/controller/provider/cloudflare/validation"
 	googlevalidation "github.com/gardener/external-dns-management/pkg/controller/provider/google/validation"
 	infobloxvalidation "github.com/gardener/external-dns-management/pkg/controller/provider/infoblox/validation"
@@ -26,8 +26,8 @@ func init() {
 	for _, adaptor := range []provider.DNSHandlerAdapter{
 		alicloudvalidation.NewAdapter(),
 		awsvalidation.NewAdapter(),
-		azureutils.NewAdapter(azureutils.ProviderTypeAzureDNS),
-		azureutils.NewAdapter(azureutils.ProviderTypeAzurePrivateDNS),
+		azurevalidation.NewAdapter(azurevalidation.ProviderTypeAzureDNS),
+		azurevalidation.NewAdapter(azurevalidation.ProviderTypeAzurePrivateDNS),
 		cloudflarevalidation.NewAdapter(),
 		googlevalidation.NewAdapter(),
 		infobloxvalidation.NewAdapter(),

--- a/pkg/controller/provider/google/factory.go
+++ b/pkg/controller/provider/google/factory.go
@@ -5,16 +5,12 @@
 package google
 
 import (
-	"fmt"
-
-	"github.com/gardener/controller-manager-library/pkg/utils"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	"github.com/gardener/external-dns-management/pkg/controller/provider/compound"
+	"github.com/gardener/external-dns-management/pkg/controller/provider/google/validation"
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 )
 
-const TYPE_CODE = "google-clouddns"
+const TYPE_CODE = validation.ProviderType
 
 var rateLimiterDefaults = provider.RateLimiterOptions{
 	Enabled: true,
@@ -22,33 +18,9 @@ var rateLimiterDefaults = provider.RateLimiterOptions{
 	Burst:   20,
 }
 
-var Factory = provider.NewDNSHandlerFactory(TYPE_CODE, NewHandler, newAdapter()).
+var Factory = provider.NewDNSHandlerFactory(NewHandler, validation.NewAdapter()).
 	SetGenericFactoryOptionDefaults(provider.GenericFactoryOptionDefaults.SetRateLimiterOptions(rateLimiterDefaults))
 
 func init() {
 	compound.MustRegister(Factory)
-}
-
-type adapter struct {
-	checks *provider.DNSHandlerAdapterChecks
-}
-
-func newAdapter() provider.DNSHandlerAdapter {
-	checks := provider.NewDNSHandlerAdapterChecks()
-	checks.Add(provider.RequiredProperty("serviceaccount.json").Validators(func(value string) error {
-		_, err := validateServiceAccountJSON([]byte(value))
-		return err
-	}).HideValue())
-	return &adapter{checks: checks}
-}
-
-func (a *adapter) ProviderType() string {
-	return TYPE_CODE
-}
-
-func (a *adapter) ValidateCredentialsAndProviderConfig(properties utils.Properties, config *runtime.RawExtension) error {
-	if config != nil && len(config.Raw) > 0 {
-		return fmt.Errorf("provider config not supported for %s provider", a.ProviderType())
-	}
-	return a.checks.ValidateProperties(a.ProviderType(), properties)
 }

--- a/pkg/controller/provider/google/handler_test.go
+++ b/pkg/controller/provider/google/handler_test.go
@@ -9,6 +9,8 @@ package google
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/gardener/external-dns-management/pkg/controller/provider/google/validation"
 )
 
 var _ = Describe("ValidateServiceAccountJSON", func() {
@@ -50,7 +52,7 @@ var _ = Describe("ValidateServiceAccountJSON", func() {
 
 	for _, tt := range tests {
 		It(tt.name, func() {
-			_, err := validateServiceAccountJSON([]byte(tt.data))
+			_, err := validation.ValidateServiceAccountJSON([]byte(tt.data))
 			if tt.wantErr {
 				Expect(err).To(HaveOccurred())
 			} else {

--- a/pkg/controller/provider/google/validation/adaptor.go
+++ b/pkg/controller/provider/google/validation/adaptor.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validation
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/gardener/controller-manager-library/pkg/utils"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/json"
+
+	"github.com/gardener/external-dns-management/pkg/dns/provider"
+)
+
+// ProviderType is the type code for the Google Cloud DNS provider.
+const ProviderType = "google-clouddns"
+
+// LightCredentialsFile represents a minimal set of fields required for Google Cloud DNS service account credentials.
+type LightCredentialsFile struct {
+	Type string `json:"type"`
+
+	// Service Account fields
+	ClientEmail  string `json:"client_email"`
+	PrivateKeyID string `json:"private_key_id"`
+	ProjectID    string `json:"project_id"`
+}
+
+type adapter struct {
+	checks *provider.DNSHandlerAdapterChecks
+}
+
+// NewAdapter creates a new DNSHandlerAdapter for the Google Cloud DNS provider.
+func NewAdapter() provider.DNSHandlerAdapter {
+	checks := provider.NewDNSHandlerAdapterChecks()
+	checks.Add(provider.RequiredProperty("serviceaccount.json").Validators(func(value string) error {
+		_, err := ValidateServiceAccountJSON([]byte(value))
+		return err
+	}).HideValue())
+	return &adapter{checks: checks}
+}
+
+func (a *adapter) ProviderType() string {
+	return ProviderType
+}
+
+func (a *adapter) ValidateCredentialsAndProviderConfig(properties utils.Properties, config *runtime.RawExtension) error {
+	if config != nil && len(config.Raw) > 0 {
+		return fmt.Errorf("provider config not supported for %s provider", a.ProviderType())
+	}
+	return a.checks.ValidateProperties(a.ProviderType(), properties)
+}
+
+var projectIDRegexp = regexp.MustCompile(`^(?P<project>[a-z][a-z0-9-]{4,28}[a-z0-9])$`)
+
+func ValidateServiceAccountJSON(data []byte) (LightCredentialsFile, error) {
+	var credInfo LightCredentialsFile
+
+	if err := json.Unmarshal(data, &credInfo); err != nil {
+		return credInfo, fmt.Errorf("'serviceaccount.json' data field does not contain a valid JSON: %s", err)
+	}
+	if !projectIDRegexp.MatchString(credInfo.ProjectID) {
+		return credInfo, fmt.Errorf("'serviceaccount.json' field 'project_id' is not a valid project")
+	}
+	if credInfo.Type != "service_account" {
+		return credInfo, fmt.Errorf("'serviceaccount.json' field 'type' is not 'service_account'")
+	}
+	return credInfo, nil
+}

--- a/pkg/controller/provider/infoblox/config/config.go
+++ b/pkg/controller/provider/infoblox/config/config.go
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+type InfobloxConfig struct {
+	Host            *string            `json:"host,omitempty"`
+	Port            *int               `json:"port,omitempty"`
+	SSLVerify       *bool              `json:"sslVerify,omitempty"`
+	Version         *string            `json:"version,omitempty"`
+	View            *string            `json:"view,omitempty"`
+	PoolConnections *int               `json:"httpPoolConnections,omitempty"`
+	RequestTimeout  *int               `json:"httpRequestTimeout,omitempty"`
+	CaCert          *string            `json:"caCert,omitempty"`
+	MaxResults      int                `json:"maxResults,omitempty"`
+	ProxyURL        *string            `json:"proxyUrl,omitempty"`
+	ExtAttrs        *map[string]string `json:"extAttrs,omitempty"`
+}

--- a/pkg/controller/provider/infoblox/factory.go
+++ b/pkg/controller/provider/infoblox/factory.go
@@ -5,105 +5,15 @@
 package infoblox
 
 import (
-	"encoding/json"
-	"fmt"
-	"strconv"
-
-	"github.com/gardener/controller-manager-library/pkg/utils"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	"github.com/gardener/external-dns-management/pkg/controller/provider/compound"
+	"github.com/gardener/external-dns-management/pkg/controller/provider/infoblox/validation"
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 )
 
-const TYPE_CODE = "infoblox-dns"
+const TYPE_CODE = validation.ProviderType
 
-var Factory = provider.NewDNSHandlerFactory(TYPE_CODE, NewHandler, newAdapter())
+var Factory = provider.NewDNSHandlerFactory(NewHandler, validation.NewAdapter())
 
 func init() {
 	compound.MustRegister(Factory)
-}
-
-type adapter struct {
-	checks *provider.DNSHandlerAdapterChecks
-}
-
-func newAdapter() provider.DNSHandlerAdapter {
-	checks := provider.NewDNSHandlerAdapterChecks()
-	checks.Add(provider.RequiredProperty("USERNAME", "username").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(64)))
-	checks.Add(provider.RequiredProperty("PASSWORD", "password").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.MaxLengthValidator(64)).
-		HideValue())
-	checks.Add(provider.RequiredProperty("VERSION", "version").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(64)))
-	checks.Add(provider.OptionalProperty("VIEW", "view").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(64)))
-	checks.Add(provider.RequiredProperty("HOST", "host").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(256)))
-	checks.Add(provider.RequiredProperty("PORT", "port").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.IntValidator(1, 65535)))
-	checks.Add(provider.OptionalProperty("HTTP_POOL_CONNECTIONS", "http_pool_connections", "httpPoolConnections").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.IntValidator(1, 100)))
-	checks.Add(provider.OptionalProperty("HTTP_REQUEST_TIMEOUT", "http_request_timeout", "httpRequestTimeout").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.IntValidator(0, 1000)))
-	checks.Add(provider.OptionalProperty("PROXY_URL", "proxy_url", "proxyUrl").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.URLValidator("http", "https"), provider.MaxLengthValidator(6)))
-	checks.Add(provider.OptionalProperty("CA_CERT", "ca_cert", "caCert").
-		Validators(provider.CACertValidator).
-		HideValue())
-	checks.Add(provider.OptionalProperty("SSL_VERIFY", "ssl_verify", "sslVerify").
-		Validators(provider.BoolValidator))
-	return &adapter{checks: checks}
-}
-
-func (a *adapter) ProviderType() string {
-	return TYPE_CODE
-}
-
-func (a *adapter) ValidateCredentialsAndProviderConfig(properties utils.Properties, config *runtime.RawExtension) error {
-	if config != nil && len(config.Raw) > 0 {
-		infobloxConfig := &InfobloxConfig{}
-		if config != nil {
-			err := json.Unmarshal(config.Raw, infobloxConfig)
-			if err != nil {
-				return fmt.Errorf("unmarshal infoblox providerConfig failed with: %s", err)
-			}
-		}
-		if infobloxConfig.CaCert != nil && *infobloxConfig.CaCert != "" {
-			a.addPropertyIfNotExists(properties, "CA_CERT", *infobloxConfig.CaCert)
-		}
-		if infobloxConfig.Host != nil && *infobloxConfig.Host != "" {
-			a.addPropertyIfNotExists(properties, "HOST", *infobloxConfig.Host)
-		}
-		if infobloxConfig.PoolConnections != nil && *infobloxConfig.PoolConnections != 0 {
-			a.addPropertyIfNotExists(properties, "HTTP_POOL_CONNECTIONS", strconv.FormatInt(int64(*infobloxConfig.PoolConnections), 10))
-		}
-		if infobloxConfig.Port != nil && *infobloxConfig.Port != 0 {
-			a.addPropertyIfNotExists(properties, "PORT", strconv.FormatInt(int64(*infobloxConfig.Port), 10))
-		}
-		if infobloxConfig.ProxyURL != nil && *infobloxConfig.ProxyURL != "" {
-			a.addPropertyIfNotExists(properties, "PROXY_URL", *infobloxConfig.ProxyURL)
-		}
-		if infobloxConfig.RequestTimeout != nil {
-			a.addPropertyIfNotExists(properties, "HTTP_REQUEST_TIMEOUT", strconv.FormatInt(int64(*infobloxConfig.RequestTimeout), 10))
-		}
-		if infobloxConfig.SSLVerify != nil {
-			a.addPropertyIfNotExists(properties, "SSL_VERIFY", strconv.FormatBool(*infobloxConfig.SSLVerify))
-		}
-		if infobloxConfig.Version != nil && *infobloxConfig.Version != "" {
-			a.addPropertyIfNotExists(properties, "VERSION", *infobloxConfig.Version)
-		}
-		if infobloxConfig.View != nil && *infobloxConfig.View != "" {
-			a.addPropertyIfNotExists(properties, "VIEW", *infobloxConfig.View)
-		}
-	}
-	return a.checks.ValidateProperties(a.ProviderType(), properties)
-}
-
-func (a *adapter) addPropertyIfNotExists(properties utils.Properties, key string, value string) {
-	if a.checks.HasPropertyNameOrAlias(properties, key) {
-		return // Property already exists, do not overwrite
-	}
-	properties[key] = value
 }

--- a/pkg/controller/provider/infoblox/validation/adapter.go
+++ b/pkg/controller/provider/infoblox/validation/adapter.go
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validation
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/gardener/controller-manager-library/pkg/utils"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gardener/external-dns-management/pkg/controller/provider/infoblox/config"
+	"github.com/gardener/external-dns-management/pkg/dns/provider"
+)
+
+// ProviderType is the type code for the Infoblox DNS provider.
+const ProviderType = "infoblox-dns"
+
+type adapter struct {
+	checks *provider.DNSHandlerAdapterChecks
+}
+
+// NewAdapter creates a new DNSHandlerAdapter for the Infoblox DNS provider.
+func NewAdapter() provider.DNSHandlerAdapter {
+	checks := provider.NewDNSHandlerAdapterChecks()
+	checks.Add(provider.RequiredProperty("USERNAME", "username").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(64)))
+	checks.Add(provider.RequiredProperty("PASSWORD", "password").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.MaxLengthValidator(64)).
+		HideValue())
+	checks.Add(provider.RequiredProperty("VERSION", "version").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(64)))
+	checks.Add(provider.OptionalProperty("VIEW", "view").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(64)))
+	checks.Add(provider.RequiredProperty("HOST", "host").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(256)))
+	checks.Add(provider.RequiredProperty("PORT", "port").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.IntValidator(1, 65535)))
+	checks.Add(provider.OptionalProperty("HTTP_POOL_CONNECTIONS", "http_pool_connections", "httpPoolConnections").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.IntValidator(1, 100)))
+	checks.Add(provider.OptionalProperty("HTTP_REQUEST_TIMEOUT", "http_request_timeout", "httpRequestTimeout").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.IntValidator(0, 1000)))
+	checks.Add(provider.OptionalProperty("PROXY_URL", "proxy_url", "proxyUrl").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.URLValidator("http", "https"), provider.MaxLengthValidator(6)))
+	checks.Add(provider.OptionalProperty("CA_CERT", "ca_cert", "caCert").
+		Validators(provider.CACertValidator).
+		HideValue())
+	checks.Add(provider.OptionalProperty("SSL_VERIFY", "ssl_verify", "sslVerify").
+		Validators(provider.BoolValidator))
+	return &adapter{checks: checks}
+}
+
+func (a *adapter) ProviderType() string {
+	return ProviderType
+}
+
+func (a *adapter) ValidateCredentialsAndProviderConfig(properties utils.Properties, rawExtension *runtime.RawExtension) error {
+	if rawExtension != nil && len(rawExtension.Raw) > 0 {
+		infobloxConfig := &config.InfobloxConfig{}
+		if rawExtension != nil {
+			err := json.Unmarshal(rawExtension.Raw, infobloxConfig)
+			if err != nil {
+				return fmt.Errorf("unmarshal infoblox providerConfig failed with: %s", err)
+			}
+		}
+		if infobloxConfig.CaCert != nil && *infobloxConfig.CaCert != "" {
+			a.addPropertyIfNotExists(properties, "CA_CERT", *infobloxConfig.CaCert)
+		}
+		if infobloxConfig.Host != nil && *infobloxConfig.Host != "" {
+			a.addPropertyIfNotExists(properties, "HOST", *infobloxConfig.Host)
+		}
+		if infobloxConfig.PoolConnections != nil && *infobloxConfig.PoolConnections != 0 {
+			a.addPropertyIfNotExists(properties, "HTTP_POOL_CONNECTIONS", strconv.FormatInt(int64(*infobloxConfig.PoolConnections), 10))
+		}
+		if infobloxConfig.Port != nil && *infobloxConfig.Port != 0 {
+			a.addPropertyIfNotExists(properties, "PORT", strconv.FormatInt(int64(*infobloxConfig.Port), 10))
+		}
+		if infobloxConfig.ProxyURL != nil && *infobloxConfig.ProxyURL != "" {
+			a.addPropertyIfNotExists(properties, "PROXY_URL", *infobloxConfig.ProxyURL)
+		}
+		if infobloxConfig.RequestTimeout != nil {
+			a.addPropertyIfNotExists(properties, "HTTP_REQUEST_TIMEOUT", strconv.FormatInt(int64(*infobloxConfig.RequestTimeout), 10))
+		}
+		if infobloxConfig.SSLVerify != nil {
+			a.addPropertyIfNotExists(properties, "SSL_VERIFY", strconv.FormatBool(*infobloxConfig.SSLVerify))
+		}
+		if infobloxConfig.Version != nil && *infobloxConfig.Version != "" {
+			a.addPropertyIfNotExists(properties, "VERSION", *infobloxConfig.Version)
+		}
+		if infobloxConfig.View != nil && *infobloxConfig.View != "" {
+			a.addPropertyIfNotExists(properties, "VIEW", *infobloxConfig.View)
+		}
+	}
+	return a.checks.ValidateProperties(a.ProviderType(), properties)
+}
+
+func (a *adapter) addPropertyIfNotExists(properties utils.Properties, key string, value string) {
+	if a.checks.HasPropertyNameOrAlias(properties, key) {
+		return // Property already exists, do not overwrite
+	}
+	properties[key] = value
+}

--- a/pkg/controller/provider/mock/factory.go
+++ b/pkg/controller/provider/mock/factory.go
@@ -22,7 +22,7 @@ var rateLimiterDefaults = provider.RateLimiterOptions{
 	Burst:   20,
 }
 
-var Factory = provider.NewDNSHandlerFactory(TYPE_CODE, NewHandler, &adapter{}).
+var Factory = provider.NewDNSHandlerFactory(NewHandler, &adapter{}).
 	SetGenericFactoryOptionDefaults(provider.GenericFactoryOptionDefaults.SetRateLimiterOptions(rateLimiterDefaults))
 
 func init() {

--- a/pkg/controller/provider/netlify/validation/adaptor.go
+++ b/pkg/controller/provider/netlify/validation/adaptor.go
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validation
+
+import (
+	"fmt"
+
+	"github.com/gardener/controller-manager-library/pkg/utils"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gardener/external-dns-management/pkg/dns/provider"
+)
+
+// Provider type code for Netlify DNS provider
+const ProviderType = "netlify-dns"
+
+type adapter struct {
+	checks *provider.DNSHandlerAdapterChecks
+}
+
+// NewAdapter creates a new DNSHandlerAdapter for the Netlify DNS provider
+func NewAdapter() provider.DNSHandlerAdapter {
+	checks := provider.NewDNSHandlerAdapterChecks()
+	checks.Add(provider.RequiredProperty("NETLIFY_AUTH_TOKEN", "NETLIFY_API_TOKEN").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.Base64CharactersValidator, provider.MaxLengthValidator(64)).
+		HideValue())
+	return &adapter{checks: checks}
+}
+
+func (a *adapter) ProviderType() string {
+	return ProviderType
+}
+
+func (a *adapter) ValidateCredentialsAndProviderConfig(properties utils.Properties, config *runtime.RawExtension) error {
+	if config != nil && len(config.Raw) > 0 {
+		return fmt.Errorf("provider config not supported for %s provider", a.ProviderType())
+	}
+	return a.checks.ValidateProperties(a.ProviderType(), properties)
+}

--- a/pkg/controller/provider/openstack/factory.go
+++ b/pkg/controller/provider/openstack/factory.go
@@ -5,16 +5,12 @@
 package openstack
 
 import (
-	"fmt"
-
-	"github.com/gardener/controller-manager-library/pkg/utils"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	"github.com/gardener/external-dns-management/pkg/controller/provider/compound"
+	"github.com/gardener/external-dns-management/pkg/controller/provider/openstack/validation"
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 )
 
-const TYPE_CODE = "openstack-designate"
+const TYPE_CODE = validation.ProviderType
 
 var rateLimiterDefaults = provider.RateLimiterOptions{
 	Enabled: true,
@@ -22,63 +18,9 @@ var rateLimiterDefaults = provider.RateLimiterOptions{
 	Burst:   20,
 }
 
-var Factory = provider.NewDNSHandlerFactory(TYPE_CODE, NewHandler, newAdapter()).
+var Factory = provider.NewDNSHandlerFactory(NewHandler, validation.NewAdapter()).
 	SetGenericFactoryOptionDefaults(provider.GenericFactoryOptionDefaults.SetRateLimiterOptions(rateLimiterDefaults))
 
 func init() {
 	compound.MustRegister(Factory)
-}
-
-type adapter struct {
-	checks *provider.DNSHandlerAdapterChecks
-}
-
-func newAdapter() provider.DNSHandlerAdapter {
-	checks := provider.NewDNSHandlerAdapterChecks()
-	checks.Add(provider.RequiredProperty("OS_AUTH_URL", "authURL").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.URLValidator("http", "https"), provider.MaxLengthValidator(256)))
-	checks.Add(provider.OptionalProperty("OS_APPLICATION_CREDENTIAL_ID", "applicationCredentialID").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(128)))
-	checks.Add(provider.OptionalProperty("OS_APPLICATION_CREDENTIAL_NAME", "applicationCredentialName").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(128)))
-	checks.Add(provider.OptionalProperty("OS_APPLICATION_CREDENTIAL_SECRET", "applicationCredentialSecret").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.MaxLengthValidator(128)).
-		HideValue())
-	checks.Add(provider.OptionalProperty("OS_USERNAME", "username").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(128)))
-	checks.Add(provider.OptionalProperty("OS_PASSWORD", "password").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.MaxLengthValidator(128), provider.NoTrailingNewlineValidator).
-		HideValue())
-	checks.Add(provider.OptionalProperty("OS_DOMAIN_NAME", "domainName").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(128)))
-	checks.Add(provider.OptionalProperty("OS_DOMAIN_ID", "domainID").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(128)))
-	// tenantName must not be longer than 64 characters, see https://docs.openstack.org/api-ref/identity/v3/?expanded=show-project-details-detail
-	checks.Add(provider.OptionalProperty("OS_PROJECT_NAME", "tenantName").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(128)))
-	checks.Add(provider.OptionalProperty("OS_PROJECT_ID", "tenantID").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(128)))
-	checks.Add(provider.OptionalProperty("OS_USER_DOMAIN_NAME", "userDomainName").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(128)))
-	checks.Add(provider.OptionalProperty("OS_USER_DOMAIN_ID", "userDomainID").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(128)))
-	checks.Add(provider.OptionalProperty("OS_REGION_NAME").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(128)))
-	checks.Add(provider.OptionalProperty("CACERT", "caCert").Validators(provider.CACertValidator).HideValue())
-	checks.Add(provider.OptionalProperty("CLIENTCERT", "clientCert").Validators(provider.PEMValidator).HideValue())
-	checks.Add(provider.OptionalProperty("CLIENTKEY", "clientKey").Validators(provider.PEMValidator).HideValue())
-	checks.Add(provider.OptionalProperty("INSECURE", "insecure").Validators(provider.BoolValidator))
-	checks.Add(provider.OptionalProperty("OS_IDENTITY_API_VERSION").Validators(provider.IntValidator(2, 100))) // not used, but some users might want to set it
-	return &adapter{checks: checks}
-}
-
-func (a *adapter) ProviderType() string {
-	return TYPE_CODE
-}
-
-func (a *adapter) ValidateCredentialsAndProviderConfig(properties utils.Properties, config *runtime.RawExtension) error {
-	if config != nil && len(config.Raw) > 0 {
-		return fmt.Errorf("provider config not supported for %s provider", a.ProviderType())
-	}
-	return a.checks.ValidateProperties(a.ProviderType(), properties)
 }

--- a/pkg/controller/provider/openstack/validation/adaptor.go
+++ b/pkg/controller/provider/openstack/validation/adaptor.go
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validation
+
+import (
+	"fmt"
+
+	"github.com/gardener/controller-manager-library/pkg/utils"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gardener/external-dns-management/pkg/dns/provider"
+)
+
+// ProviderType is the type identifier for the OpenStack Designate DNS provider.
+const ProviderType = "openstack-designate"
+
+type adapter struct {
+	checks *provider.DNSHandlerAdapterChecks
+}
+
+// NewAdapter creates a new DNSHandlerAdapter for the OpenStack Designate provider.
+func NewAdapter() provider.DNSHandlerAdapter {
+	checks := provider.NewDNSHandlerAdapterChecks()
+	checks.Add(provider.RequiredProperty("OS_AUTH_URL", "authURL").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.URLValidator("http", "https"), provider.MaxLengthValidator(256)))
+	checks.Add(provider.OptionalProperty("OS_APPLICATION_CREDENTIAL_ID", "applicationCredentialID").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(128)))
+	checks.Add(provider.OptionalProperty("OS_APPLICATION_CREDENTIAL_NAME", "applicationCredentialName").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(128)))
+	checks.Add(provider.OptionalProperty("OS_APPLICATION_CREDENTIAL_SECRET", "applicationCredentialSecret").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.MaxLengthValidator(128)).
+		HideValue())
+	checks.Add(provider.OptionalProperty("OS_USERNAME", "username").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(128)))
+	checks.Add(provider.OptionalProperty("OS_PASSWORD", "password").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.MaxLengthValidator(128), provider.NoTrailingNewlineValidator).
+		HideValue())
+	checks.Add(provider.OptionalProperty("OS_DOMAIN_NAME", "domainName").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(128)))
+	checks.Add(provider.OptionalProperty("OS_DOMAIN_ID", "domainID").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(128)))
+	// tenantName must not be longer than 64 characters, see https://docs.openstack.org/api-ref/identity/v3/?expanded=show-project-details-detail
+	checks.Add(provider.OptionalProperty("OS_PROJECT_NAME", "tenantName").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(128)))
+	checks.Add(provider.OptionalProperty("OS_PROJECT_ID", "tenantID").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(128)))
+	checks.Add(provider.OptionalProperty("OS_USER_DOMAIN_NAME", "userDomainName").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(128)))
+	checks.Add(provider.OptionalProperty("OS_USER_DOMAIN_ID", "userDomainID").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(128)))
+	checks.Add(provider.OptionalProperty("OS_REGION_NAME").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(128)))
+	checks.Add(provider.OptionalProperty("CACERT", "caCert").Validators(provider.CACertValidator).HideValue())
+	checks.Add(provider.OptionalProperty("CLIENTCERT", "clientCert").Validators(provider.PEMValidator).HideValue())
+	checks.Add(provider.OptionalProperty("CLIENTKEY", "clientKey").Validators(provider.PEMValidator).HideValue())
+	checks.Add(provider.OptionalProperty("INSECURE", "insecure").Validators(provider.BoolValidator))
+	checks.Add(provider.OptionalProperty("OS_IDENTITY_API_VERSION").Validators(provider.IntValidator(2, 100))) // not used, but some users might want to set it
+	return &adapter{checks: checks}
+}
+
+func (a *adapter) ProviderType() string {
+	return ProviderType
+}
+
+func (a *adapter) ValidateCredentialsAndProviderConfig(properties utils.Properties, config *runtime.RawExtension) error {
+	if config != nil && len(config.Raw) > 0 {
+		return fmt.Errorf("provider config not supported for %s provider", a.ProviderType())
+	}
+	return a.checks.ValidateProperties(a.ProviderType(), properties)
+}

--- a/pkg/controller/provider/powerdns/factory.go
+++ b/pkg/controller/provider/powerdns/factory.go
@@ -5,16 +5,12 @@
 package powerdns
 
 import (
-	"fmt"
-
-	"github.com/gardener/controller-manager-library/pkg/utils"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	"github.com/gardener/external-dns-management/pkg/controller/provider/compound"
+	"github.com/gardener/external-dns-management/pkg/controller/provider/powerdns/validation"
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 )
 
-const TYPE_CODE = "powerdns"
+const TYPE_CODE = validation.ProviderType
 
 var rateLimiterDefaults = provider.RateLimiterOptions{
 	Enabled: true,
@@ -22,41 +18,9 @@ var rateLimiterDefaults = provider.RateLimiterOptions{
 	Burst:   10,
 }
 
-var Factory = provider.NewDNSHandlerFactory(TYPE_CODE, NewHandler, newAdapter()).
+var Factory = provider.NewDNSHandlerFactory(NewHandler, validation.NewAdapter()).
 	SetGenericFactoryOptionDefaults(provider.GenericFactoryOptionDefaults.SetRateLimiterOptions(rateLimiterDefaults))
 
 func init() {
 	compound.MustRegister(Factory)
-}
-
-type adapter struct {
-	checks *provider.DNSHandlerAdapterChecks
-}
-
-func newAdapter() provider.DNSHandlerAdapter {
-	checks := provider.NewDNSHandlerAdapterChecks()
-	checks.Add(provider.RequiredProperty("Server", "server").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.URLValidator("https", "http"), provider.MaxLengthValidator(256)))
-	checks.Add(provider.RequiredProperty("ApiKey", "apiKey").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(8192)). // PowerDNS does not impose a maximum length for API keys. Therefore, the typical maximum length of HTTP headers is used.
-		HideValue())
-	checks.Add(provider.OptionalProperty("VirtualHost", "virtualHost").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(128)))
-	checks.Add(provider.OptionalProperty("InsecureSkipVerify", "insecureSkipVerify").
-		Validators(provider.BoolValidator))
-	checks.Add(provider.OptionalProperty("TrustedCaCert", "trustedCaCert").
-		Validators(provider.CACertValidator).
-		HideValue())
-	return &adapter{checks: checks}
-}
-
-func (a *adapter) ProviderType() string {
-	return TYPE_CODE
-}
-
-func (a *adapter) ValidateCredentialsAndProviderConfig(properties utils.Properties, config *runtime.RawExtension) error {
-	if config != nil && len(config.Raw) > 0 {
-		return fmt.Errorf("provider config not supported for %s provider", a.ProviderType())
-	}
-	return a.checks.ValidateProperties(a.ProviderType(), properties)
 }

--- a/pkg/controller/provider/powerdns/validation/adaptor.go
+++ b/pkg/controller/provider/powerdns/validation/adaptor.go
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validation
+
+import (
+	"fmt"
+
+	"github.com/gardener/controller-manager-library/pkg/utils"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gardener/external-dns-management/pkg/dns/provider"
+)
+
+// ProviderType is the type of the PowerDNS provider.
+const ProviderType = "powerdns"
+
+type adapter struct {
+	checks *provider.DNSHandlerAdapterChecks
+}
+
+// NewAdapter creates a new DNSHandlerAdapter for the PowerDNS provider.
+func NewAdapter() provider.DNSHandlerAdapter {
+	checks := provider.NewDNSHandlerAdapterChecks()
+	checks.Add(provider.RequiredProperty("Server", "server").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.URLValidator("https", "http"), provider.MaxLengthValidator(256)))
+	checks.Add(provider.RequiredProperty("ApiKey", "apiKey").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(8192)). // PowerDNS does not impose a maximum length for API keys. Therefore, the typical maximum length of HTTP headers is used.
+		HideValue())
+	checks.Add(provider.OptionalProperty("VirtualHost", "virtualHost").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(128)))
+	checks.Add(provider.OptionalProperty("InsecureSkipVerify", "insecureSkipVerify").
+		Validators(provider.BoolValidator))
+	checks.Add(provider.OptionalProperty("TrustedCaCert", "trustedCaCert").
+		Validators(provider.CACertValidator).
+		HideValue())
+	return &adapter{checks: checks}
+}
+
+func (a *adapter) ProviderType() string {
+	return ProviderType
+}
+
+func (a *adapter) ValidateCredentialsAndProviderConfig(properties utils.Properties, config *runtime.RawExtension) error {
+	if config != nil && len(config.Raw) > 0 {
+		return fmt.Errorf("provider config not supported for %s provider", a.ProviderType())
+	}
+	return a.checks.ValidateProperties(a.ProviderType(), properties)
+}

--- a/pkg/controller/provider/remote/factory.go
+++ b/pkg/controller/provider/remote/factory.go
@@ -5,16 +5,12 @@
 package remote
 
 import (
-	"fmt"
-
-	"github.com/gardener/controller-manager-library/pkg/utils"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	"github.com/gardener/external-dns-management/pkg/controller/provider/compound"
+	"github.com/gardener/external-dns-management/pkg/controller/provider/remote/validation"
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 )
 
-const TYPE_CODE = "remote"
+const TYPE_CODE = validation.ProviderType
 
 var rateLimiterDefaults = provider.RateLimiterOptions{
 	Enabled: true,
@@ -27,44 +23,10 @@ var advancedDefaults = provider.AdvancedOptions{
 	MaxRetries: 7,
 }
 
-var Factory = provider.NewDNSHandlerFactory(TYPE_CODE, NewHandler, newAdapter()).
+var Factory = provider.NewDNSHandlerFactory(NewHandler, validation.NewAdapter()).
 	SetGenericFactoryOptionDefaults(provider.GenericFactoryOptionDefaults.
 		SetRateLimiterOptions(rateLimiterDefaults).SetAdvancedOptions(advancedDefaults))
 
 func init() {
 	compound.MustRegister(Factory)
-}
-
-type adapter struct {
-	checks *provider.DNSHandlerAdapterChecks
-}
-
-func newAdapter() provider.DNSHandlerAdapter {
-	checks := provider.NewDNSHandlerAdapterChecks()
-	checks.Add(provider.RequiredProperty("REMOTE_ENDPOINT", "remoteEndpoint").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(256)))
-	checks.Add(provider.RequiredProperty("CLIENT_CERT", "tls.crt").
-		Validators(provider.PEMValidator).
-		HideValue())
-	checks.Add(provider.RequiredProperty("CLIENT_KEY", "tls.key").
-		Validators(provider.PEMValidator).
-		HideValue())
-	checks.Add(provider.RequiredProperty("NAMESPACE", "namespace").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(64)))
-	checks.Add(provider.OptionalProperty("SERVER_CA_CERT", "ca.crt").
-		Validators(provider.CACertValidator).HideValue())
-	checks.Add(provider.OptionalProperty("OVERRIDE_SERVER_NAME", "overrideServerName").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(64)))
-	return &adapter{checks: checks}
-}
-
-func (a *adapter) ProviderType() string {
-	return TYPE_CODE
-}
-
-func (a *adapter) ValidateCredentialsAndProviderConfig(properties utils.Properties, config *runtime.RawExtension) error {
-	if config != nil && len(config.Raw) > 0 {
-		return fmt.Errorf("provider config not supported for %s provider", a.ProviderType())
-	}
-	return a.checks.ValidateProperties(a.ProviderType(), properties)
 }

--- a/pkg/controller/provider/remote/validation/adaptor.go
+++ b/pkg/controller/provider/remote/validation/adaptor.go
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validation
+
+import (
+	"fmt"
+
+	"github.com/gardener/controller-manager-library/pkg/utils"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gardener/external-dns-management/pkg/dns/provider"
+)
+
+// ProviderType is the type of the Remote DNS provider.
+const ProviderType = "remote"
+
+type adapter struct {
+	checks *provider.DNSHandlerAdapterChecks
+}
+
+// NewAdapter creates a new DNSHandlerAdapter for the Remote DNS provider.
+func NewAdapter() provider.DNSHandlerAdapter {
+	checks := provider.NewDNSHandlerAdapterChecks()
+	checks.Add(provider.RequiredProperty("REMOTE_ENDPOINT", "remoteEndpoint").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(256)))
+	checks.Add(provider.RequiredProperty("CLIENT_CERT", "tls.crt").
+		Validators(provider.PEMValidator).
+		HideValue())
+	checks.Add(provider.RequiredProperty("CLIENT_KEY", "tls.key").
+		Validators(provider.PEMValidator).
+		HideValue())
+	checks.Add(provider.RequiredProperty("NAMESPACE", "namespace").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(64)))
+	checks.Add(provider.OptionalProperty("SERVER_CA_CERT", "ca.crt").
+		Validators(provider.CACertValidator).HideValue())
+	checks.Add(provider.OptionalProperty("OVERRIDE_SERVER_NAME", "overrideServerName").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(64)))
+	return &adapter{checks: checks}
+}
+
+func (a *adapter) ProviderType() string {
+	return ProviderType
+}
+
+func (a *adapter) ValidateCredentialsAndProviderConfig(properties utils.Properties, config *runtime.RawExtension) error {
+	if config != nil && len(config.Raw) > 0 {
+		return fmt.Errorf("provider config not supported for %s provider", a.ProviderType())
+	}
+	return a.checks.ValidateProperties(a.ProviderType(), properties)
+}

--- a/pkg/controller/provider/rfc2136/factory.go
+++ b/pkg/controller/provider/rfc2136/factory.go
@@ -5,17 +5,12 @@
 package rfc2136
 
 import (
-	"fmt"
-
-	"github.com/gardener/controller-manager-library/pkg/utils"
-	miekgdns "github.com/miekg/dns"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	"github.com/gardener/external-dns-management/pkg/controller/provider/compound"
+	"github.com/gardener/external-dns-management/pkg/controller/provider/rfc2136/validation"
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 )
 
-const TYPE_CODE = "rfc2136"
+const TYPE_CODE = validation.ProviderType
 
 var rateLimiterDefaults = provider.RateLimiterOptions{
 	Enabled: true,
@@ -23,59 +18,9 @@ var rateLimiterDefaults = provider.RateLimiterOptions{
 	Burst:   10,
 }
 
-var Factory = provider.NewDNSHandlerFactory(TYPE_CODE, NewHandler, newAdapter()).
+var Factory = provider.NewDNSHandlerFactory(NewHandler, validation.NewAdapter()).
 	SetGenericFactoryOptionDefaults(provider.GenericFactoryOptionDefaults.SetRateLimiterOptions(rateLimiterDefaults))
 
 func init() {
 	compound.MustRegister(Factory)
-}
-
-type adapter struct {
-	checks *provider.DNSHandlerAdapterChecks
-}
-
-func newAdapter() provider.DNSHandlerAdapter {
-	checks := provider.NewDNSHandlerAdapterChecks()
-	checks.Add(provider.RequiredProperty("Server").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(256)))
-	checks.Add(provider.RequiredProperty("Zone").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(256), zoneValidator))
-	checks.Add(provider.RequiredProperty("TSIGKeyName").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(256), fqdnValidator))
-	checks.Add(provider.RequiredProperty("TSIGSecret").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.MaxLengthValidator(128)).
-		HideValue())
-	checks.Add(provider.OptionalProperty("TSIGSecretAlgorithm").
-		Validators(algorithmValidator))
-	return &adapter{checks: checks}
-}
-
-func (a *adapter) ProviderType() string {
-	return TYPE_CODE
-}
-
-func (a *adapter) ValidateCredentialsAndProviderConfig(properties utils.Properties, config *runtime.RawExtension) error {
-	if config != nil && len(config.Raw) > 0 {
-		return fmt.Errorf("provider config not supported for %s provider", a.ProviderType())
-	}
-	return a.checks.ValidateProperties(a.ProviderType(), properties)
-}
-
-func zoneValidator(value string) error {
-	if value != miekgdns.CanonicalName(value) {
-		return fmt.Errorf("zone must be given in canonical form: '%s' instead of '%s'", miekgdns.CanonicalName(value), value)
-	}
-	return nil
-}
-
-func fqdnValidator(value string) error {
-	if value != miekgdns.Fqdn(value) {
-		return fmt.Errorf("TSIGKeyName must end with '.'")
-	}
-	return nil
-}
-
-func algorithmValidator(value string) error {
-	_, err := findTsigAlgorithm(value)
-	return err
 }

--- a/pkg/controller/provider/rfc2136/validation/adaptor.go
+++ b/pkg/controller/provider/rfc2136/validation/adaptor.go
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validation
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gardener/controller-manager-library/pkg/utils"
+	miekgdns "github.com/miekg/dns"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gardener/external-dns-management/pkg/dns/provider"
+)
+
+// ProviderType is the type of the RFC2136 DNS provider.
+const ProviderType = "rfc2136"
+
+type adapter struct {
+	checks *provider.DNSHandlerAdapterChecks
+}
+
+// NewAdapter creates a new DNSHandlerAdapter for the RFC2136 DNS provider.
+func NewAdapter() provider.DNSHandlerAdapter {
+	checks := provider.NewDNSHandlerAdapterChecks()
+	checks.Add(provider.RequiredProperty("Server").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(256)))
+	checks.Add(provider.RequiredProperty("Zone").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(256), zoneValidator))
+	checks.Add(provider.RequiredProperty("TSIGKeyName").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(256), fqdnValidator))
+	checks.Add(provider.RequiredProperty("TSIGSecret").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.MaxLengthValidator(128)).
+		HideValue())
+	checks.Add(provider.OptionalProperty("TSIGSecretAlgorithm").
+		Validators(algorithmValidator))
+	return &adapter{checks: checks}
+}
+
+func (a *adapter) ProviderType() string {
+	return ProviderType
+}
+
+func (a *adapter) ValidateCredentialsAndProviderConfig(properties utils.Properties, config *runtime.RawExtension) error {
+	if config != nil && len(config.Raw) > 0 {
+		return fmt.Errorf("provider config not supported for %s provider", a.ProviderType())
+	}
+	return a.checks.ValidateProperties(a.ProviderType(), properties)
+}
+
+func zoneValidator(value string) error {
+	if value != miekgdns.CanonicalName(value) {
+		return fmt.Errorf("zone must be given in canonical form: '%s' instead of '%s'", miekgdns.CanonicalName(value), value)
+	}
+	return nil
+}
+
+func fqdnValidator(value string) error {
+	if value != miekgdns.Fqdn(value) {
+		return fmt.Errorf("TSIGKeyName must end with '.'")
+	}
+	return nil
+}
+
+func algorithmValidator(value string) error {
+	_, err := FindTsigAlgorithm(value)
+	return err
+}
+
+// tsigAlgs are the supported TSIG algorithms
+var tsigAlgs = []string{miekgdns.HmacSHA1, miekgdns.HmacSHA224, miekgdns.HmacSHA256, miekgdns.HmacSHA384, miekgdns.HmacSHA512}
+
+func FindTsigAlgorithm(alg string) (string, error) {
+	if alg == "" {
+		return miekgdns.HmacSHA256, nil
+	}
+
+	fqdnAlg := miekgdns.Fqdn(alg)
+	for _, a := range tsigAlgs {
+		if fqdnAlg == a {
+			return fqdnAlg, nil
+		}
+	}
+	return "", fmt.Errorf("invalid TSIG secret algorithm: %s (supported: %s)", alg, strings.ReplaceAll(strings.Join(tsigAlgs, ","), ".", ""))
+}

--- a/pkg/dns/provider/factory.go
+++ b/pkg/dns/provider/factory.go
@@ -28,13 +28,13 @@ type Factory struct {
 
 var _ DNSHandlerFactory = &Factory{}
 
-func NewDNSHandlerFactory(typecode string, create DNSHandlerCreatorFunction, adapter DNSHandlerAdapter, disableZoneStateCache ...bool) *Factory {
+func NewDNSHandlerFactory(create DNSHandlerCreatorFunction, adapter DNSHandlerAdapter, disableZoneStateCache ...bool) *Factory {
 	disable := false
 	for _, b := range disableZoneStateCache {
 		disable = disable || b
 	}
 	return &Factory{
-		typecode:              typecode,
+		typecode:              adapter.ProviderType(),
 		create:                create,
 		adapter:               adapter,
 		supportZoneStateCache: !disable,

--- a/pkg/dns/provider/provider_suite_test.go
+++ b/pkg/dns/provider/provider_suite_test.go
@@ -7,11 +7,13 @@ package provider
 import (
 	"testing"
 
+	cmllogger "github.com/gardener/controller-manager-library/pkg/logger"
 	ginkgov2 "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 func TestUtilsSuite(t *testing.T) {
 	RegisterFailHandler(ginkgov2.Fail)
+	cmllogger.SetOutput(ginkgov2.GinkgoWriter)
 	ginkgov2.RunSpecs(t, "Provider Suite")
 }

--- a/pkg/dnsman2/apis/dns/crd-dns.gardener.cloud_dnsproviders.yaml
+++ b/pkg/dnsman2/apis/dns/crd-dns.gardener.cloud_dnsproviders.yaml
@@ -136,8 +136,10 @@ spec:
                 - azure-dns
                 - azure-private-dns
                 - cloudflare-dns
+                - gdch-dns
                 - google-clouddns
                 - infoblox-dns
+                - local
                 - mock-inmemory
                 - netlify-dns
                 - openstack-designate


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
- Refactor `DNSHandlerAdapter` implementations to avoid provider specific dependencies on reuse. The adaptors have been moved to own packages.
- Fix `RequiredIfUnset` for properties with aliases
- Allow values `local` and `gdch-dns` for provider types to simplify dealing with these types used in special environments

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Refactor `DNSHandlerAdapter` implementations to avoid provider specific dependencies on reuse.
```

```other operator
Allow values `local` and `gdch-dns` for provider types
```