### PR TITLE
[Controller-Runtime-Rewrite] Add handler for `rfc2136`

### DIFF
--- a/docs/rfc2136/README.md
+++ b/docs/rfc2136/README.md
@@ -62,7 +62,7 @@ metadata:
 type: Opaque
 data:
   # replace '...' with values encoded as base64
-  Server: ... # "<host>[:<port>]" of the authorive DNS server, default port is 53
+  Server: ... # "<host>[:<port>]" of the authoritative DNS server, default port is 53
   TSIGKeyName: ... # key name of the TSIG secret (must end with a dot)
   TSIGSecret: ... # TSIG secret
   Zone: ... # zone (must be fully qualified)

--- a/pkg/dnsman2/controller/dnsprovider/controlplane/add.go
+++ b/pkg/dnsman2/controller/dnsprovider/controlplane/add.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/handler/aws"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/handler/google"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/handler/openstack"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/handler/rfc2136"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/state"
 )
 
@@ -41,6 +42,7 @@ var allTypes = map[string]provider.AddToRegistryFunc{
 	aws.ProviderType:       aws.RegisterTo,
 	google.ProviderType:    google.RegisterTo,
 	openstack.ProviderType: openstack.RegisterTo,
+	rfc2136.ProviderType:   rfc2136.RegisterTo,
 }
 
 // AddToManager adds Reconciler to the given manager.

--- a/pkg/dnsman2/dns/provider/handler/rfc2136/const.go
+++ b/pkg/dnsman2/dns/provider/handler/rfc2136/const.go
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package rfc2136
+
+const (
+	// PropertyServer is the secret data key for the authoritative server.
+	PropertyServer = "Server"
+	// PropertyZone is the secret data key for the zone.
+	PropertyZone = "Zone"
+	// PropertyTSIGKeyName is the secret data key for the key name of the TSIG secret (must end with a dot).
+	PropertyTSIGKeyName = "TSIGKeyName"
+	// PropertyTSIGSecret is the secret data key for TSIG secret.
+	PropertyTSIGSecret = "TSIGSecret"
+	// PropertyTSIGSecretAlgorithm is the secret data key for the TSIG Algorithm Name for Hash-based Message Authentication (HMAC).
+	PropertyTSIGSecretAlgorithm = "TSIGSecretAlgorithm"
+)

--- a/pkg/dnsman2/dns/provider/handler/rfc2136/execution.go
+++ b/pkg/dnsman2/dns/provider/handler/rfc2136/execution.go
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package rfc2136
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"time"
+
+	"github.com/go-logr/logr"
+	miekgdns "github.com/miekg/dns"
+
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/utils"
+)
+
+type execution struct {
+	log     logr.Logger
+	handler *handler
+	zone    provider.DNSHostedZone
+}
+
+func newExecution(log logr.Logger, h *handler, zone provider.DNSHostedZone) *execution {
+	return &execution{log: log, handler: h, zone: zone}
+}
+
+func (exec *execution) apply(_ context.Context, setName dns.DNSSetName, req *provider.ChangeRequestUpdate) error {
+	var (
+		err                error
+		addRRSet, delRRSet []miekgdns.RR
+		action             string
+	)
+
+	domain := dns.NormalizeDomainName(exec.handler.zone)
+	if req.New != nil {
+		action = "CREATE"
+		if req.Old != nil {
+			action = "UPDATE"
+		}
+		exec.log.Info(fmt.Sprintf("Desired %s: %s record set %s[%s] with TTL %d: %s", action, req.New.Type, setName.DNSName, domain, req.New.TTL, req.New.RecordString()))
+		addRRSet, err = exec.buildResourceRecords(setName, req.New)
+		if err != nil {
+			return err
+		}
+		if req.Old != nil {
+			newRecords, updRecords, delRecords := req.New.DiffTo(req.Old)
+			addRecords := append(newRecords, updRecords...)
+			if recreateOnTTLChange {
+				// experience with know-dns: update of TTL needs deletion and insert
+				delRecords = append(delRecords, updRecords...)
+			}
+			addRRSet, err = exec.buildResourceRecords(setName, &dns.RecordSet{Type: req.New.Type, TTL: req.New.TTL, Records: addRecords})
+			if err != nil {
+				return err
+			}
+			if len(delRecords) > 0 {
+				delRRSet, err = exec.buildResourceRecords(setName, &dns.RecordSet{Type: req.Old.Type, TTL: req.Old.TTL, Records: delRecords})
+				if err != nil {
+					return err
+				}
+			}
+		}
+	} else if req.Old != nil {
+		exec.log.Info(fmt.Sprintf("Desired DELETE: %s record set %s[%s] with TTL %d: %s", req.Old.Type, setName.DNSName, domain, req.Old.TTL, req.Old.RecordString()))
+		delRRSet, err = exec.buildResourceRecords(setName, req.Old)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(delRRSet) != 0 {
+		if err := exec.delete(delRRSet); err != nil {
+			return err
+		}
+	}
+	if len(addRRSet) != 0 {
+		if err := exec.insert(addRRSet); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (exec *execution) buildResourceRecords(setName dns.DNSSetName, rset *dns.RecordSet) ([]miekgdns.RR, error) {
+	if setName.SetIdentifier != "" || rset.RoutingPolicy != nil {
+		return nil, fmt.Errorf("routing policies not supported for " + ProviderType)
+	}
+
+	var records []miekgdns.RR
+
+	hdr := miekgdns.RR_Header{
+		Name: miekgdns.Fqdn(setName.DNSName),
+		Ttl:  utils.TTLToUint32(rset.TTL),
+	}
+	switch rset.Type {
+	case dns.TypeA:
+		hdr.Rrtype = miekgdns.TypeA
+		for _, r := range rset.Records {
+			ip := net.ParseIP(r.Value)
+			if ip == nil {
+				return nil, fmt.Errorf("invalid IP address: %s", r.Value)
+			}
+			if ip.To4() == nil {
+				return nil, fmt.Errorf("not an IPv4 address: %s", r.Value)
+			}
+			records = append(records, &miekgdns.A{Hdr: hdr, A: ip.To4()})
+		}
+		return records, nil
+	case dns.TypeAAAA:
+		hdr.Rrtype = miekgdns.TypeAAAA
+		for _, r := range rset.Records {
+			ip := net.ParseIP(r.Value)
+			if ip == nil {
+				return nil, fmt.Errorf("invalid IP address: %s", r.Value)
+			}
+			if ip.To16() == nil {
+				return nil, fmt.Errorf("not an IPv6 address: %s", r.Value)
+			}
+			records = append(records, &miekgdns.AAAA{Hdr: hdr, AAAA: ip.To16()})
+		}
+		return records, nil
+	case dns.TypeCNAME:
+		hdr.Rrtype = miekgdns.TypeCNAME
+		for _, r := range rset.Records {
+			records = append(records, &miekgdns.CNAME{Hdr: hdr, Target: miekgdns.Fqdn(r.Value)})
+		}
+		return records, nil
+	case dns.TypeTXT:
+		hdr.Rrtype = miekgdns.TypeTXT
+		txtRecord := &miekgdns.TXT{Hdr: hdr}
+		for _, r := range rset.Records {
+			unquoted, err := strconv.Unquote(r.Value)
+			if err != nil {
+				unquoted = r.Value
+			}
+			txtRecord.Txt = append(txtRecord.Txt, unquoted)
+		}
+		records = append(records, txtRecord)
+		return records, nil
+	default:
+		return nil, fmt.Errorf("unexpected record type: %s", rset.Type)
+	}
+}
+
+func (exec *execution) insert(records []miekgdns.RR) error {
+	return exec.exchange(records,
+		func(msg *miekgdns.Msg, rrs []miekgdns.RR) { msg.Insert(rrs) },
+		provider.MetricsRequestTypeUpdateRecords,
+		exec.handler.config.Metrics)
+}
+
+func (exec *execution) delete(records []miekgdns.RR) error {
+	return exec.exchange(records,
+		func(msg *miekgdns.Msg, rrs []miekgdns.RR) { msg.Remove(rrs) },
+		provider.MetricsRequestTypeDeleteRecords,
+		exec.handler.config.Metrics)
+}
+
+func (exec *execution) exchange(records []miekgdns.RR, apply func(*miekgdns.Msg, []miekgdns.RR), requestType provider.MetricsRequestType, metrics provider.Metrics) error {
+	exec.handler.config.RateLimiter.Accept()
+
+	c := &miekgdns.Client{
+		Net:        tcp,
+		TsigSecret: map[string]string{exec.handler.tsigKeyname: exec.handler.tsigSecret},
+	}
+
+	msg := &miekgdns.Msg{}
+	msg.SetUpdate(exec.handler.zone)
+	msg.SetTsig(exec.handler.tsigKeyname, exec.handler.tsigAlgorithm, clockSkew, time.Now().Unix())
+
+	apply(msg, records)
+
+	retMsg, _, err := c.Exchange(msg, exec.handler.nameserver) // your DNS server
+	metrics.AddZoneRequests(exec.handler.zone, requestType, 1)
+	if err != nil {
+		return err
+	}
+
+	if retMsg.Rcode != miekgdns.RcodeSuccess {
+		return fmt.Errorf("DNS server returned error code on %s: %d", requestType, retMsg.Rcode)
+	}
+	return nil
+}

--- a/pkg/dnsman2/dns/provider/handler/rfc2136/factory.go
+++ b/pkg/dnsman2/dns/provider/handler/rfc2136/factory.go
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package rfc2136
+
+import (
+	"fmt"
+	"strings"
+
+	miekgdns "github.com/miekg/dns"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gardener/external-dns-management/pkg/dnsman2/apis/config"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/utils"
+)
+
+// ProviderType is the type of the RFC2136 DNS provider.
+const ProviderType = "rfc2136"
+
+// RegisterTo registers the OpenStack Designate DNS handler to the given registry.
+func RegisterTo(registry *provider.DNSHandlerRegistry) {
+	registry.Register(
+		ProviderType,
+		NewHandler,
+		newAdapter(),
+		&config.RateLimiterOptions{
+			Enabled: true,
+			QPS:     50,
+			Burst:   10,
+		},
+		nil,
+	)
+}
+
+type adapter struct {
+	checks *provider.DNSHandlerAdapterChecks
+}
+
+// newAdapter creates a new DNSHandlerAdapter for the RFC2136 DNS provider.
+func newAdapter() provider.DNSHandlerAdapter {
+	checks := provider.NewDNSHandlerAdapterChecks()
+	checks.Add(provider.RequiredProperty("Server").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(256)))
+	checks.Add(provider.RequiredProperty("Zone").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(256), zoneValidator))
+	checks.Add(provider.RequiredProperty("TSIGKeyName").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(256), fqdnValidator))
+	checks.Add(provider.RequiredProperty("TSIGSecret").
+		Validators(provider.NoTrailingWhitespaceValidator, provider.MaxLengthValidator(128)).
+		HideValue())
+	checks.Add(provider.OptionalProperty("TSIGSecretAlgorithm").
+		Validators(algorithmValidator))
+	return &adapter{checks: checks}
+}
+
+func (a *adapter) ProviderType() string {
+	return ProviderType
+}
+
+func (a *adapter) ValidateCredentialsAndProviderConfig(properties utils.Properties, config *runtime.RawExtension) error {
+	if config != nil && len(config.Raw) > 0 {
+		return fmt.Errorf("provider config not supported for %s provider", a.ProviderType())
+	}
+	return a.checks.ValidateProperties(a.ProviderType(), properties)
+}
+
+func zoneValidator(value string) error {
+	if value != miekgdns.CanonicalName(value) {
+		return fmt.Errorf("zone must be given in canonical form: '%s' instead of '%s'", miekgdns.CanonicalName(value), value)
+	}
+	return nil
+}
+
+func fqdnValidator(value string) error {
+	if value != miekgdns.Fqdn(value) {
+		return fmt.Errorf("TSIGKeyName must end with '.'")
+	}
+	return nil
+}
+
+func algorithmValidator(value string) error {
+	_, err := findTsigAlgorithm(value)
+	return err
+}
+
+// tsigAlgs are the supported TSIG algorithms
+var tsigAlgs = []string{miekgdns.HmacSHA1, miekgdns.HmacSHA224, miekgdns.HmacSHA256, miekgdns.HmacSHA384, miekgdns.HmacSHA512}
+
+func findTsigAlgorithm(alg string) (string, error) {
+	if alg == "" {
+		return miekgdns.HmacSHA256, nil
+	}
+
+	fqdnAlg := miekgdns.Fqdn(alg)
+	for _, a := range tsigAlgs {
+		if fqdnAlg == a {
+			return fqdnAlg, nil
+		}
+	}
+	return "", fmt.Errorf("invalid TSIG secret algorithm: %s (supported: %s)", alg, strings.ReplaceAll(strings.Join(tsigAlgs, ","), ".", ""))
+}

--- a/pkg/dnsman2/dns/provider/handler/rfc2136/factory.go
+++ b/pkg/dnsman2/dns/provider/handler/rfc2136/factory.go
@@ -19,7 +19,7 @@ import (
 // ProviderType is the type of the RFC2136 DNS provider.
 const ProviderType = "rfc2136"
 
-// RegisterTo registers the OpenStack Designate DNS handler to the given registry.
+// RegisterTo registers the RFC2136 DNS handler to the given registry.
 func RegisterTo(registry *provider.DNSHandlerRegistry) {
 	registry.Register(
 		ProviderType,
@@ -41,16 +41,16 @@ type adapter struct {
 // newAdapter creates a new DNSHandlerAdapter for the RFC2136 DNS provider.
 func newAdapter() provider.DNSHandlerAdapter {
 	checks := provider.NewDNSHandlerAdapterChecks()
-	checks.Add(provider.RequiredProperty("Server").
+	checks.Add(provider.RequiredProperty(PropertyServer).
 		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(256)))
-	checks.Add(provider.RequiredProperty("Zone").
+	checks.Add(provider.RequiredProperty(PropertyZone).
 		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(256), zoneValidator))
-	checks.Add(provider.RequiredProperty("TSIGKeyName").
+	checks.Add(provider.RequiredProperty(PropertyTSIGKeyName).
 		Validators(provider.NoTrailingWhitespaceValidator, provider.AlphaNumericPunctuationValidator, provider.MaxLengthValidator(256), fqdnValidator))
-	checks.Add(provider.RequiredProperty("TSIGSecret").
+	checks.Add(provider.RequiredProperty(PropertyTSIGSecret).
 		Validators(provider.NoTrailingWhitespaceValidator, provider.MaxLengthValidator(128)).
 		HideValue())
-	checks.Add(provider.OptionalProperty("TSIGSecretAlgorithm").
+	checks.Add(provider.OptionalProperty(PropertyTSIGSecretAlgorithm).
 		Validators(algorithmValidator))
 	return &adapter{checks: checks}
 }

--- a/pkg/dnsman2/dns/provider/handler/rfc2136/handler.go
+++ b/pkg/dnsman2/dns/provider/handler/rfc2136/handler.go
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package rfc2136
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	miekgdns "github.com/miekg/dns"
+
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/utils"
+)
+
+const (
+	// maximum time DNS client can be off from server for an update to succeed
+	clockSkew = 300
+	tcp       = "tcp"
+	// recreateOnTTLChange specifies if changing TTL of a recordset needs deletion and insert of recordset
+	recreateOnTTLChange = true
+)
+
+type handler struct {
+	provider.DefaultDNSHandler
+	config provider.DNSHandlerConfig
+
+	nameserver    string
+	zone          string
+	tsigKeyname   string
+	tsigSecret    string
+	tsigAlgorithm string
+}
+
+var _ provider.DNSHandler = &handler{}
+
+// NewHandler constructs a new DNSHandler object.
+func NewHandler(c *provider.DNSHandlerConfig) (provider.DNSHandler, error) {
+	h := &handler{
+		DefaultDNSHandler: provider.NewDefaultDNSHandler(ProviderType),
+		config:            *c,
+	}
+
+	server, err := c.GetRequiredProperty("Server")
+	if err != nil {
+		return nil, err
+	}
+	if !strings.Contains(server, ":") {
+		server += ":53"
+	}
+	h.nameserver = server
+
+	zone, err := c.GetRequiredProperty("Zone")
+	if err != nil {
+		return nil, err
+	}
+	if zone != miekgdns.CanonicalName(zone) {
+		return nil, fmt.Errorf("zone must be given in canonical form: '%s' instead of '%s'", miekgdns.CanonicalName(zone), h.zone)
+	}
+	h.zone = zone
+
+	keyname, err := c.GetRequiredProperty("TSIGKeyName")
+	if err != nil {
+		return nil, err
+	}
+	if keyname != miekgdns.Fqdn(keyname) {
+		return nil, fmt.Errorf("TSIGKeyName must end with '.'")
+	}
+	h.tsigKeyname = miekgdns.Fqdn(keyname)
+
+	secret, err := c.GetRequiredProperty("TSIGSecret")
+	if err != nil {
+		return nil, err
+	}
+	h.tsigSecret = secret
+
+	h.tsigAlgorithm, err = findTsigAlgorithm(c.GetProperty("TSIGSecretAlgorithm"))
+	if err != nil {
+		return nil, err
+	}
+
+	return h, nil
+}
+
+func (h *handler) Release() {
+}
+
+func (h *handler) GetZones(_ context.Context) ([]provider.DNSHostedZone, error) {
+	domainName := dns.NormalizeDomainName(h.zone)
+	h.config.Metrics.AddGenericRequests(provider.MetricsRequestTypeListZones, 1)
+	return []provider.DNSHostedZone{
+		provider.NewDNSHostedZone(ProviderType, h.zone, domainName, h.zone, false),
+	}, nil
+}
+
+// GetCustomQueryDNSFunc returns a custom DNS query function for the Alicloud DNS provider.
+func (h *handler) GetCustomQueryDNSFunc(_ dns.ZoneInfo, factory utils.QueryDNSFactoryFunc) (provider.CustomQueryDNSFunc, error) {
+	defaultQueryFunc, err := factory()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create default query function: %w", err)
+	}
+	return func(ctx context.Context, _ dns.ZoneInfo, setName dns.DNSSetName, recordType dns.RecordType) (*dns.RecordSet, error) {
+		queryResult := defaultQueryFunc.Query(ctx, setName, recordType)
+		return queryResult.RecordSet, queryResult.Err
+	}, nil
+}
+
+func (h *handler) ExecuteRequests(ctx context.Context, zone provider.DNSHostedZone, reqs provider.ChangeRequests) error {
+	log, err := h.getLogFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	exec := newExecution(log, h, zone)
+
+	var (
+		succeeded, failed int
+		errs              []error
+	)
+	for _, r := range reqs.Updates {
+		if err := exec.apply(ctx, reqs.Name, r); err != nil {
+			failed++
+			log.Error(err, "apply failed")
+			errs = append(errs, err)
+		} else {
+			succeeded++
+		}
+	}
+
+	if succeeded > 0 {
+		log.Info("Succeeded updates for records", "zone", zone.ZoneID().ID, "count", succeeded)
+	}
+	if failed > 0 {
+		log.Info("Failed updates for records", "zone", zone.ZoneID().ID, "count", failed)
+		return fmt.Errorf("%d changes failed", failed)
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to execute change requests for zone %s: %w", zone.ZoneID(), errors.Join(errs...))
+	}
+	return nil
+}
+
+func (h *handler) getLogFromContext(ctx context.Context) (logr.Logger, error) {
+	log, err := logr.FromContext(ctx)
+	if err != nil {
+		return log, fmt.Errorf("failed to get logger from context: %w", err)
+	}
+	log = log.WithValues(
+		"provider", h.ProviderType(),
+	)
+	return log, nil
+}

--- a/pkg/dnsman2/dns/provider/handler/rfc2136/handler.go
+++ b/pkg/dnsman2/dns/provider/handler/rfc2136/handler.go
@@ -46,7 +46,7 @@ func NewHandler(c *provider.DNSHandlerConfig) (provider.DNSHandler, error) {
 		config:            *c,
 	}
 
-	server, err := c.GetRequiredProperty("Server")
+	server, err := c.GetRequiredProperty(PropertyServer)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func NewHandler(c *provider.DNSHandlerConfig) (provider.DNSHandler, error) {
 	}
 	h.nameserver = server
 
-	zone, err := c.GetRequiredProperty("Zone")
+	zone, err := c.GetRequiredProperty(PropertyZone)
 	if err != nil {
 		return nil, err
 	}
@@ -64,22 +64,22 @@ func NewHandler(c *provider.DNSHandlerConfig) (provider.DNSHandler, error) {
 	}
 	h.zone = zone
 
-	keyname, err := c.GetRequiredProperty("TSIGKeyName")
+	keyname, err := c.GetRequiredProperty(PropertyTSIGKeyName)
 	if err != nil {
 		return nil, err
 	}
 	if keyname != miekgdns.Fqdn(keyname) {
-		return nil, fmt.Errorf("TSIGKeyName must end with '.'")
+		return nil, fmt.Errorf("%s must end with '.'", PropertyTSIGKeyName)
 	}
 	h.tsigKeyname = miekgdns.Fqdn(keyname)
 
-	secret, err := c.GetRequiredProperty("TSIGSecret")
+	secret, err := c.GetRequiredProperty(PropertyTSIGSecret)
 	if err != nil {
 		return nil, err
 	}
 	h.tsigSecret = secret
 
-	h.tsigAlgorithm, err = findTsigAlgorithm(c.GetProperty("TSIGSecretAlgorithm"))
+	h.tsigAlgorithm, err = findTsigAlgorithm(c.GetProperty(PropertyTSIGSecretAlgorithm))
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func (h *handler) GetZones(_ context.Context) ([]provider.DNSHostedZone, error) 
 	}, nil
 }
 
-// GetCustomQueryDNSFunc returns a custom DNS query function for the Alicloud DNS provider.
+// GetCustomQueryDNSFunc returns a custom DNS query function for the RFC2136 DNS provider.
 func (h *handler) GetCustomQueryDNSFunc(_ dns.ZoneInfo, factory utils.QueryDNSFactoryFunc) (provider.CustomQueryDNSFunc, error) {
 	defaultQueryFunc, err := factory()
 	if err != nil {

--- a/pkg/dnsman2/dns/records.go
+++ b/pkg/dnsman2/dns/records.go
@@ -120,6 +120,9 @@ func (rs *RecordSet) Add(records ...*Record) *RecordSet {
 
 // RecordString returns a string representation of the records in the RecordSet.
 func (rs *RecordSet) RecordString() string {
+	if rs == nil {
+		return "null"
+	}
 	line := ""
 	sep := ""
 	for _, r := range rs.Records {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Implementation of handler for provider type `rfc2136` for new dnsman implementation.
 
**Which issue(s) this PR fixes**:

Part of:
* https://github.com/gardener/external-dns-management/issues/441

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
