### PR TITLE
Allow underscore character for `netlify` api token

### DIFF
--- a/pkg/controller/provider/netlify/validation/adaptor.go
+++ b/pkg/controller/provider/netlify/validation/adaptor.go
@@ -24,7 +24,7 @@ type adapter struct {
 func NewAdapter() provider.DNSHandlerAdapter {
 	checks := provider.NewDNSHandlerAdapterChecks()
 	checks.Add(provider.RequiredProperty("NETLIFY_AUTH_TOKEN", "NETLIFY_API_TOKEN").
-		Validators(provider.NoTrailingWhitespaceValidator, provider.Base64CharactersValidator, provider.MaxLengthValidator(64)).
+		Validators(provider.NoTrailingWhitespaceValidator, provider.Base64CharactersUnderscoreValidator, provider.MaxLengthValidator(64)).
 		HideValue())
 	return &adapter{checks: checks}
 }

--- a/pkg/dns/provider/propertyvalidators.go
+++ b/pkg/dns/provider/propertyvalidators.go
@@ -57,6 +57,16 @@ func Base64CharactersValidator(value string) error {
 	return nil
 }
 
+var base64UnderscoreRegex = regexp.MustCompile(`^[a-zA-Z0-9=+/_]+$`)
+
+// Base64CharactersUnderscoreValidator checks if the value contains only characters used for base64 encoding or underscore character.
+func Base64CharactersUnderscoreValidator(value string) error {
+	if !base64UnderscoreRegex.MatchString(value) {
+		return fmt.Errorf("value must contain only characters used for base64 encoding (A-Z, a-z, 0-9, +, /, =, and _)")
+	}
+	return nil
+}
+
 // BoolValidator checks if the value is a valid boolean (true/false).
 func BoolValidator(value string) error {
 	if _, err := strconv.ParseBool(value); err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
The `NETLIFY_API_TOKEN` may contain a underscore character, which is currently forbidden by the validation.
The validation allows now this character now.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
[netlify-dns] Allow underscore character on validating the API token for netlify.
```
