### PR TITLE
Add `set -o pipefail` to react on `make generate` failure

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,7 +74,7 @@ jobs:
       - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
       - name: run-verify
         run: |
-          set -eu
+          set -euo pipefail
           mkdir /tmp/blobs.d
           .ci/verify |& tee /tmp/blobs.d/verify-log.txt
           tar czf /tmp/blobs.d/verify-log.tar.gz -C/tmp/blobs.d verify-log.txt
@@ -106,7 +106,7 @@ jobs:
       - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
       - name: run-check
         run: |
-          set -eu
+          set -euo pipefail
           mkdir /tmp/blobs.d
           .ci/check |& tee /tmp/blobs.d/check-log.txt
           # check calls `make sast-report`, which generates `gosec-report.sarif`

--- a/pkg/dnsman2/dns/provider/handler/google/execution.go
+++ b/pkg/dnsman2/dns/provider/handler/google/execution.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gardener/controller-manager-library/pkg/utils"
 	"github.com/go-logr/logr"
 	googledns "google.golang.org/api/dns/v1"
 	"google.golang.org/api/googleapi"
@@ -100,14 +99,14 @@ func (ex *execution) prepareSubmission(rrsetGetter rrsetGetterFunc) error {
 	}
 
 	for _, c := range ex.change.Deletions {
-		ex.log.Info(fmt.Sprintf("desired change: Deletion %s %s: %s", c.Name, c.Type, utils.Strings(c.Rrdatas...)))
+		ex.log.Info(fmt.Sprintf("desired change: Deletion %s %s: %s", c.Name, c.Type, toStrings(c.Rrdatas...)))
 	}
 	for _, c := range routingPolicyDeletions {
 		ex.log.Info(fmt.Sprintf("desired change: Deletion %s %s (routing policy: %s)", c.Name, c.Type, describeRoutingPolicy(c)))
 		ex.change.Deletions = append(ex.change.Deletions, c)
 	}
 	for _, c := range ex.change.Additions {
-		ex.log.Info(fmt.Sprintf("desired change: Addition %s %s: %s", c.Name, c.Type, utils.Strings(c.Rrdatas...)))
+		ex.log.Info(fmt.Sprintf("desired change: Addition %s %s: %s", c.Name, c.Type, toStrings(c.Rrdatas...)))
 	}
 	for _, c := range routingPolicyAdditions {
 		ex.log.Info(fmt.Sprintf("desired change: Addition %s %s (routing policy: %s)", c.Name, c.Type, describeRoutingPolicy(c)))
@@ -236,4 +235,8 @@ func mapRecordSet(name dns.DNSSetName, rs *dns.RecordSet, policy *googleRoutingP
 	}
 	rrset = mapPolicyRecordSet(rrset, policy)
 	return rrset
+}
+
+func toStrings(s ...string) string {
+	return "[" + strings.Join(s, ", ") + "]"
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind task

**What this PR does / why we need it**:
The `build` workflow reports success, even if `make generate` fails in the `verify` job.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
