### PR TITLE
[Controller-Runtime-Rewrite] Documentation for reconciliation of `DNSEntry` and `DNSProvider`

### DIFF
--- a/docs/development/dnsentry-reconciliation.md
+++ b/docs/development/dnsentry-reconciliation.md
@@ -1,0 +1,73 @@
+# `DNSEntry` reconciliation
+
+The `reconcile` method in the code handles DNS entry reconciliation by:
+1. Managing DNS provider selection and validation
+2. Locking DNS names to prevent concurrent modifications
+3. Calculating and comparing old vs new DNS targets
+4. Applying necessary changes to DNS records
+5. Updating the DNSEntry status based on the reconciliation results
+
+It's part of a DNS controller that ensures DNS entries are properly managed through different DNS providers while handling state transitions, routing policies, and record updates.
+
+```mermaid
+---
+title: DNSEntry reconciliation
+config:
+  flowchart:
+    htmlLabels: false
+---
+flowchart TD
+    Get("`Get **DNSEntry**`")
+    CheckIgnored{"Has
+    ignore
+    annotation?"}
+    Requeue["Requeue"]
+    LockName{"DNSName
+    locked
+    successfully?"}
+    CalcNewProvider("Calculate New Provider")
+    ProviderFound{"Provider found?"}
+    ProviderReady{"Provider ready?"}
+    UpdateStatus("UpdateStatus")
+    StateReady>"State=Ready"]
+    StateStale>"State=Stale"]
+    TargetsInStatus{"Has targets in\nDNSEntry status?"}
+    StateError>"State=Error"]
+    Validate("Validate DNSEntry spec")
+    CalcOldTargets("Calculate old targets
+    from DNSEntry status")
+    CalcNewTargets("Calculate new targets
+    from DNSEntry spec")
+    QueryRecords("Query records\nfrom authoritative DNS server
+    or via API")
+    CalculateChanges("Calculate change requests
+    (per zone)")
+    ApplyChangeRequests("Apply change requests
+    (if any)")
+    NoMatchingTxt1[/"no matching DNS provider found"/]
+    NoMatchingTxt2[/"no matching DNS provider found"/]
+    ProviderNotReadyTxt[/"provider has status ...
+    or is not ready yet"/]
+    
+    Start --> Get --> CheckIgnored
+    CheckIgnored -->|no| LockName
+    CheckIgnored -->|yes| Stop
+    LockName -->|yes| CalcNewProvider
+    LockName -->|already locked by\nanother reconciliation| Requeue --> Stop
+    CalcNewProvider --> ProviderFound
+    ProviderFound -->|yes| ProviderReady
+    ProviderFound -->|no| TargetsInStatus
+    TargetsInStatus -->|yes| NoMatchingTxt1 --> StateStale
+    TargetsInStatus -->|no| NoMatchingTxt2 --> StateError
+    ProviderReady -->|yes| Validate --> CalcOldTargets
+    ProviderReady -->|no| ProviderNotReadyTxt --> StateStale
+    CalcOldTargets --> CalcNewTargets
+    CalcNewTargets --> QueryRecords
+    QueryRecords --> CalculateChanges
+    CalculateChanges --> ApplyChangeRequests
+    ApplyChangeRequests --> StateReady
+    StateStale --> UpdateStatus
+    StateError --> UpdateStatus
+    StateReady --> UpdateStatus
+    UpdateStatus --> Stop
+```

--- a/docs/dnsman2/README.md
+++ b/docs/dnsman2/README.md
@@ -1,0 +1,18 @@
+# Controller-Runtime-Rewrite
+
+This folder contains documentation for the next major version of the dns-controller-manager,
+which is being rewritten using the [controller-runtime](sigs.k8s.io/controller-runtime).
+The rewrite is still in progress and not yet released.
+
+Additionally, it will contain some major changes to the architecture and features of the dns-controller-manager.
+
+## Major Changes:
+- On reconciling `DNSEntry`, the current state is retrieved by DNS queries to the authoritative nameservers are used instead of the API endpoints of the DNS providers. This saves lots of calls to the API endpoints and makes existing rate limits much less problematic.
+- No support for `InfoBlox` and `Remote` DNS providers anymore
+- No caching of zone state needed anymore.
+
+## Development
+
+See here for current reconciliation logic for DNSEntries and DNSProviders:
+- [Reconciliation of DNSEntries](development/dnsentry-reconciliation.md)
+- [Reconciliation of DNSProviders](development/dnsprovider-reconciliation.md)

--- a/docs/dnsman2/development/dnsprovider-reconciliation.md
+++ b/docs/dnsman2/development/dnsprovider-reconciliation.md
@@ -1,0 +1,52 @@
+# `DNSProvider` reconciliation
+
+The `reconcile` method in this code is responsible for managing DNS provider configurations with the following key steps:
+
+1. Validates the provider type and checks if it's enabled and supported
+2. Retrieves and validates secret references and credentials
+3. Sets up DNS account configuration with TTL and rate limits
+4. Fetches hosted zones from the DNS provider account
+5. Updates the provider state and selection based on zones
+6. Updates the DNSProvider status with current state, zones, TTL, and rate limits
+
+The method ensures proper configuration and state management of DNS providers while handling error cases and validation.
+
+```mermaid
+---
+title: DNSProvider reconciliation
+config:
+  flowchart:
+    htmlLabels: false
+---
+flowchart TD
+    Get("`Get **DNSProvider**`")
+    UpdateStatus("UpdateStatus")
+    StateReady>"State=Ready"]
+    StateError>"State=Error"]
+    StateInvalid>"State=Invalid"]
+    GetSecret("`Get provider **Secret**`")
+    ValidateCredentialsAndProviderConfig("Validate secret data
+    and provider config")
+    GetAccount("Get account
+    from cache or API")
+    GetZones("Get zones")
+    Requeue5min["Requeue after 5min"]
+    CalcZoneAndDomainSelection("Calculate zone and
+    domain selection")
+    
+    Start --> Get
+    Get -->|enabled and supported| GetSecret
+    Get -->|not enabled or not supported| StateInvalid
+    GetSecret -->|ok| ValidateCredentialsAndProviderConfig
+    GetSecret -->|not found| StateError
+    ValidateCredentialsAndProviderConfig -->|validation ok| GetAccount
+    ValidateCredentialsAndProviderConfig -->|validation failed| StateError
+    GetAccount --> GetZones
+    GetZones --> CalcZoneAndDomainSelection
+    GetZones -->|no zones| Requeue5min --> StateError
+    CalcZoneAndDomainSelection --> StateReady
+    StateError --> UpdateStatus
+    StateReady --> UpdateStatus
+    StateInvalid --> UpdateStatus
+    UpdateStatus --> Stop
+```


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind task

**What this PR does / why we need it**:
Documentation and flow charts for reconciliation of `DNSEntry` and `DNSProvider` for the Controller-Runtime-Rewrite, code name "dnsman2".

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
