### PR TITLE
Improve handling on deletion of stale `DNSEntries`

### DIFF
--- a/pkg/dns/provider/entry.go
+++ b/pkg/dns/provider/entry.go
@@ -465,7 +465,11 @@ func (this *EntryVersion) Setup(logger logger.LogContext, state *state, p *Entry
 	if this.IsDeleting() {
 		logger.Infof("update state to %s", api.STATE_DELETING)
 		this.status.State = api.STATE_DELETING
-		this.status.Message = StatusMessage("entry is scheduled to be deleted")
+		msg := "entry is scheduled to be deleted"
+		if this.obsolete {
+			msg += "; no suitable provider available"
+		}
+		this.status.Message = StatusMessage(msg)
 		this.valid = true
 		state.DeleteLookupJob(this.object.ObjectName())
 	} else {

--- a/pkg/dns/provider/state_entry.go
+++ b/pkg/dns/provider/state_entry.go
@@ -372,7 +372,11 @@ func (this *state) cleanupEntry(logger logger.LogContext, e *Entry, oldDNSSet *d
 			}
 		}
 		if txn := this.getActiveZoneTransaction(e.activezone); txn != nil {
-			txn.AddEntryChange(e.ObjectKey(), e.object.GetGeneration(), oldDNSSet, nil)
+			if !e.obsolete {
+				txn.AddEntryChange(e.ObjectKey(), e.object.GetGeneration(), oldDNSSet, nil)
+			} else {
+				logger.Warnf("cannot cleanup stale entry %s(%s)", e.ObjectName(), e.DNSSetName())
+			}
 		}
 		if found == nil {
 			logger.Infof("no duplicate found to reactivate")

--- a/test/integration/testenv.go
+++ b/test/integration/testenv.go
@@ -758,6 +758,9 @@ func (te *TestEnv) HasProviderState(name string, states ...string) (bool, error)
 	if err != nil {
 		return false, err
 	}
+	if provider.Status.ObservedGeneration != provider.Generation {
+		return false, fmt.Errorf("provider status not updated to latest generation")
+	}
 	found := false
 	for _, state := range states {
 		found = found || provider.Status.State == state


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Deleting a `DNSEntry` in state `Stale` is now blocked if its `dnsName` does not match the domain restrictions of the available `DNSProviders`. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Improve handling on deletion of stale `DNSEntries`. The deletion is blocked if domain restrictions of available `DNSProvider` do not match.
```
