### PR TITLE
Drop redundant `check` step in build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -76,42 +76,13 @@ jobs:
         run: |
           set -euo pipefail
           mkdir /tmp/blobs.d
-          .ci/verify |& tee /tmp/blobs.d/verify-log.txt
-          tar czf /tmp/blobs.d/verify-log.tar.gz -C/tmp/blobs.d verify-log.txt
-      - name: add-verify-report-to-component-descriptor
-        uses: gardener/cc-utils/.github/actions/export-ocm-fragments@master
-        with:
-          blobs-directory: /tmp/blobs.d
-          ocm-resources: |
-            name: test-results
-            extraIdentity:
-              test: verify
-            relation: local
-            access:
-              type: localBlob
-              localReference: verify-log.tar.gz
-            labels:
-              - name: gardener.cloud/purposes
-                value:
-                  - test
 
-  check:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/setup-go@v6
-        with:
-          go-version: '1.25'
-      - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
-      - name: run-check
-        run: |
-          set -euo pipefail
-          mkdir /tmp/blobs.d
-          .ci/check |& tee /tmp/blobs.d/check-log.txt
-          # check calls `make sast-report`, which generates `gosec-report.sarif`
-          tar czf /tmp/blobs.d/check-log.tar.gz -C/tmp/blobs.d check-log.txt
+          .ci/verify |& tee /tmp/blobs.d/verify-log.txt
+
+          # verify calls `make sast-report`, which generates `gosec-report.sarif`
+
           tar czf /tmp/blobs.d/gosec-report.tar.gz gosec-report.sarif
+          tar czf /tmp/blobs.d/verify-log.tar.gz -C/tmp/blobs.d verify-log.txt
       - name: add-reports-to-component-descriptor
         uses: gardener/cc-utils/.github/actions/export-ocm-fragments@master
         with:
@@ -133,12 +104,10 @@ jobs:
                     we use gosec (linter) for SAST scans
                     see: https://github.com/securego/gosec
             - name: test-results
-              extraIdentity:
-                test: check
               relation: local
               access:
                 type: localBlob
-                localReference: check-log.tar.gz
+                localReference: verify-log.tar.gz
               labels:
                 - name: gardener.cloud/purposes
                   value:

--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,6 @@ clean:
 	@rm -f pkg/apis/dns/crds/*
 	@rm -rf /pkg/client/dns
 
-.PHONY: check
-check: sast-report fastcheck check-imports
-
 .PHONY: check-generate
 check-generate:
 	@bash $(GARDENER_HACK_DIR)/check-generate.sh $(REPO_ROOT)
@@ -46,8 +43,8 @@ check-generate:
 check-imports: $(IMPORT_BOSS)
 	$(IMPORT_BOSS) ./cmd/... ./pkg/... ./test/...
 
-.PHONY: fastcheck
-fastcheck: format $(GOIMPORTS) $(GOLANGCI_LINT)
+.PHONY: check
+check: format check-imports $(GOIMPORTS) $(GOLANGCI_LINT)
 	@TOOLS_BIN_DIR="$(TOOLS_BIN_DIR)" bash $(CONTROLLER_MANAGER_LIB_HACK_DIR)/check.sh --golangci-lint-config=./.golangci.yaml ./cmd/... ./pkg/... ./test/...
 	@echo "Running go vet..."
 	@go vet ./cmd/... ./pkg/... ./test/...
@@ -130,7 +127,7 @@ sast-report: $(GOSEC)
 	@./hack/sast.sh --exclude-dirs hack,local --gosec-report true
 
 .PHONY: verify
-verify: fastcheck format sast
+verify: check format sast
 
 .PHONY: verify-extended
-verify-extended: check-generate fastcheck format sast-report
+verify-extended: check-generate check format sast-report


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind task

**What this PR does / why we need it**:
Drop redundant `check` step in build workflow, as all make targets is already performed in the `verify` step, which calls the `verify-extended` make target.
The `fastcheck` and `check` target have been unified into `check` without the `sast` target. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Simplify build workflow, drop redundant `check` step.
```
