### PR TITLE
[Chore] import cleanup for `pkg/dnsman2/...`

### DIFF
--- a/pkg/dnsman2/.import-restrictions
+++ b/pkg/dnsman2/.import-restrictions
@@ -2,7 +2,6 @@ rules:
   - selectorRegexp: github[.]com/gardener/external-dns-management
     allowedPrefixes:
       - github.com/gardener/external-dns-management/pkg/apis
-      - github.com/gardener/external-dns-management/pkg/dns
       - github.com/gardener/external-dns-management/pkg/dnsman2
   - selectorRegexp: github[.]com/gardener/controller-manager-library
     forbiddenPrefixes:

--- a/pkg/dnsman2/dns/ignore.go
+++ b/pkg/dnsman2/dns/ignore.go
@@ -6,17 +6,16 @@ package dns
 
 import (
 	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
-	"github.com/gardener/external-dns-management/pkg/dns"
 )
 
 // IgnoreFullByAnnotation checks whether the given DNSEntry should be ignored fully based on its annotations.
 // It returns the annotation that caused ignoring it, a boolean indicating whether to ignore it even for deletion.
 func IgnoreFullByAnnotation(entry *v1alpha1.DNSEntry) (string, bool) {
-	if entry.Annotations[dns.AnnotationHardIgnore] == "true" {
-		return dns.AnnotationHardIgnore + "=true", true
+	if entry.Annotations[AnnotationHardIgnore] == "true" {
+		return AnnotationHardIgnore + "=true", true
 	}
-	if entry.Annotations[dns.AnnotationIgnore] == dns.AnnotationIgnoreValueFull {
-		return dns.AnnotationIgnore + "=" + dns.AnnotationIgnoreValueFull, true
+	if entry.Annotations[AnnotationIgnore] == AnnotationIgnoreValueFull {
+		return AnnotationIgnore + "=" + AnnotationIgnoreValueFull, true
 	}
 	return "", false
 }
@@ -24,8 +23,8 @@ func IgnoreFullByAnnotation(entry *v1alpha1.DNSEntry) (string, bool) {
 // IgnoreReconcileByAnnotation checks whether the given DNSEntry should be ignored only for reconciliation based on its annotations.
 // It returns the annotation that caused ignoring it, a boolean indicating whether to ignore it.
 func IgnoreReconcileByAnnotation(entry *v1alpha1.DNSEntry) (string, bool) {
-	if value := entry.Annotations[dns.AnnotationIgnore]; value == dns.AnnotationIgnoreValueReconcile || value == dns.AnnotationIgnoreValueTrue {
-		return dns.AnnotationIgnore + "=" + value, true
+	if value := entry.Annotations[AnnotationIgnore]; value == AnnotationIgnoreValueReconcile || value == AnnotationIgnoreValueTrue {
+		return AnnotationIgnore + "=" + value, true
 	}
 	return "", false
 }

--- a/pkg/dnsman2/dns/provider/errors/handlererror.go
+++ b/pkg/dnsman2/dns/provider/errors/handlererror.go
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package errors
+
+import (
+	"fmt"
+)
+
+type handlerError struct {
+	err error
+}
+
+// WrapAsHandlerError wraps an error as a handler error with a message.
+func WrapAsHandlerError(err error, msg string) error {
+	return fmt.Errorf("%s: %w", msg, &handlerError{err: err})
+}
+
+// WrapfAsHandlerError wraps an error as a handler error with a formatted message.
+func WrapfAsHandlerError(err error, msg string, args ...any) error {
+	s := fmt.Sprintf(msg, args...)
+	return WrapAsHandlerError(err, s)
+}
+
+// IsHandlerError returns true if the error is a handler error.
+func IsHandlerError(err error) bool {
+	_, ok := err.(*handlerError)
+	return ok
+}
+
+// Error returns the error message.
+func (e *handlerError) Error() string {
+	return e.err.Error()
+}
+
+// Cause returns the underlying error.
+func (e *handlerError) Cause() error {
+	return e.err
+}

--- a/pkg/dnsman2/dns/provider/errors/throttlingerror.go
+++ b/pkg/dnsman2/dns/provider/errors/throttlingerror.go
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package errors
+
+import "fmt"
+
+// NewThrottlingError creates a new ThrottlingError.
+func NewThrottlingError(err error) *ThrottlingError {
+	return &ThrottlingError{err: err}
+}
+
+// ThrottlingError wraps an error related to throttling.
+type ThrottlingError struct {
+	err error
+}
+
+// Error returns the error message with throttling prefix.
+func (e *ThrottlingError) Error() string {
+	return fmt.Sprintf("Throttling: %s", e.err)
+}
+
+// IsThrottlingError returns true if the error is a throttling error.
+func IsThrottlingError(err error) bool {
+	_, ok := err.(*ThrottlingError)
+	return ok
+}

--- a/pkg/dnsman2/dns/provider/handler/alicloud/handler.go
+++ b/pkg/dnsman2/dns/provider/handler/alicloud/handler.go
@@ -13,10 +13,10 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/utils/ptr"
 
-	perrs "github.com/gardener/external-dns-management/pkg/dns/provider/errors"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/apis/config"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider"
+	perrs "github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/errors"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/raw"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/utils"
 )

--- a/pkg/dnsman2/dns/provider/handler/aws/execution.go
+++ b/pkg/dnsman2/dns/provider/handler/aws/execution.go
@@ -18,9 +18,9 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/client-go/util/flowcontrol"
 
-	dnserrors "github.com/gardener/external-dns-management/pkg/dns/provider/errors"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider"
+	dnserrors "github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/errors"
 )
 
 type wrappedChange struct {

--- a/pkg/dnsman2/dns/provider/handler/azure-private/handler.go
+++ b/pkg/dnsman2/dns/provider/handler/azure-private/handler.go
@@ -16,10 +16,10 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/utils/ptr"
 
-	perrs "github.com/gardener/external-dns-management/pkg/dns/provider/errors"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/apis/config"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider"
+	perrs "github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/errors"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/handler/azure-private/utils"
 	azutils "github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/handler/azure/utils"
 	dnsutils "github.com/gardener/external-dns-management/pkg/dnsman2/dns/utils"

--- a/pkg/dnsman2/dns/provider/handler/azure/handler.go
+++ b/pkg/dnsman2/dns/provider/handler/azure/handler.go
@@ -14,10 +14,10 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/utils/ptr"
 
-	perrs "github.com/gardener/external-dns-management/pkg/dns/provider/errors"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/apis/config"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider"
+	perrs "github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/errors"
 	azutils "github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/handler/azure/utils"
 	dnsutils "github.com/gardener/external-dns-management/pkg/dnsman2/dns/utils"
 )

--- a/pkg/dnsman2/dns/provider/handler/azure/utils/utils.go
+++ b/pkg/dnsman2/dns/provider/handler/azure/utils/utils.go
@@ -23,8 +23,8 @@ import (
 	securityv1alpha1constants "github.com/gardener/gardener/pkg/apis/security/v1alpha1/constants"
 
 	workloadidentityazure "github.com/gardener/external-dns-management/pkg/apis/dns/workloadidentity/azure"
-	perrs "github.com/gardener/external-dns-management/pkg/dns/provider/errors"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider"
+	perrs "github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/errors"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/handler/azure/constants"
 )
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind technical-debt

**What this PR does / why we need it**:
Ensure that `pkg/dnsman2` packages do not import packages from `github.com/gardener/external-dns-management/pkg/dns`
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
