### PR TITLE
[Controller-Runtime-Rewrite] Add handler for `openstack-designate`

### DIFF
--- a/pkg/controller/provider/openstack/validation/adaptor.go
+++ b/pkg/controller/provider/openstack/validation/adaptor.go
@@ -43,7 +43,7 @@ func NewAdapter() provider.DNSHandlerAdapter {
 		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(128)))
 	// tenantName must not be longer than 64 characters, see https://docs.openstack.org/api-ref/identity/v3/?expanded=show-project-details-detail
 	checks.Add(provider.OptionalProperty("OS_PROJECT_NAME", "tenantName").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(128)))
+		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(64)))
 	checks.Add(provider.OptionalProperty("OS_PROJECT_ID", "tenantID").
 		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(128)))
 	checks.Add(provider.OptionalProperty("OS_USER_DOMAIN_NAME", "userDomainName").

--- a/pkg/dnsman2/controller/dnsprovider/controlplane/add.go
+++ b/pkg/dnsman2/controller/dnsprovider/controlplane/add.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/handler/aws"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/handler/google"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/handler/openstack"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/state"
 )
 
@@ -37,8 +38,9 @@ import (
 const ControllerName = "dnsprovider-controlplane"
 
 var allTypes = map[string]provider.AddToRegistryFunc{
-	aws.ProviderType:    aws.RegisterTo,
-	google.ProviderType: google.RegisterTo,
+	aws.ProviderType:       aws.RegisterTo,
+	google.ProviderType:    google.RegisterTo,
+	openstack.ProviderType: openstack.RegisterTo,
 }
 
 // AddToManager adds Reconciler to the given manager.

--- a/pkg/dnsman2/dns/provider/handler/openstack/designateclient.go
+++ b/pkg/dnsman2/dns/provider/handler/openstack/designateclient.go
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package openstack
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack"
+	"github.com/gophercloud/gophercloud/v2/openstack/dns/v2/recordsets"
+	"github.com/gophercloud/gophercloud/v2/openstack/dns/v2/zones"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+	"github.com/gophercloud/utils/v2/openstack/clientconfig"
+
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider"
+)
+
+// interface between provider and OpenStack DNS API
+type designateClientInterface interface {
+	// ForEachZone calls handler for each zone managed by the Designate
+	ForEachZone(ctx context.Context, handler func(zone *zones.Zone) error) error
+
+	// ForEachRecordSet calls handler for each recordset in the given DNS zone
+	ForEachRecordSet(ctx context.Context, zoneID string, handler func(recordSet *recordsets.RecordSet) error) error
+
+	// ForEachRecordSet calls handler for each recordset in the given DNS zone restricted to rrtype
+	ForEachRecordSetFilterByTypeAndName(ctx context.Context, zoneID string, rrtype string, name string, handler func(recordSet *recordsets.RecordSet) error) error
+
+	// CreateRecordSet creates recordset in the given DNS zone
+	CreateRecordSet(ctx context.Context, zoneID string, opts recordsets.CreateOpts) (string, error)
+
+	// UpdateRecordSet updates recordset in the given DNS zone
+	UpdateRecordSet(ctx context.Context, zoneID, recordSetID string, opts recordsets.UpdateOpts) error
+
+	// DeleteRecordSet deletes recordset in the given DNS zone
+	DeleteRecordSet(ctx context.Context, zoneID, recordSetID string) error
+}
+
+// implementation of the designateClientInterface
+type designateClient struct {
+	serviceClient *gophercloud.ServiceClient
+	metrics       provider.Metrics
+}
+
+var _ designateClientInterface = &designateClient{}
+
+type clientAuthConfig struct {
+	clientconfig.AuthInfo
+	RegionName string
+	Insecure   bool
+	CACert     string
+	ClientCert string
+	ClientKey  string
+}
+
+// authenticate in OpenStack and obtain Designate service endpoint
+func createDesignateServiceClient(ctx context.Context, logger logr.Logger, clientAuthConfig *clientAuthConfig) (*gophercloud.ServiceClient, error) {
+	clientOpts := new(clientconfig.ClientOpts)
+	clientOpts.AuthInfo = &clientAuthConfig.AuthInfo
+	if clientAuthConfig.ApplicationCredentialSecret != "" {
+		clientOpts.AuthType = clientconfig.AuthV3ApplicationCredential
+	}
+	clientOpts.EnvPrefix = "_NEVER_OVERWRITE_FROM_ENV_"
+
+	ao, err := clientconfig.AuthOptions(clientOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client auth options: %+v", err)
+	}
+	ao.AllowReauth = true
+
+	logger.Info("Using OpenStack Keystone", "endpoint", ao.IdentityEndpoint)
+	providerClient, err := openstack.NewClient(ao.IdentityEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	tlscfg := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+
+	if clientAuthConfig.CACert != "" {
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM([]byte(clientAuthConfig.CACert))
+		tlscfg.RootCAs = caCertPool
+	}
+	if clientAuthConfig.Insecure {
+		tlscfg.InsecureSkipVerify = true
+	}
+
+	if clientAuthConfig.ClientCert != "" && clientAuthConfig.ClientKey != "" {
+		cert, err := tls.X509KeyPair([]byte(clientAuthConfig.ClientCert), []byte(clientAuthConfig.ClientKey))
+		if err != nil {
+			return nil, err
+		}
+		tlscfg.Certificates = []tls.Certificate{cert}
+	}
+
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		TLSClientConfig:       tlscfg,
+	}
+	providerClient.HTTPClient.Transport = transport
+
+	if err = openstack.Authenticate(ctx, providerClient, *ao); err != nil {
+		return nil, err
+	}
+
+	eo := gophercloud.EndpointOpts{
+		Region: clientAuthConfig.RegionName,
+	}
+
+	client, err := openstack.NewDNSV2(providerClient, eo)
+	if err != nil {
+		return nil, err
+	}
+	logger.Info("Found OpenStack Designate service", "endpoint", client.Endpoint)
+	return client, nil
+}
+
+// ForEachZone calls handler for each zone managed by the Designate
+func (c designateClient) ForEachZone(ctx context.Context, handler func(zone *zones.Zone) error) error {
+	pager := zones.List(c.serviceClient, zones.ListOpts{})
+	rt := provider.MetricsRequestTypeListZones
+	return pager.EachPage(ctx,
+		func(_ context.Context, page pagination.Page) (bool, error) {
+			c.metrics.AddGenericRequests(rt, 1)
+			rt = provider.MetricsRequestTypeListZonesPages
+			list, err := zones.ExtractZones(page)
+			if err != nil {
+				return false, err
+			}
+			for _, zone := range list {
+				err := handler(&zone)
+				if err != nil {
+					return false, err
+				}
+			}
+			return true, nil
+		},
+	)
+}
+
+// ForEachRecordSet calls handler for each recordset in the given DNS zone
+func (c designateClient) ForEachRecordSet(ctx context.Context, zoneID string, handler func(recordSet *recordsets.RecordSet) error) error {
+	return c.ForEachRecordSetFilterByTypeAndName(ctx, zoneID, "", "", handler)
+}
+
+// ForEachRecordSet calls handler for each recordset in the given DNS zone restricted to rrtype
+func (c designateClient) ForEachRecordSetFilterByTypeAndName(ctx context.Context, zoneID string, rrtype string, name string, handler func(recordSet *recordsets.RecordSet) error) error {
+	pager := recordsets.ListByZone(c.serviceClient, zoneID, recordsets.ListOpts{Type: rrtype, Name: name})
+	rt := provider.MetricsRequestTypeListRecords
+	return pager.EachPage(ctx,
+		func(_ context.Context, page pagination.Page) (bool, error) {
+			c.metrics.AddZoneRequests(zoneID, rt, 1)
+			rt = provider.MetricsRequestTypeListRecordPages
+			list, err := recordsets.ExtractRecordSets(page)
+			if err != nil {
+				return false, err
+			}
+			for _, recordSet := range list {
+				err := handler(&recordSet)
+				if err != nil {
+					return false, err
+				}
+			}
+			return true, nil
+		},
+	)
+}
+
+// CreateRecordSet creates recordset in the given DNS zone
+func (c designateClient) CreateRecordSet(ctx context.Context, zoneID string, opts recordsets.CreateOpts) (string, error) {
+	r, err := recordsets.Create(ctx, c.serviceClient, zoneID, opts).Extract()
+	c.metrics.AddZoneRequests(zoneID, provider.MetricsRequestTypeCreateRecords, 1)
+	if err != nil {
+		return "", err
+	}
+	return r.ID, nil
+}
+
+// UpdateRecordSet updates recordset in the given DNS zone
+func (c designateClient) UpdateRecordSet(ctx context.Context, zoneID, recordSetID string, opts recordsets.UpdateOpts) error {
+	_, err := recordsets.Update(ctx, c.serviceClient, zoneID, recordSetID, opts).Extract()
+	c.metrics.AddZoneRequests(zoneID, provider.MetricsRequestTypeUpdateRecords, 1)
+	return err
+}
+
+// DeleteRecordSet deletes recordset in the given DNS zone
+func (c designateClient) DeleteRecordSet(ctx context.Context, zoneID, recordSetID string) error {
+	err := recordsets.Delete(ctx, c.serviceClient, zoneID, recordSetID).ExtractErr()
+	c.metrics.AddZoneRequests(zoneID, provider.MetricsRequestTypeDeleteRecords, 1)
+	return err
+}

--- a/pkg/dnsman2/dns/provider/handler/openstack/execution.go
+++ b/pkg/dnsman2/dns/provider/handler/openstack/execution.go
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package openstack
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/gophercloud/gophercloud/v2/openstack/dns/v2/recordsets"
+
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider"
+)
+
+type execution struct {
+	log     logr.Logger
+	handler *handler
+	zone    provider.DNSHostedZone
+}
+
+func newExecution(log logr.Logger, h *handler, zone provider.DNSHostedZone) *execution {
+	return &execution{log: log, handler: h, zone: zone}
+}
+
+func (exec *execution) apply(ctx context.Context, name dns.DNSSetName, req *provider.ChangeRequestUpdate) error {
+	var rsOld, rsNew *recordsets.RecordSet
+	var err error
+	if req.Old != nil {
+		rsOld, err = exec.buildRecordSet(name, req.Old)
+		if err != nil {
+			return err
+		}
+	}
+	if req.New != nil {
+		rsNew, err = exec.buildRecordSet(name, req.New)
+		if err != nil {
+			return err
+		}
+	}
+	switch {
+	case rsOld == nil && rsNew != nil:
+		return exec.create(ctx, rsNew)
+	case rsOld != nil && rsNew != nil:
+		return exec.update(ctx, rsNew)
+	case rsOld != nil && rsNew == nil:
+		return exec.delete(ctx, rsOld)
+	}
+	return fmt.Errorf("both old and new record sets are nil for %s", name)
+}
+
+func (exec *execution) buildRecordSet(name dns.DNSSetName, rs *dns.RecordSet) (*recordsets.RecordSet, error) {
+	if rs.RoutingPolicy != nil || name.SetIdentifier != "" {
+		return nil, fmt.Errorf("OpenStack provider does not support routing policies")
+	}
+
+	osRSet := &recordsets.RecordSet{
+		Name: name.DNSName,
+		TTL:  int(rs.TTL),
+		Type: string(rs.Type),
+	}
+
+	for _, r := range rs.Records {
+		value := r.Value
+		switch rs.Type {
+		case dns.TypeCNAME:
+			value = dns.EnsureTrailingDot(value)
+		case dns.TypeTXT:
+			value = strconv.Quote(value)
+		}
+		osRSet.Records = append(osRSet.Records, value)
+	}
+
+	return osRSet, nil
+}
+
+func (exec *execution) create(ctx context.Context, rs *recordsets.RecordSet) error {
+	exec.logAction(rs.Name, "create", rs)
+
+	opts := recordsets.CreateOpts{
+		Name:    dns.EnsureTrailingDot(rs.Name),
+		Type:    rs.Type,
+		TTL:     rs.TTL,
+		Records: rs.Records,
+	}
+	exec.handler.config.RateLimiter.Accept()
+	_, err := exec.handler.client.CreateRecordSet(ctx, exec.zone.ZoneID().ID, opts)
+	return err
+}
+
+func (exec *execution) lookupRecordSetID(ctx context.Context, rset *recordsets.RecordSet) (string, error) {
+	name := dns.EnsureTrailingDot(rset.Name)
+	recordSetID := ""
+	handler := func(recordSet *recordsets.RecordSet) error {
+		if recordSet.Name == name {
+			recordSetID = recordSet.ID
+		}
+		return nil
+	}
+	exec.handler.config.RateLimiter.Accept()
+	err := exec.handler.client.ForEachRecordSetFilterByTypeAndName(ctx, exec.zone.ZoneID().ID, rset.Type, name, handler)
+	if err != nil {
+		return "", fmt.Errorf("RecordSet lookup for %s %s failed with: %s", rset.Type, rset.Name, err)
+	}
+	if recordSetID == "" {
+		return "", fmt.Errorf("RecordSet %s %s not found for update", rset.Type, rset.Name)
+	}
+	return recordSetID, nil
+}
+
+func (exec *execution) update(ctx context.Context, rs *recordsets.RecordSet) error {
+	exec.logAction(rs.Name, "update", rs)
+
+	recordSetID, err := exec.lookupRecordSetID(ctx, rs)
+	if err != nil {
+		return err
+	}
+
+	opts := recordsets.UpdateOpts{
+		TTL:     &rs.TTL,
+		Records: rs.Records,
+	}
+	exec.handler.config.RateLimiter.Accept()
+	err = exec.handler.client.UpdateRecordSet(ctx, exec.zone.ZoneID().ID, recordSetID, opts)
+	return err
+}
+
+func (exec *execution) delete(ctx context.Context, rs *recordsets.RecordSet) error {
+	exec.logAction(rs.Name, "delete", rs)
+
+	recordSetID, err := exec.lookupRecordSetID(ctx, rs)
+	if err != nil {
+		return err
+	}
+	exec.handler.config.RateLimiter.Accept()
+	err = exec.handler.client.DeleteRecordSet(ctx, exec.zone.ZoneID().ID, recordSetID)
+	return err
+}
+
+func (exec *execution) logAction(name, action string, rs *recordsets.RecordSet) {
+	exec.log.Info(fmt.Sprintf("Desired %s: %s record set %s[%s]: [%s]", action, rs.Type, name, exec.zone.Domain(), strings.Join(rs.Records, ", ")))
+}

--- a/pkg/dnsman2/dns/provider/handler/openstack/factory.go
+++ b/pkg/dnsman2/dns/provider/handler/openstack/factory.go
@@ -59,7 +59,7 @@ func newAdapter() provider.DNSHandlerAdapter {
 		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(128)))
 	// tenantName must not be longer than 64 characters, see https://docs.openstack.org/api-ref/identity/v3/?expanded=show-project-details-detail
 	checks.Add(provider.OptionalProperty("OS_PROJECT_NAME", "tenantName").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(128)))
+		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(64)))
 	checks.Add(provider.OptionalProperty("OS_PROJECT_ID", "tenantID").
 		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(128)))
 	checks.Add(provider.OptionalProperty("OS_USER_DOMAIN_NAME", "userDomainName").

--- a/pkg/dnsman2/dns/provider/handler/openstack/factory.go
+++ b/pkg/dnsman2/dns/provider/handler/openstack/factory.go
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package openstack
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gardener/external-dns-management/pkg/dnsman2/apis/config"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/utils"
+)
+
+// ProviderType is the type identifier for the OpenStack Designate DNS provider.
+const ProviderType = "openstack-designate"
+
+// RegisterTo registers the OpenStack Designate DNS handler to the given registry.
+func RegisterTo(registry *provider.DNSHandlerRegistry) {
+	registry.Register(
+		ProviderType,
+		NewHandler,
+		newAdapter(),
+		&config.RateLimiterOptions{
+			Enabled: true,
+			QPS:     100,
+			Burst:   20,
+		},
+		nil,
+	)
+}
+
+type adapter struct {
+	checks *provider.DNSHandlerAdapterChecks
+}
+
+// newAdapter creates a new DNSHandlerAdapter for the OpenStack Designate provider.
+func newAdapter() provider.DNSHandlerAdapter {
+	checks := provider.NewDNSHandlerAdapterChecks()
+	checks.Add(provider.RequiredProperty("OS_AUTH_URL", "authURL").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.URLValidator("http", "https"), provider.MaxLengthValidator(256)))
+	checks.Add(provider.OptionalProperty("OS_APPLICATION_CREDENTIAL_ID", "applicationCredentialID").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(128)))
+	checks.Add(provider.OptionalProperty("OS_APPLICATION_CREDENTIAL_NAME", "applicationCredentialName").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(128)))
+	checks.Add(provider.OptionalProperty("OS_APPLICATION_CREDENTIAL_SECRET", "applicationCredentialSecret").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.MaxLengthValidator(128)).
+		HideValue())
+	checks.Add(provider.OptionalProperty("OS_USERNAME", "username").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(128)))
+	checks.Add(provider.OptionalProperty("OS_PASSWORD", "password").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.MaxLengthValidator(128), provider.NoTrailingNewlineValidator).
+		HideValue())
+	checks.Add(provider.OptionalProperty("OS_DOMAIN_NAME", "domainName").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(128)))
+	checks.Add(provider.OptionalProperty("OS_DOMAIN_ID", "domainID").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(128)))
+	// tenantName must not be longer than 64 characters, see https://docs.openstack.org/api-ref/identity/v3/?expanded=show-project-details-detail
+	checks.Add(provider.OptionalProperty("OS_PROJECT_NAME", "tenantName").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(128)))
+	checks.Add(provider.OptionalProperty("OS_PROJECT_ID", "tenantID").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(128)))
+	checks.Add(provider.OptionalProperty("OS_USER_DOMAIN_NAME", "userDomainName").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(128)))
+	checks.Add(provider.OptionalProperty("OS_USER_DOMAIN_ID", "userDomainID").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(128)))
+	checks.Add(provider.OptionalProperty("OS_REGION_NAME").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.PrintableValidator, provider.MaxLengthValidator(128)))
+	checks.Add(provider.OptionalProperty("CACERT", "caCert").Validators(provider.CACertValidator).HideValue())
+	checks.Add(provider.OptionalProperty("CLIENTCERT", "clientCert").Validators(provider.PEMValidator).HideValue())
+	checks.Add(provider.OptionalProperty("CLIENTKEY", "clientKey").Validators(provider.PEMValidator).HideValue())
+	checks.Add(provider.OptionalProperty("INSECURE", "insecure").Validators(provider.BoolValidator))
+	checks.Add(provider.OptionalProperty("OS_IDENTITY_API_VERSION").Validators(provider.IntValidator(2, 100))) // not used, but some users might want to set it
+	return &adapter{checks: checks}
+}
+
+func (a *adapter) ProviderType() string {
+	return ProviderType
+}
+
+func (a *adapter) ValidateCredentialsAndProviderConfig(properties utils.Properties, config *runtime.RawExtension) error {
+	if config != nil && len(config.Raw) > 0 {
+		return fmt.Errorf("provider config not supported for %s provider", a.ProviderType())
+	}
+	return a.checks.ValidateProperties(a.ProviderType(), properties)
+}

--- a/pkg/dnsman2/dns/provider/handler/openstack/handler.go
+++ b/pkg/dnsman2/dns/provider/handler/openstack/handler.go
@@ -31,7 +31,7 @@ var _ provider.DNSHandler = &handler{}
 
 // NewHandler constructs a new DNSHandler object.
 func NewHandler(c *provider.DNSHandlerConfig) (provider.DNSHandler, error) {
-	authConfig, err := readAuthConfig(c)
+	authConfig, err := buildAndValidateAuthConfig(c)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func NewHandler(c *provider.DNSHandlerConfig) (provider.DNSHandler, error) {
 	return h, nil
 }
 
-func readAuthConfig(c *provider.DNSHandlerConfig) (*clientAuthConfig, error) {
+func buildAndValidateAuthConfig(c *provider.DNSHandlerConfig) (*clientAuthConfig, error) {
 	authURL, err := c.GetRequiredProperty("OS_AUTH_URL", "authURL")
 	if err != nil {
 		return nil, err
@@ -199,8 +199,10 @@ func (h *handler) ExecuteRequests(ctx context.Context, zone provider.DNSHostedZo
 
 	exec := newExecution(log, h, zone)
 
-	var succeeded, failed int
-	var errs []error
+	var (
+		succeeded, failed int
+		errs              []error
+	)
 	for _, r := range reqs.Updates {
 		if err := exec.apply(ctx, reqs.Name, r); err != nil {
 			failed++

--- a/pkg/dnsman2/dns/provider/handler/openstack/handler.go
+++ b/pkg/dnsman2/dns/provider/handler/openstack/handler.go
@@ -1,0 +1,226 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package openstack
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/gophercloud/gophercloud/v2/openstack/dns/v2/zones"
+	"github.com/gophercloud/utils/v2/openstack/clientconfig"
+
+	"github.com/gardener/external-dns-management/pkg/dnsman2/apis/config"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/utils"
+)
+
+type handler struct {
+	provider.DefaultDNSHandler
+	config provider.DNSHandlerConfig
+
+	client designateClientInterface
+}
+
+var _ provider.DNSHandler = &handler{}
+
+// NewHandler constructs a new DNSHandler object.
+func NewHandler(c *provider.DNSHandlerConfig) (provider.DNSHandler, error) {
+	authConfig, err := readAuthConfig(c)
+	if err != nil {
+		return nil, err
+	}
+
+	serviceClient, err := createDesignateServiceClient(context.Background(), c.Log, authConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	h := &handler{
+		DefaultDNSHandler: provider.NewDefaultDNSHandler(ProviderType),
+		config:            *c,
+		client:            designateClient{serviceClient: serviceClient, metrics: c.Metrics},
+	}
+
+	return h, nil
+}
+
+func readAuthConfig(c *provider.DNSHandlerConfig) (*clientAuthConfig, error) {
+	authURL, err := c.GetRequiredProperty("OS_AUTH_URL", "authURL")
+	if err != nil {
+		return nil, err
+	}
+
+	applicationCredentialID := c.GetProperty("OS_APPLICATION_CREDENTIAL_ID", "applicationCredentialID")
+	applicationCredentialName := c.GetProperty("OS_APPLICATION_CREDENTIAL_NAME", "applicationCredentialName")
+	applicationCredentialSecret := c.GetProperty("OS_APPLICATION_CREDENTIAL_SECRET", "applicationCredentialSecret")
+	username := c.GetProperty("OS_USERNAME", "username")
+	password := c.GetProperty("OS_PASSWORD", "password")
+	if applicationCredentialID != "" || applicationCredentialName != "" {
+		if applicationCredentialSecret == "" {
+			return nil, fmt.Errorf("'OS_APPLICATION_CREDENTIAL_SECRET' (or 'applicationCredentialSecret') is required if 'OS_APPLICATION_CREDENTIAL_ID' or 'OS_APPLICATION_CREDENTIAL_NAME' is given")
+		}
+		if applicationCredentialID == "" && applicationCredentialName != "" {
+			if username == "" {
+				return nil, fmt.Errorf("OS_USERNAME' (or 'username') is required if 'OS_APPLICATION_CREDENTIAL_NAME' is given")
+			}
+		}
+		if password != "" {
+			return nil, fmt.Errorf("'OS_PASSWORD' (or 'password)' is not allowed if application credentials are used")
+		}
+	} else {
+		if username == "" {
+			return nil, fmt.Errorf("'OS_USERNAME' (or 'username') is required if application credentials are not used")
+		}
+		if password == "" {
+			return nil, fmt.Errorf("'OS_PASSWORD' (or 'password') is required if application credentials are not used")
+		}
+	}
+
+	domainName := c.GetProperty("OS_DOMAIN_NAME", "domainName")
+	domainID := c.GetProperty("OS_DOMAIN_ID", "domainID")
+	projectName := c.GetProperty("OS_PROJECT_NAME", "tenantName")
+	projectID := c.GetProperty("OS_PROJECT_ID", "tenantID")
+	userDomainName := c.GetProperty("OS_USER_DOMAIN_NAME", "userDomainName")
+	userDomainID := c.GetProperty("OS_USER_DOMAIN_ID", "userDomainID")
+	// optional restriction to region
+	regionName := c.GetProperty("OS_REGION_NAME")
+	// optional CA Certificate for keystone
+	caCert := c.GetProperty("CACERT", "caCert")
+	// optional Client Certificate
+	clientCert := c.GetProperty("CLIENTCERT", "clientCert")
+	clientKey := c.GetProperty("CLIENTKEY", "clientKey")
+	insecure := strings.ToLower(c.GetProperty("INSECURE", "insecure"))
+
+	authConfig := clientAuthConfig{
+		AuthInfo: clientconfig.AuthInfo{
+			AuthURL:                     authURL,
+			ApplicationCredentialID:     applicationCredentialID,
+			ApplicationCredentialName:   applicationCredentialName,
+			ApplicationCredentialSecret: applicationCredentialSecret,
+			Username:                    username,
+			Password:                    password,
+			DomainName:                  domainName,
+			DomainID:                    domainID,
+			ProjectName:                 projectName,
+			ProjectID:                   projectID,
+			UserDomainID:                userDomainID,
+			UserDomainName:              userDomainName,
+		},
+		RegionName: regionName,
+		CACert:     caCert,
+		ClientCert: clientCert,
+		ClientKey:  clientKey,
+		Insecure:   insecure == "true" || insecure == "yes",
+	}
+
+	return &authConfig, nil
+}
+
+// Release releases the zone cache.
+func (h *handler) Release() {
+}
+
+// GetZones returns a list of hosted zones from the cache.
+func (h *handler) GetZones(ctx context.Context) ([]provider.DNSHostedZone, error) {
+	log, err := h.getLogFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var hostedZones []provider.DNSHostedZone
+
+	zoneHandler := func(zone *zones.Zone) error {
+		if h.isBlockedZone(zone.ID) {
+			log.Info("ignoring blocked zone", "zone", zone.ID)
+			return nil
+		}
+
+		hostedZone := provider.NewDNSHostedZone(h.ProviderType(), zone.ID, dns.NormalizeDomainName(zone.Name), "", false)
+		hostedZones = append(hostedZones, hostedZone)
+		return nil
+	}
+
+	h.config.RateLimiter.Accept()
+	if err := h.client.ForEachZone(ctx, zoneHandler); err != nil {
+		return nil, fmt.Errorf("listing DNS zones failed. Details: %s", err.Error())
+	}
+
+	return hostedZones, nil
+}
+
+func (h *handler) getLogFromContext(ctx context.Context) (logr.Logger, error) {
+	log, err := logr.FromContext(ctx)
+	if err != nil {
+		return log, fmt.Errorf("failed to get logger from context: %w", err)
+	}
+	log = log.WithValues(
+		"provider", h.ProviderType(),
+	)
+	return log, nil
+}
+
+func (h *handler) getAdvancedOptions() config.AdvancedOptions {
+	return h.config.GlobalConfig.ProviderAdvancedOptions[ProviderType]
+}
+
+func (h *handler) isBlockedZone(zoneID string) bool {
+	for _, zone := range h.getAdvancedOptions().BlockedZones {
+		if zone == zoneID {
+			return true
+		}
+	}
+	return false
+}
+
+// GetCustomQueryDNSFunc returns a custom DNS query function for the Openstack Designate provider.
+func (h *handler) GetCustomQueryDNSFunc(_ dns.ZoneInfo, factory utils.QueryDNSFactoryFunc) (provider.CustomQueryDNSFunc, error) {
+	defaultQueryFunc, err := factory()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create default query function: %w", err)
+	}
+	return func(ctx context.Context, _ dns.ZoneInfo, setName dns.DNSSetName, recordType dns.RecordType) (*dns.RecordSet, error) {
+		queryResult := defaultQueryFunc.Query(ctx, setName, recordType)
+		return queryResult.RecordSet, queryResult.Err
+	}, nil
+}
+
+// ExecuteRequests applies a given change request to a given hosted zone.
+func (h *handler) ExecuteRequests(ctx context.Context, zone provider.DNSHostedZone, reqs provider.ChangeRequests) error {
+	log, err := h.getLogFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	exec := newExecution(log, h, zone)
+
+	var succeeded, failed int
+	var errs []error
+	for _, r := range reqs.Updates {
+		if err := exec.apply(ctx, reqs.Name, r); err != nil {
+			failed++
+			log.Error(err, "apply failed")
+			errs = append(errs, err)
+		} else {
+			succeeded++
+		}
+	}
+
+	if succeeded > 0 {
+		log.Info("Succeeded updates for records", "zone", zone.ZoneID().ID, "count", succeeded)
+	}
+	if failed > 0 {
+		log.Info("Failed updates for records", "zone", zone.ZoneID().ID, "count", failed)
+		return fmt.Errorf("%d changes failed", failed)
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to execute change requests for zone %s: %w", zone.ZoneID(), errors.Join(errs...))
+	}
+	return nil
+}

--- a/pkg/dnsman2/dns/utils/dnsquery.go
+++ b/pkg/dnsman2/dns/utils/dnsquery.go
@@ -83,6 +83,9 @@ func (q *standardQueryDNS) Query(ctx context.Context, setName dns.DNSSetName, rs
 		return QueryDNSResult{Err: err}
 	}
 	if msg.Rcode != miekgdns.RcodeSuccess {
+		if msg.Rcode == miekgdns.RcodeNameError {
+			return QueryDNSResult{} // NXDOMAIN is not an error, just no records
+		}
 		return QueryDNSResult{Err: fmt.Errorf("DNS lookup failed with rcode %d", msg.Rcode)}
 	}
 	rs := dns.NewRecordSet(rstype, 0, nil)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Implementation of handler for provider type `openstack-designate` for new dnsman implementation.
 
**Which issue(s) this PR fixes**:

Part of:
* https://github.com/gardener/external-dns-management/issues/441

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
