### PR TITLE
feat: Validate `DNSAnnotation` data fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,8 +482,8 @@ The handling of this resource is done by a dedicated controller, the `annotation
 controller. It caches the annotation settings declared by those objects and
 makes them accessible for the DNS source controllers.
 
-The DNS source controller responsible for a dedicated kind of resource
-,for example Service, reads the object, analyses the annotations, and then decides
+The DNS source controller responsible for a dedicated kind of resource, 
+for example Service, reads the object, analyses the annotations, and then decides
 what to do with it. Most of the flow is handled by a central library, only
 some dedicated resource dependent steps are implemented separately by a
 dedicated source controller. The `DNSAnnotation` resource slightly extends this

--- a/charts/external-dns-management/templates/crds.yaml
+++ b/charts/external-dns-management/templates/crds.yaml
@@ -329,24 +329,48 @@ spec:
               annotations:
                 additionalProperties:
                   type: string
+                description: Annotations to be added to the referenced resource.
+                maxProperties: 20
+                minProperties: 1
                 type: object
               resourceRef:
+                description: ResourceRef specifies the resource that should be annotated.
                 properties:
                   apiVersion:
                     description: API Version of the annotated object
+                    enum:
+                    - v1
+                    - networking.k8s.io/v1
+                    - gateway.networking.k8s.io/v1
+                    - gateway.networking.k8s.io/v1beta1
+                    - networking.istio.io/v1
+                    - networking.istio.io/v1beta1
+                    - networking.istio.io/v1alpha3
                     type: string
                   kind:
                     description: |-
                       Kind of the annotated object
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    enum:
+                    - Service
+                    - Ingress
+                    - Gateway
                     type: string
                   name:
-                    description: Name of the annotated object
+                    description: |-
+                      Name of the annotated object
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
                   namespace:
                     description: |-
-                      Namspace of the annotated object
+                      Namespace of the annotated object
                       Defaulted by the namespace of the containing resource.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
+                    maxLength: 63
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
                 required:
                 - apiVersion
@@ -359,7 +383,7 @@ spec:
           status:
             properties:
               active:
-                description: Indicates that annotation is observed by a DNS sorce
+                description: Indicates that annotation is observed by a DNS source
                   controller
                 type: boolean
               message:

--- a/pkg/apis/dns/crds/dns.gardener.cloud_dnsannotations.yaml
+++ b/pkg/apis/dns/crds/dns.gardener.cloud_dnsannotations.yaml
@@ -61,24 +61,48 @@ spec:
               annotations:
                 additionalProperties:
                   type: string
+                description: Annotations to be added to the referenced resource.
+                maxProperties: 20
+                minProperties: 1
                 type: object
               resourceRef:
+                description: ResourceRef specifies the resource that should be annotated.
                 properties:
                   apiVersion:
                     description: API Version of the annotated object
+                    enum:
+                    - v1
+                    - networking.k8s.io/v1
+                    - gateway.networking.k8s.io/v1
+                    - gateway.networking.k8s.io/v1beta1
+                    - networking.istio.io/v1
+                    - networking.istio.io/v1beta1
+                    - networking.istio.io/v1alpha3
                     type: string
                   kind:
                     description: |-
                       Kind of the annotated object
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    enum:
+                    - Service
+                    - Ingress
+                    - Gateway
                     type: string
                   name:
-                    description: Name of the annotated object
+                    description: |-
+                      Name of the annotated object
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
                   namespace:
                     description: |-
-                      Namspace of the annotated object
+                      Namespace of the annotated object
                       Defaulted by the namespace of the containing resource.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
+                    maxLength: 63
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
                 required:
                 - apiVersion
@@ -91,7 +115,7 @@ spec:
           status:
             properties:
               active:
-                description: Indicates that annotation is observed by a DNS sorce
+                description: Indicates that annotation is observed by a DNS source
                   controller
                 type: boolean
               message:

--- a/pkg/apis/dns/crds/zz_generated_crds.go
+++ b/pkg/apis/dns/crds/zz_generated_crds.go
@@ -77,24 +77,48 @@ spec:
               annotations:
                 additionalProperties:
                   type: string
+                description: Annotations to be added to the referenced resource.
+                maxProperties: 20
+                minProperties: 1
                 type: object
               resourceRef:
+                description: ResourceRef specifies the resource that should be annotated.
                 properties:
                   apiVersion:
                     description: API Version of the annotated object
+                    enum:
+                    - v1
+                    - networking.k8s.io/v1
+                    - gateway.networking.k8s.io/v1
+                    - gateway.networking.k8s.io/v1beta1
+                    - networking.istio.io/v1
+                    - networking.istio.io/v1beta1
+                    - networking.istio.io/v1alpha3
                     type: string
                   kind:
                     description: |-
                       Kind of the annotated object
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    enum:
+                    - Service
+                    - Ingress
+                    - Gateway
                     type: string
                   name:
-                    description: Name of the annotated object
+                    description: |-
+                      Name of the annotated object
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
                   namespace:
                     description: |-
-                      Namspace of the annotated object
+                      Namespace of the annotated object
                       Defaulted by the namespace of the containing resource.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
+                    maxLength: 63
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
                 required:
                 - apiVersion
@@ -107,7 +131,7 @@ spec:
           status:
             properties:
               active:
-                description: Indicates that annotation is observed by a DNS sorce
+                description: Indicates that annotation is observed by a DNS source
                   controller
                 type: boolean
               message:

--- a/pkg/apis/dns/v1alpha1/dnsannotation.go
+++ b/pkg/apis/dns/v1alpha1/dnsannotation.go
@@ -40,27 +40,39 @@ type DNSAnnotation struct {
 }
 
 type DNSAnnotationSpec struct {
+	// ResourceRef specifies the resource that should be annotated.
 	ResourceRef ResourceReference `json:"resourceRef"`
+	// Annotations to be added to the referenced resource.
+	// +kubebuilder:validation:MinProperties=1
+	// +kubebuilder:validation:MaxProperties=20
 	Annotations map[string]string `json:"annotations"`
 }
 
 type ResourceReference struct {
 	// API Version of the annotated object
+	// +kubebuilder:validation:Enum=v1;networking.k8s.io/v1;gateway.networking.k8s.io/v1;networking.istio.io/v1
 	APIVersion string `json:"apiVersion"`
 	// Kind of the annotated object
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+	// +kubebuilder:validation:Enum=Service,Ingress,Gateway
 	Kind string `json:"kind"`
 	// Name of the annotated object
-	// +optional
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
 	Name string `json:"name,omitempty"`
-	// Namspace of the annotated object
+	// Namespace of the annotated object
 	// Defaulted by the namespace of the containing resource.
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
 	// +optional
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
 	Namespace string `json:"namespace,omitempty"`
 }
 
 type DNSAnnotationStatus struct {
-	// Indicates that annotation is observed by a DNS sorce controller
+	// Indicates that annotation is observed by a DNS source controller
 	// +optional
 	Active bool `json:"active,omitempty"`
 	// In case of a configuration problem this field describes the reason

--- a/pkg/apis/dns/v1alpha1/dnsannotation.go
+++ b/pkg/apis/dns/v1alpha1/dnsannotation.go
@@ -54,7 +54,7 @@ type ResourceReference struct {
 	APIVersion string `json:"apiVersion"`
 	// Kind of the annotated object
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	// +kubebuilder:validation:Enum=Service,Ingress,Gateway
+	// +kubebuilder:validation:Enum=Service;Ingress;Gateway
 	Kind string `json:"kind"`
 	// Name of the annotated object
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names

--- a/pkg/apis/dns/v1alpha1/dnsannotation.go
+++ b/pkg/apis/dns/v1alpha1/dnsannotation.go
@@ -50,7 +50,7 @@ type DNSAnnotationSpec struct {
 
 type ResourceReference struct {
 	// API Version of the annotated object
-	// +kubebuilder:validation:Enum=v1;networking.k8s.io/v1;gateway.networking.k8s.io/v1;networking.istio.io/v1
+	// +kubebuilder:validation:Enum=v1;networking.k8s.io/v1;gateway.networking.k8s.io/v1;gateway.networking.k8s.io/v1beta1;networking.istio.io/v1;networking.istio.io/v1beta1;networking.istio.io/v1alpha3
 	APIVersion string `json:"apiVersion"`
 	// Kind of the annotated object
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds

--- a/pkg/controller/annotation/controller.go
+++ b/pkg/controller/annotation/controller.go
@@ -5,6 +5,8 @@
 package annotation
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/gardener/controller-manager-library/pkg/config"
@@ -86,6 +88,9 @@ func (this *reconciler) Setup() error {
 ///////////////////////////////////////////////////////////////////////////////
 
 func (this *reconciler) Reconcile(logger logger.LogContext, obj resources.Object) reconcile.Status {
+	if err := this.validate(obj); err != nil {
+		return this.handleValidationError(logger, obj, err)
+	}
 	err := this.annotations.Add(logger, obj)
 	return reconcile.FailedOnError(logger, err)
 }
@@ -98,4 +103,43 @@ func (this *reconciler) Delete(logger logger.LogContext, obj resources.Object) r
 func (this *reconciler) Deleted(logger logger.LogContext, key resources.ClusterObjectKey) reconcile.Status {
 	this.annotations.Remove(logger, key)
 	return reconcile.Succeeded(logger)
+}
+
+func (this *reconciler) validate(obj resources.Object) error {
+	dnsAnnotation, ok := obj.Data().(*api.DNSAnnotation)
+
+	if !ok {
+		return fmt.Errorf("not a DNSAnnotation, unexpected type: %T", obj)
+	}
+
+	for annotation, _ := range dnsAnnotation.Spec.Annotations {
+		group := strings.SplitN(annotation, "/", 2)[0]
+
+		switch group {
+		case dns.ANNOTATION_GROUP:
+		case dns.AnnotationServiceBetaGroup:
+		case dns.AnnotationOpenStackLoadBalancerGroup:
+			continue
+		default:
+			return fmt.Errorf("annotation %q is not allowed in DNSAnnotation", annotation)
+		}
+	}
+
+	return nil
+}
+
+func (this *reconciler) handleValidationError(logger logger.LogContext, obj resources.Object, validationError error) reconcile.Status {
+	_, err := obj.ModifyStatus(func(data resources.ObjectData) (bool, error) {
+		dnsAnnotation := data.(*api.DNSAnnotation)
+		message := fmt.Sprintf("invalid DNSAnnotation: %s", validationError)
+		if message != dnsAnnotation.Status.Message {
+			dnsAnnotation.Status.Message = message
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return reconcile.Failed(logger, err)
+	}
+	return reconcile.Failed(logger, validationError)
 }

--- a/pkg/controller/annotation/controller.go
+++ b/pkg/controller/annotation/controller.go
@@ -112,7 +112,7 @@ func (this *reconciler) validate(obj resources.Object) error {
 		return fmt.Errorf("not a DNSAnnotation, unexpected type: %T", obj)
 	}
 
-	for annotation, _ := range dnsAnnotation.Spec.Annotations {
+	for annotation := range dnsAnnotation.Spec.Annotations {
 		group := strings.SplitN(annotation, "/", 2)[0]
 
 		switch group {

--- a/pkg/controller/annotation/controller.go
+++ b/pkg/controller/annotation/controller.go
@@ -89,6 +89,7 @@ func (this *reconciler) Setup() error {
 
 func (this *reconciler) Reconcile(logger logger.LogContext, obj resources.Object) reconcile.Status {
 	if err := this.validate(obj); err != nil {
+		this.annotations.Remove(logger, obj.ClusterKey())
 		return this.handleValidationError(logger, obj, err)
 	}
 	err := this.annotations.Add(logger, obj)

--- a/pkg/controller/source/service/handler.go
+++ b/pkg/controller/source/service/handler.go
@@ -38,14 +38,14 @@ func GetTargets(_ logger.LogContext, obj resources.ObjectData, names dns.DNSName
 	set := utils.StringSet{}
 	for _, i := range svc.Status.LoadBalancer.Ingress {
 		if i.Hostname != "" && i.IP == "" {
-			if svc.Annotations["loadbalancer.openstack.org/load-balancer-address"] != "" {
+			if svc.Annotations[dns.AnnotationOpenStackLoadBalancerAddress] != "" {
 				// Support for PROXY protocol on Openstack (which needs a hostname as ingress)
 				// If the user sets the annotation `loadbalancer.openstack.org/hostname`, the
 				// annotation `loadbalancer.openstack.org/load-balancer-address` contains the IP address.
 				// This address can then be used to create a DNS record for the hostname specified both
 				// in annotation `loadbalancer.openstack.org/hostname` and `dns.gardener.cloud/dnsnames`
 				// see https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md#service-annotations
-				set.Add(svc.Annotations["loadbalancer.openstack.org/load-balancer-address"])
+				set.Add(svc.Annotations[dns.AnnotationOpenStackLoadBalancerAddress])
 			} else {
 				set.Add(i.Hostname)
 			}
@@ -58,7 +58,7 @@ func GetTargets(_ logger.LogContext, obj resources.ObjectData, names dns.DNSName
 	if svc.Annotations[dns.AnnotationIPStack] != "" {
 		ipstack = svc.Annotations[dns.AnnotationIPStack]
 	}
-	if svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-ip-address-type"] == "dualstack" {
+	if svc.Annotations[dns.AnnotationAwsLoadBalancerIpAddressType] == dns.AnnotationAwsLoadBalancerIpAddressTypeValueDualStack {
 		ipstack = dns.AnnotationValueIPStackIPDualStack
 	}
 	if v := svc.Annotations[source.RESOLVE_TARGETS_TO_ADDRS_ANNOTATION]; v != "" {

--- a/pkg/dns/const.go
+++ b/pkg/dns/const.go
@@ -48,4 +48,24 @@ const (
 
 	// AnnotationValidationError is an optional annotation for replicated provider secrets to indicate a validation error.
 	AnnotationValidationError = ANNOTATION_GROUP + "/validation-error"
+
+	// AnnotationServiceBetaGroup is the group for beta Service annotations.
+	AnnotationServiceBetaGroup = "service.beta.kubernetes.io"
+	// AnnotationAwsLoadBalancerIpAddressType is an optional annotation for AWS LoadBalancer Services to specify the IP address type.
+	// Values are 'ipv4' and 'dual-stack'. If not specified, 'ipv4' is assumed.
+	// Behaves similar to dns.gardener.cloud/ip-stack=dual-stack
+	AnnotationAwsLoadBalancerIpAddressType = AnnotationServiceBetaGroup + "/aws-load-balancer-ip-address-type"
+	// AnnotationAwsLoadBalancerIpAddressTypeValueDualStack is the value for the annotation to specify dual-stack IP address type.
+	AnnotationAwsLoadBalancerIpAddressTypeValueDualStack = "dualstack"
+
+	// AnnotationOpenStackLoadBalancerGroup is the group for OpenStack LoadBalancer Service annotations.
+	AnnotationOpenStackLoadBalancerGroup = "loadbalancer.openstack.org"
+	// AnnotationOpenStackLoadBalancerAddress is an optional annotation for OpenStack LoadBalancer Services to specify the load balancer address.
+	// Support for PROXY protocol on Openstack (which needs a hostname as ingress)
+	// If the user sets the annotation `loadbalancer.openstack.org/hostname`, the
+	// annotation `loadbalancer.openstack.org/load-balancer-address` contains the IP address.
+	// This address can then be used to create a DNS record for the hostname specified both
+	// in annotation `loadbalancer.openstack.org/hostname` and `dns.gardener.cloud/dnsnames`
+	// see https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md#service-annotations
+	AnnotationOpenStackLoadBalancerAddress = AnnotationOpenStackLoadBalancerGroup + "/load-balancer-address"
 )

--- a/pkg/dnsman2/apis/dns/crd-dns.gardener.cloud_dnsannotations.yaml
+++ b/pkg/dnsman2/apis/dns/crd-dns.gardener.cloud_dnsannotations.yaml
@@ -61,24 +61,48 @@ spec:
               annotations:
                 additionalProperties:
                   type: string
+                description: Annotations to be added to the referenced resource.
+                maxProperties: 20
+                minProperties: 1
                 type: object
               resourceRef:
+                description: ResourceRef specifies the resource that should be annotated.
                 properties:
                   apiVersion:
                     description: API Version of the annotated object
+                    enum:
+                    - v1
+                    - networking.k8s.io/v1
+                    - gateway.networking.k8s.io/v1
+                    - gateway.networking.k8s.io/v1beta1
+                    - networking.istio.io/v1
+                    - networking.istio.io/v1beta1
+                    - networking.istio.io/v1alpha3
                     type: string
                   kind:
                     description: |-
                       Kind of the annotated object
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    enum:
+                    - Service
+                    - Ingress
+                    - Gateway
                     type: string
                   name:
-                    description: Name of the annotated object
+                    description: |-
+                      Name of the annotated object
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
                   namespace:
                     description: |-
-                      Namspace of the annotated object
+                      Namespace of the annotated object
                       Defaulted by the namespace of the containing resource.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
+                    maxLength: 63
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
                 required:
                 - apiVersion
@@ -91,7 +115,7 @@ spec:
           status:
             properties:
               active:
-                description: Indicates that annotation is observed by a DNS sorce
+                description: Indicates that annotation is observed by a DNS source
                   controller
                 type: boolean
               message:

--- a/test/integration/source/dnsentry_test.go
+++ b/test/integration/source/dnsentry_test.go
@@ -325,8 +325,8 @@ var _ = Describe("DNSEntry source and DNSProvider replication controller tests",
 				},
 				Spec: v1alpha1.DNSAnnotationSpec{
 					ResourceRef: v1alpha1.ResourceReference{
-						APIVersion: "v1alpha1",
-						Kind:       "DNSEntry",
+						APIVersion: "v1",
+						Kind:       "Service",
 						Name:       "does-not-need-to-exist",
 						Namespace:  testRunID,
 					},

--- a/test/integration/source/dnsentry_test.go
+++ b/test/integration/source/dnsentry_test.go
@@ -120,7 +120,7 @@ var _ = Describe("DNSEntry source and DNSProvider replication controller tests",
 				"--target", tc2.kubeconfigFile,
 				"--target.id=target-id",
 				"--target.disable-deploy-crds",
-				"--controllers", "compound,dnsentry-source,dnsprovider-replication",
+				"--controllers", "compound,dnsentry-source,dnsprovider-replication,annotation",
 				"--omit-lease",
 				"--dns-delay", "1s",
 				"--reschedule-delay", "2s",
@@ -312,5 +312,58 @@ var _ = Describe("DNSEntry source and DNSProvider replication controller tests",
 			g.Expect(provider2.Status.State).To(Equal("Error"))
 			g.Expect(provider2.Status.Message).To(PointTo(ContainSubstring("bad_key")))
 		}).To(Succeed())
+	})
+
+	Context("DNSAnnotation", func() {
+		var dnsAnnotation *v1alpha1.DNSAnnotation
+
+		BeforeEach(func() {
+			dnsAnnotation = &v1alpha1.DNSAnnotation{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:    testRunID,
+					GenerateName: "dnsentry-annotation-",
+				},
+				Spec: v1alpha1.DNSAnnotationSpec{
+					ResourceRef: v1alpha1.ResourceReference{
+						APIVersion: "v1alpha1",
+						Kind:       "DNSEntry",
+						Name:       "does-not-need-to-exist",
+						Namespace:  testRunID,
+					},
+				},
+			}
+		})
+
+		It("rejects unknown annotation groups", func() {
+			dnsAnnotation.Spec.Annotations = map[string]string{
+				"not.recognized.cloud": "will-be-rejected",
+			}
+			Expect(tc1.client.Create(ctx, dnsAnnotation)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(tc1.client.Delete(ctx, dnsAnnotation)).To(Succeed())
+			})
+
+			Eventually(func(g Gomega) {
+				g.Expect(tc1.client.Get(ctx, client.ObjectKeyFromObject(dnsAnnotation), dnsAnnotation)).To(Succeed())
+				g.Expect(dnsAnnotation.Status.Message).To(ContainSubstring("invalid DNSAnnotation"))
+			}).Should(Succeed())
+		})
+
+		It("recognizes known annotation groups", func() {
+			dnsAnnotation.Spec.Annotations = map[string]string{
+				"dns.gardener.cloud/foo":         "bar",
+				"service.beta.kubernetes.io/foo": "bar",
+				"loadbalancer.openstack.org/foo": "bar",
+			}
+			Expect(tc1.client.Create(ctx, dnsAnnotation)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(tc1.client.Delete(ctx, dnsAnnotation)).To(Succeed())
+			})
+
+			Consistently(func(g Gomega) {
+				g.Expect(tc1.client.Get(ctx, client.ObjectKeyFromObject(dnsAnnotation), dnsAnnotation)).To(Succeed())
+				g.Expect(dnsAnnotation.Status.Message).To(BeEmpty())
+			}).WithTimeout(1 * time.Second)
+		})
 	})
 })

--- a/test/integration/source/dnsentry_test.go
+++ b/test/integration/source/dnsentry_test.go
@@ -363,7 +363,7 @@ var _ = Describe("DNSEntry source and DNSProvider replication controller tests",
 			Consistently(func(g Gomega) {
 				g.Expect(tc1.client.Get(ctx, client.ObjectKeyFromObject(dnsAnnotation), dnsAnnotation)).To(Succeed())
 				g.Expect(dnsAnnotation.Status.Message).To(BeEmpty())
-			}).WithTimeout(1 * time.Second)
+			}).WithTimeout(1 * time.Second).Should(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement task

**What this PR does / why we need it**:

Introduces validation for data fields in the `DNSAnnotation` resource.
Primarily, using [kubebuilder validations](https://book.kubebuilder.io/reference/markers/crd-validation) and a new validation check in the `DNSAnnotation` controller to check for known annotation groups.

**Which issue(s) this PR fixes**:

Fixes #549

**Special notes for your reviewer**:

/cc @MartinWeindel 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Introduced validation of data fields in the `DNSAnnotation` resource.
```
