### PR TITLE
Enhances the DNSProvider resource status to include Gardener-standard `lastOperation` and `lastError` fields

### DIFF
--- a/charts/external-dns-management/templates/crds.yaml
+++ b/charts/external-dns-management/templates/crds.yaml
@@ -606,6 +606,62 @@ spec:
                       type: string
                     type: array
                 type: object
+              lastError:
+                description: lastError holds information about the last occurred error
+                  during an operation
+                properties:
+                  codes:
+                    description: Well-defined error codes of the last error(s).
+                    items:
+                      description: ErrorCode is a string alias.
+                      type: string
+                    type: array
+                  description:
+                    description: A human readable message indicating details about
+                      the last error.
+                    type: string
+                  lastUpdateTime:
+                    description: Last time the error was reported
+                    format: date-time
+                    type: string
+                  taskID:
+                    description: ID of the task which caused this last error
+                    type: string
+                required:
+                - description
+                type: object
+              lastOperation:
+                description: lastOperation holds information about the last operation
+                  on the provider
+                properties:
+                  description:
+                    description: A human readable message indicating details about
+                      the last operation.
+                    type: string
+                  lastUpdateTime:
+                    description: Last time the operation state transitioned from one
+                      to another.
+                    format: date-time
+                    type: string
+                  progress:
+                    description: The progress in percentage (0-100) of the last operation.
+                    format: int32
+                    type: integer
+                  state:
+                    description: Status of the last operation, one of Aborted, Processing,
+                      Succeeded, Error, Failed.
+                    type: string
+                  type:
+                    description: Type of the last operation, one of Create, Reconcile,
+                      Delete, Migrate, Restore.
+                    type: string
+                required:
+                - description
+                - lastUpdateTime
+                - progress
+                - state
+                - type
+                type: object
               lastUpdateTime:
                 description: lastUpdateTime contains the timestamp of the last status
                   update

--- a/pkg/apis/dns/crds/dns.gardener.cloud_dnsproviders.yaml
+++ b/pkg/apis/dns/crds/dns.gardener.cloud_dnsproviders.yaml
@@ -199,6 +199,62 @@ spec:
                       type: string
                     type: array
                 type: object
+              lastError:
+                description: lastError holds information about the last occurred error
+                  during an operation
+                properties:
+                  codes:
+                    description: Well-defined error codes of the last error(s).
+                    items:
+                      description: ErrorCode is a string alias.
+                      type: string
+                    type: array
+                  description:
+                    description: A human readable message indicating details about
+                      the last error.
+                    type: string
+                  lastUpdateTime:
+                    description: Last time the error was reported
+                    format: date-time
+                    type: string
+                  taskID:
+                    description: ID of the task which caused this last error
+                    type: string
+                required:
+                - description
+                type: object
+              lastOperation:
+                description: lastOperation holds information about the last operation
+                  on the provider
+                properties:
+                  description:
+                    description: A human readable message indicating details about
+                      the last operation.
+                    type: string
+                  lastUpdateTime:
+                    description: Last time the operation state transitioned from one
+                      to another.
+                    format: date-time
+                    type: string
+                  progress:
+                    description: The progress in percentage (0-100) of the last operation.
+                    format: int32
+                    type: integer
+                  state:
+                    description: Status of the last operation, one of Aborted, Processing,
+                      Succeeded, Error, Failed.
+                    type: string
+                  type:
+                    description: Type of the last operation, one of Create, Reconcile,
+                      Delete, Migrate, Restore.
+                    type: string
+                required:
+                - description
+                - lastUpdateTime
+                - progress
+                - state
+                - type
+                type: object
               lastUpdateTime:
                 description: lastUpdateTime contains the timestamp of the last status
                   update

--- a/pkg/apis/dns/crds/zz_generated_crds.go
+++ b/pkg/apis/dns/crds/zz_generated_crds.go
@@ -739,6 +739,62 @@ spec:
                       type: string
                     type: array
                 type: object
+              lastError:
+                description: lastError holds information about the last occurred error
+                  during an operation
+                properties:
+                  codes:
+                    description: Well-defined error codes of the last error(s).
+                    items:
+                      description: ErrorCode is a string alias.
+                      type: string
+                    type: array
+                  description:
+                    description: A human readable message indicating details about
+                      the last error.
+                    type: string
+                  lastUpdateTime:
+                    description: Last time the error was reported
+                    format: date-time
+                    type: string
+                  taskID:
+                    description: ID of the task which caused this last error
+                    type: string
+                required:
+                - description
+                type: object
+              lastOperation:
+                description: lastOperation holds information about the last operation
+                  on the provider
+                properties:
+                  description:
+                    description: A human readable message indicating details about
+                      the last operation.
+                    type: string
+                  lastUpdateTime:
+                    description: Last time the operation state transitioned from one
+                      to another.
+                    format: date-time
+                    type: string
+                  progress:
+                    description: The progress in percentage (0-100) of the last operation.
+                    format: int32
+                    type: integer
+                  state:
+                    description: Status of the last operation, one of Aborted, Processing,
+                      Succeeded, Error, Failed.
+                    type: string
+                  type:
+                    description: Type of the last operation, one of Create, Reconcile,
+                      Delete, Migrate, Restore.
+                    type: string
+                required:
+                - description
+                - lastUpdateTime
+                - progress
+                - state
+                - type
+                type: object
               lastUpdateTime:
                 description: lastUpdateTime contains the timestamp of the last status
                   update

--- a/pkg/apis/dns/v1alpha1/dnsprovider.go
+++ b/pkg/apis/dns/v1alpha1/dnsprovider.go
@@ -5,6 +5,7 @@
 package v1alpha1
 
 import (
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -130,6 +131,12 @@ type DNSProviderStatus struct {
 	// actually used access credential
 	// +optional
 	SecretRef *corev1.SecretReference `json:"secretRef,omitempty"`
+	// lastOperation holds information about the last operation on the provider
+	// +optional
+	LastOperation *gardencorev1beta1.LastOperation `json:"lastOperation,omitempty"`
+	// lastError holds information about the last occurred error during an operation
+	// +optional
+	LastError *gardencorev1beta1.LastError `json:"lastError,omitempty"`
 }
 
 type DNSSelectionStatus struct {

--- a/pkg/apis/dns/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/dns/v1alpha1/zz_generated.deepcopy.go
@@ -9,6 +9,7 @@
 package v1alpha1
 
 import (
+	v1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -551,6 +552,16 @@ func (in *DNSProviderStatus) DeepCopyInto(out *DNSProviderStatus) {
 		in, out := &in.SecretRef, &out.SecretRef
 		*out = new(v1.SecretReference)
 		**out = **in
+	}
+	if in.LastOperation != nil {
+		in, out := &in.LastOperation, &out.LastOperation
+		*out = new(v1beta1.LastOperation)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.LastError != nil {
+		in, out := &in.LastError, &out.LastError
+		*out = new(v1beta1.LastError)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/pkg/controller/replication/dnsprovider/handler.go
+++ b/pkg/controller/replication/dnsprovider/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/resources/access"
 	"github.com/gardener/controller-manager-library/pkg/utils"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -398,6 +399,39 @@ func (this *sourceReconciler) updateSourceStatus(source *api.DNSProvider, source
 		mod.AssureStringPtrPtr(&s.Status.Message, &sourceMsg)
 		mod.AssureStringValue(&s.Status.State, api.STATE_ERROR)
 		mod.AssureInt64Value(&s.Status.ObservedGeneration, source.Generation)
+
+		// Set LastError with error codes
+		errorCodes := dnsutils.DetermineErrorCodes(fmt.Errorf("%s", sourceMsg))
+		newLastError := &gardencorev1beta1.LastError{
+			Description: sourceMsg,
+			Codes:       errorCodes,
+		}
+
+		// Set LastOperation to Failed/Error state
+		operationType := gardencorev1beta1.LastOperationTypeReconcile
+		if source.DeletionTimestamp != nil {
+			operationType = gardencorev1beta1.LastOperationTypeDelete
+		}
+
+		operationState := gardencorev1beta1.LastOperationStateError
+		// Use Failed state for non-retryable errors
+		if dnsutils.HasNonRetryableErrorCode(errorCodes) {
+			operationState = gardencorev1beta1.LastOperationStateFailed
+		}
+
+		newLastOperation := &gardencorev1beta1.LastOperation{
+			Description: sourceMsg,
+			Progress:    0,
+			State:       operationState,
+			Type:        operationType,
+		}
+		b := dnsutils.SetLastOperationAndError(&s.Status, newLastOperation, newLastError)
+		mod.Modified = mod.Modified || b
+		if mod.Modified {
+			dnsutils.SetLastUpdateTime(&s.Status.LastUpdateTime)
+			dnsutils.SetLastOperationAndErrorTime(&s.Status)
+		}
+
 		return mod.IsModified(), nil
 	})
 	if err != nil {

--- a/pkg/controller/replication/dnsprovider/slaves.go
+++ b/pkg/controller/replication/dnsprovider/slaves.go
@@ -90,6 +90,8 @@ func (this *slaveReconciler) Reconcile(logger logger.LogContext, obj resources.O
 				}
 				mod.AssureStringPtrPtr(&ownerStatus.Message, msg)
 				assureTimeValuePtrPtr(mod, &ownerStatus.LastUpdateTime, status.LastUpdateTime)
+				b := utils.SetLastOperationAndError(ownerStatus, status.LastOperation, status.LastError)
+				mod.Modified = mod.Modified || b
 				if mod.IsModified() {
 					err = o.UpdateStatus()
 					if err != nil {

--- a/pkg/dns/provider/provider.go
+++ b/pkg/dns/provider/provider.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gardener/controller-manager-library/pkg/logger"
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/utils"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	securityv1alpha1constants "github.com/gardener/gardener/pkg/apis/security/v1alpha1/constants"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -385,19 +386,19 @@ func updateDNSProvider(logger logger.LogContext, state *state, provider *dnsutil
 
 	if validationError := secretObj.GetAnnotations()[dns.AnnotationValidationError]; validationError != "" {
 		// propagate validation error from the target secret (if it is a replicated provider)
-		return this, this.failed(logger, false, fmt.Errorf("%s", validationError), false)
+		return this, this.failed(logger, false, fmt.Errorf("%s", validationError), false, gardencorev1beta1.ErrorConfigurationProblem)
 	}
 
 	if err := checkAndAddWorkloadIdentitySecretLabel(secretObj, props); err != nil {
-		return this, this.failed(logger, false, err, false)
+		return this, this.failed(logger, false, err, false, gardencorev1beta1.ErrorConfigurationProblem)
 	}
 
 	adapter, err := state.GetHandlerFactory().GetDNSHandlerAdapter(provider.TypeCode())
 	if err != nil {
-		return this, this.failed(logger, false, err, false)
+		return this, this.failed(logger, false, err, false, gardencorev1beta1.ErrorConfigurationProblem)
 	}
 	if err := adapter.ValidateCredentialsAndProviderConfig(props, provider.Spec().ProviderConfig); err != nil {
-		return this, this.failed(logger, false, err, false)
+		return this, this.failed(logger, false, err, false, gardencorev1beta1.ErrorConfigurationProblem)
 	}
 
 	this.account, err = state.GetDNSAccount(logger, provider, props)
@@ -545,8 +546,8 @@ func (this *dnsProviderVersion) MapTargets(dnsName string, targets []Target) []T
 	return this.account.MapTargets(dnsName, targets)
 }
 
-func (this *dnsProviderVersion) setError(modified bool, err error) error {
-	modified = this.object.SetStateWithError(api.STATE_ERROR, err) || modified
+func (this *dnsProviderVersion) setError(modified bool, err error, errorCodes ...gardencorev1beta1.ErrorCode) error {
+	modified = this.object.SetStateWithError(api.STATE_ERROR, err, errorCodes...) || modified
 	if modified {
 		dnsutils.SetLastUpdateTime(&this.object.Status().LastUpdateTime)
 		return this.object.UpdateStatus()
@@ -554,8 +555,8 @@ func (this *dnsProviderVersion) setError(modified bool, err error) error {
 	return nil
 }
 
-func (this *dnsProviderVersion) failed(logger logger.LogContext, modified bool, err error, temp bool) reconcile.Status {
-	uerr := this.setError(modified, err)
+func (this *dnsProviderVersion) failed(logger logger.LogContext, modified bool, err error, temp bool, errorCodes ...gardencorev1beta1.ErrorCode) reconcile.Status {
+	uerr := this.setError(modified, err, errorCodes...)
 	if uerr != nil {
 		if temp {
 			logger.Info(err)
@@ -605,8 +606,18 @@ func (this *dnsProviderVersion) succeeded(logger logger.LogContext, modified boo
 	mod.AssureInt64Value(&status.ObservedGeneration, this.object.DNSProvider().Generation)
 	mod.AssureInt64PtrValue(&status.DefaultTTL, this.defaultTTL)
 	assureRateLimit(mod, &status.RateLimit, this.rateLimit)
+	// Set LastOperation to Succeeded and clear LastError on success
+	newLastOperation := &gardencorev1beta1.LastOperation{
+		Description: "Provider operational",
+		Progress:    100,
+		State:       gardencorev1beta1.LastOperationStateSucceeded,
+		Type:        gardencorev1beta1.LastOperationTypeReconcile,
+	}
+	b := dnsutils.SetLastOperationAndError(status, newLastOperation, nil)
+	mod.Modified = mod.Modified || b
 	if mod.IsModified() {
 		dnsutils.SetLastUpdateTime(&this.object.Status().LastUpdateTime)
+		dnsutils.SetLastOperationAndErrorTime(this.object.Status())
 	}
 	return reconcile.UpdateStatus(logger, mod)
 }

--- a/pkg/dns/utils/errors.go
+++ b/pkg/dns/utils/errors.go
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"strings"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+)
+
+// DetermineErrorCodes analyzes an error message and returns appropriate Gardener error codes.
+// This enables Gardener to distinguish between user configuration errors and system-level failures,
+// allowing for proper retry logic and error propagation to Shoot status.
+func DetermineErrorCodes(err error) []gardencorev1beta1.ErrorCode {
+	if err == nil {
+		return nil
+	}
+
+	errStr := strings.ToLower(err.Error())
+	var codes []gardencorev1beta1.ErrorCode
+
+	// Check for authentication/authorization issues
+	// These are typically user configuration errors (invalid credentials/tokens)
+	if containsAny(errStr,
+		"unauthenticated",
+		"authentication failed",
+		"invalid token",
+		"invalid credentials",
+		"invalid api token",
+		"invalid access token",
+		"invalid api key",
+		"authentication error",
+		"auth failed",
+		"bad credentials",
+		"signaturedoesnotmatch") {
+		codes = append(codes, gardencorev1beta1.ErrorInfraUnauthenticated)
+	}
+
+	if containsAny(errStr,
+		"unauthorized",
+		"forbidden",
+		"access denied",
+		"permission denied",
+		"insufficient permissions") {
+		codes = append(codes, gardencorev1beta1.ErrorInfraUnauthorized)
+	}
+
+	// Rate limiting - these are retryable errors
+	if containsAny(errStr,
+		"rate limit",
+		"ratelimit",
+		"throttl",
+		"too many requests",
+		"request limit exceeded") {
+		codes = append(codes, gardencorev1beta1.ErrorInfraRateLimitsExceeded)
+	}
+
+	// Quota issues - non-retryable, user needs to increase quota
+	if containsAny(errStr,
+		"quota exceeded",
+		"quota limit",
+		"insufficient quota") {
+		codes = append(codes, gardencorev1beta1.ErrorInfraQuotaExceeded)
+	}
+
+	// Generic configuration problem if no specific code matched but looks like config issue
+	if len(codes) == 0 && containsAny(errStr,
+		"invalid",
+		"malformed",
+		"bad request",
+		"configuration error",
+		"config error",
+		"validation error",
+		"validation failed",
+		"not supported") {
+		codes = append(codes, gardencorev1beta1.ErrorConfigurationProblem)
+	}
+
+	return codes
+}
+
+var nonRetryableCodes = map[gardencorev1beta1.ErrorCode]bool{
+	gardencorev1beta1.ErrorInfraUnauthenticated:   true,
+	gardencorev1beta1.ErrorInfraUnauthorized:      true,
+	gardencorev1beta1.ErrorInfraQuotaExceeded:     true,
+	gardencorev1beta1.ErrorInfraDependencies:      true,
+	gardencorev1beta1.ErrorInfraResourcesDepleted: true,
+	gardencorev1beta1.ErrorConfigurationProblem:   true,
+	gardencorev1beta1.ErrorProblematicWebhook:     true,
+}
+
+// HasNonRetryableErrorCode checks if any of the provided error codes indicate
+// a non-retryable error (e.g., authentication failure, configuration problem).
+func HasNonRetryableErrorCode(codes []gardencorev1beta1.ErrorCode) bool {
+	for _, code := range codes {
+		if nonRetryableCodes[code] {
+			return true
+		}
+	}
+	return false
+}
+
+// containsAny checks if the string contains any of the provided substrings.
+func containsAny(s string, substrs ...string) bool {
+	for _, substr := range substrs {
+		if strings.Contains(s, substr) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/dns/utils/errors.go
+++ b/pkg/dns/utils/errors.go
@@ -68,9 +68,7 @@ func DetermineErrorCodes(err error) []gardencorev1beta1.ErrorCode {
 
 	// Generic configuration problem if no specific code matched but looks like config issue
 	if len(codes) == 0 && containsAny(errStr,
-		"invalid",
 		"malformed",
-		"bad request",
 		"configuration error",
 		"config error",
 		"validation error",

--- a/pkg/dns/utils/errors.go
+++ b/pkg/dns/utils/errors.go
@@ -34,7 +34,8 @@ func DetermineErrorCodes(err error) []gardencorev1beta1.ErrorCode {
 		"authentication error",
 		"auth failed",
 		"bad credentials",
-		"signaturedoesnotmatch") {
+		"signaturedoesnotmatch",
+		"invalid_grant") {
 		codes = append(codes, gardencorev1beta1.ErrorInfraUnauthenticated)
 	}
 

--- a/pkg/dns/utils/errors_test.go
+++ b/pkg/dns/utils/errors_test.go
@@ -100,12 +100,6 @@ var _ = Describe("Error Code Determination", func() {
 		})
 
 		Context("when error contains configuration keywords", func() {
-			It("should return ErrorConfigurationProblem for invalid configuration", func() {
-				err := errors.New("Invalid DNS zone configuration")
-				codes := DetermineErrorCodes(err)
-				Expect(codes).To(ConsistOf(gardencorev1beta1.ErrorConfigurationProblem))
-			})
-
 			It("should return ErrorConfigurationProblem for malformed request", func() {
 				err := errors.New("Malformed API request")
 				codes := DetermineErrorCodes(err)

--- a/pkg/dns/utils/errors_test.go
+++ b/pkg/dns/utils/errors_test.go
@@ -40,6 +40,21 @@ var _ = Describe("Error Code Determination", func() {
 				codes := DetermineErrorCodes(err)
 				Expect(codes).To(ConsistOf(gardencorev1beta1.ErrorInfraUnauthenticated))
 			})
+
+			It("should return ErrorInfraUnauthenticated for Aws Route53 invalid access", func() {
+				err := errors.New(`ListHostedZones failed: api error SignatureDoesNotMatch: The request
+      signature we calculated does not match the signature you provided. Check your
+      AWS Secret Access Key and signing method. Consult the service documentation
+      for details.`)
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(ConsistOf(gardencorev1beta1.ErrorInfraUnauthenticated))
+			})
+
+			It("should return ErrorInfraUnauthenticated for Google Cloud DNS invalid grant", func() {
+				err := errors.New(`Response: {"error":"invalid_grant","error_description":"Invalid grant: account not found"}`)
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(ConsistOf(gardencorev1beta1.ErrorInfraUnauthenticated))
+			})
 		})
 
 		Context("when error contains authorization keywords", func() {

--- a/pkg/dns/utils/errors_test.go
+++ b/pkg/dns/utils/errors_test.go
@@ -1,0 +1,216 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"errors"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Error Code Determination", func() {
+	Describe("DetermineErrorCodes", func() {
+		Context("when error is nil", func() {
+			It("should return nil codes", func() {
+				codes := DetermineErrorCodes(nil)
+				Expect(codes).To(BeNil())
+			})
+		})
+
+		Context("when error contains authentication keywords", func() {
+			It("should return ErrorInfraUnauthenticated for invalid token", func() {
+				err := errors.New("Cloudflare API error: Invalid access token (HTTP 403)")
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(HaveLen(1))
+				Expect(codes).To(ContainElement(gardencorev1beta1.ErrorInfraUnauthenticated))
+			})
+
+			It("should return ErrorInfraUnauthenticated for invalid API key", func() {
+				err := errors.New("Invalid API key provided")
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(ConsistOf(gardencorev1beta1.ErrorInfraUnauthenticated))
+			})
+
+			It("should return ErrorInfraUnauthenticated for bad credentials", func() {
+				err := errors.New("Authentication failed: bad credentials")
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(ConsistOf(gardencorev1beta1.ErrorInfraUnauthenticated))
+			})
+		})
+
+		Context("when error contains authorization keywords", func() {
+			It("should return ErrorInfraUnauthorized for forbidden", func() {
+				err := errors.New("Access forbidden: insufficient permissions")
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(ConsistOf(gardencorev1beta1.ErrorInfraUnauthorized))
+			})
+
+			It("should return ErrorInfraUnauthorized for access denied", func() {
+				err := errors.New("Access denied for this resource")
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(ConsistOf(gardencorev1beta1.ErrorInfraUnauthorized))
+			})
+		})
+
+		Context("when error contains rate limiting keywords", func() {
+			It("should return ErrorInfraRateLimitsExceeded for rate limit error", func() {
+				err := errors.New("Rate limit exceeded, please retry later")
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(ConsistOf(gardencorev1beta1.ErrorInfraRateLimitsExceeded))
+			})
+
+			It("should return ErrorInfraRateLimitsExceeded for too many requests", func() {
+				err := errors.New("Too many requests (HTTP 429)")
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(ConsistOf(gardencorev1beta1.ErrorInfraRateLimitsExceeded))
+			})
+
+			It("should return ErrorInfraRateLimitsExceeded for throttling", func() {
+				err := errors.New("Request throttled by provider")
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(ConsistOf(gardencorev1beta1.ErrorInfraRateLimitsExceeded))
+			})
+		})
+
+		Context("when error contains quota keywords", func() {
+			It("should return ErrorInfraQuotaExceeded for quota error", func() {
+				err := errors.New("Quota exceeded for DNS zones")
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(ConsistOf(gardencorev1beta1.ErrorInfraQuotaExceeded))
+			})
+		})
+
+		Context("when error contains configuration keywords", func() {
+			It("should return ErrorConfigurationProblem for invalid configuration", func() {
+				err := errors.New("Invalid DNS zone configuration")
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(ConsistOf(gardencorev1beta1.ErrorConfigurationProblem))
+			})
+
+			It("should return ErrorConfigurationProblem for malformed request", func() {
+				err := errors.New("Malformed API request")
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(ConsistOf(gardencorev1beta1.ErrorConfigurationProblem))
+			})
+
+			It("should return ErrorConfigurationProblem for unsupported provider", func() {
+				err := errors.New("provider type \"foo\" is not supported")
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(ConsistOf(gardencorev1beta1.ErrorConfigurationProblem))
+			})
+		})
+
+		Context("when error contains multiple error patterns", func() {
+			It("should return multiple error codes", func() {
+				err := errors.New("Invalid token and rate limit exceeded")
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(HaveLen(2))
+				Expect(codes).To(ConsistOf(
+					gardencorev1beta1.ErrorInfraUnauthenticated,
+					gardencorev1beta1.ErrorInfraRateLimitsExceeded,
+				))
+			})
+		})
+
+		Context("when error does not match any pattern", func() {
+			It("should return no error codes", func() {
+				err := errors.New("Generic error message without keywords")
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(BeEmpty())
+			})
+		})
+	})
+
+	Describe("hasNonRetryableErrorCode", func() {
+		Context("when codes list is empty", func() {
+			It("should return false for nil codes", func() {
+				Expect(HasNonRetryableErrorCode(nil)).To(BeFalse())
+			})
+
+			It("should return false for empty codes slice", func() {
+				Expect(HasNonRetryableErrorCode([]gardencorev1beta1.ErrorCode{})).To(BeFalse())
+			})
+		})
+
+		Context("when codes contain only retryable errors", func() {
+			It("should return false for rate limit error", func() {
+				codes := []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorInfraRateLimitsExceeded}
+				Expect(HasNonRetryableErrorCode(codes)).To(BeFalse())
+			})
+
+			It("should return false for retryable configuration problem", func() {
+				codes := []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorRetryableConfigurationProblem}
+				Expect(HasNonRetryableErrorCode(codes)).To(BeFalse())
+			})
+
+			It("should return false for retryable infra dependencies", func() {
+				codes := []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorRetryableInfraDependencies}
+				Expect(HasNonRetryableErrorCode(codes)).To(BeFalse())
+			})
+		})
+
+		Context("when codes contain non-retryable errors", func() {
+			It("should return true for unauthenticated error", func() {
+				codes := []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorInfraUnauthenticated}
+				Expect(HasNonRetryableErrorCode(codes)).To(BeTrue())
+			})
+
+			It("should return true for unauthorized error", func() {
+				codes := []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorInfraUnauthorized}
+				Expect(HasNonRetryableErrorCode(codes)).To(BeTrue())
+			})
+
+			It("should return true for configuration problem", func() {
+				codes := []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorConfigurationProblem}
+				Expect(HasNonRetryableErrorCode(codes)).To(BeTrue())
+			})
+
+			It("should return true for quota exceeded error", func() {
+				codes := []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorInfraQuotaExceeded}
+				Expect(HasNonRetryableErrorCode(codes)).To(BeTrue())
+			})
+		})
+
+		Context("when codes contain mixed retryable and non-retryable errors", func() {
+			It("should return true if any code is non-retryable", func() {
+				codes := []gardencorev1beta1.ErrorCode{
+					gardencorev1beta1.ErrorInfraRateLimitsExceeded,
+					gardencorev1beta1.ErrorInfraUnauthenticated,
+				}
+				Expect(HasNonRetryableErrorCode(codes)).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("containsAny", func() {
+		Context("when substring list is empty", func() {
+			It("should return false", func() {
+				Expect(containsAny("hello world")).To(BeFalse())
+			})
+		})
+
+		Context("when string contains one of the substrings", func() {
+			It("should return true for single match", func() {
+				Expect(containsAny("invalid token provided", "invalid", "error")).To(BeTrue())
+			})
+
+			It("should return true for multiple matches", func() {
+				Expect(containsAny("invalid token provided", "invalid", "token")).To(BeTrue())
+			})
+		})
+
+		Context("when string contains none of the substrings", func() {
+			It("should return false", func() {
+				Expect(containsAny("hello world", "foo", "bar")).To(BeFalse())
+			})
+
+			It("should be case sensitive", func() {
+				Expect(containsAny("hello world", "Hello")).To(BeFalse())
+			})
+		})
+	})
+})

--- a/pkg/dns/utils/utils.go
+++ b/pkg/dns/utils/utils.go
@@ -77,5 +77,5 @@ func (this *LogMessage) Debugf(logger logger.LogContext, add ...any) bool {
 
 // SetLastUpdateTime sets the time wrapper to the current UTC time.
 func SetLastUpdateTime(lastUpdateTime **metav1.Time) {
-	*lastUpdateTime = &metav1.Time{Time: time.Now().UTC()}
+	*lastUpdateTime = &metav1.Time{Time: time.Now()}
 }

--- a/pkg/dns/utils/utils_provider.go
+++ b/pkg/dns/utils/utils_provider.go
@@ -6,10 +6,12 @@ package utils
 
 import (
 	"errors"
+	"reflect"
 	"strings"
 
 	"github.com/gardener/controller-manager-library/pkg/resources"
 	"github.com/gardener/controller-manager-library/pkg/utils"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	api "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
@@ -46,7 +48,7 @@ func (this *DNSProviderObject) TypeCode() string {
 	return this.DNSProvider().Spec.Type
 }
 
-func (this *DNSProviderObject) SetStateWithError(_ string, err error) bool {
+func (this *DNSProviderObject) SetStateWithError(_ string, err error, errorCodes ...gardencorev1beta1.ErrorCode) bool {
 	type causer interface {
 		error
 		Cause() error
@@ -75,22 +77,59 @@ func (this *DNSProviderObject) SetStateWithError(_ string, err error) bool {
 		if len(message) > len(handlerErrorMsg) && strings.HasSuffix(message, handlerErrorMsg) {
 			prefix = message[:len(message)-len(handlerErrorMsg)]
 		}
-		return this.SetState(api.STATE_ERROR, message, prefix)
+		return this.SetState(api.STATE_ERROR, message, errorCodes, prefix)
 	}
-	return this.SetState(api.STATE_ERROR, message)
+	return this.SetState(api.STATE_ERROR, message, errorCodes)
 }
 
-func (this *DNSProviderObject) SetState(state, message string, commonMessagePrefix ...string) bool {
+func (this *DNSProviderObject) SetState(state, message string, errorCodes []gardencorev1beta1.ErrorCode, commonMessagePrefix ...string) bool {
 	mod := &utils.ModificationState{}
 	status := &this.DNSProvider().Status
 	if len(commonMessagePrefix) != 1 || status.Message == nil || !strings.HasPrefix(*status.Message, commonMessagePrefix[0]) {
-		// only update if prefix has changed. This avoids race conditions (state update <-> reconcilie) if message
+		// only update if prefix has changed. This avoids race conditions (state update <-> reconcile) if message
 		// contains time stamps or correlation ids
 		mod.AssureStringPtrValue(&status.Message, message)
 	}
 	mod.AssureStringValue(&status.State, state)
+	this.updateLastOperationAndLastError(mod, message, errorCodes...)
 	mod.AssureInt64Value(&status.ObservedGeneration, this.DNSProvider().Generation)
 	return mod.IsModified()
+}
+
+func (this *DNSProviderObject) updateLastOperationAndLastError(mod *utils.ModificationState, message string, errorCodes ...gardencorev1beta1.ErrorCode) {
+	status := &this.DNSProvider().Status
+	if len(errorCodes) == 0 {
+		errorCodes = DetermineErrorCodes(errors.New(message))
+	}
+	newLastError := &gardencorev1beta1.LastError{
+		Description: message,
+		Codes:       errorCodes,
+	}
+
+	// Set LastOperation to Failed/Error state
+	operationType := gardencorev1beta1.LastOperationTypeReconcile
+	if this.DNSProvider().DeletionTimestamp != nil {
+		operationType = gardencorev1beta1.LastOperationTypeDelete
+	}
+
+	operationState := gardencorev1beta1.LastOperationStateError
+	// Use Failed state for non-retryable errors
+	if HasNonRetryableErrorCode(errorCodes) {
+		operationState = gardencorev1beta1.LastOperationStateFailed
+	}
+
+	newLastOperation := &gardencorev1beta1.LastOperation{
+		Description: message,
+		Progress:    0,
+		State:       operationState,
+		Type:        operationType,
+	}
+	b := SetLastOperationAndError(status, newLastOperation, newLastError)
+	mod.Modified = mod.Modified || b
+	if mod.Modified {
+		SetLastUpdateTime(&status.LastUpdateTime)
+		SetLastOperationAndErrorTime(status)
+	}
 }
 
 func (this *DNSProviderObject) SetSelection(included, excluded utils.StringSet, target *api.DNSSelectionStatus) bool {
@@ -113,4 +152,28 @@ func DNSProvider(o resources.Object) *DNSProviderObject {
 		return &DNSProviderObject{o}
 	}
 	return nil
+}
+
+func SetLastOperationAndError(status *api.DNSProviderStatus, lastOperation *gardencorev1beta1.LastOperation, lastError *gardencorev1beta1.LastError) bool {
+	var modified = status.LastOperation == nil ||
+		status.LastOperation.State != lastOperation.State ||
+		status.LastOperation.Type != lastOperation.Type ||
+		status.LastOperation.Description != lastOperation.Description ||
+		status.LastOperation.Progress != lastOperation.Progress
+
+	status.LastOperation = lastOperation
+
+	modified = modified || !reflect.DeepEqual(status.LastError, lastError)
+	status.LastError = lastError
+
+	return modified
+}
+
+func SetLastOperationAndErrorTime(status *api.DNSProviderStatus) {
+	if status.LastOperation != nil && status.LastUpdateTime != nil {
+		status.LastOperation.LastUpdateTime = *status.LastUpdateTime
+	}
+	if status.LastError != nil {
+		status.LastError.LastUpdateTime = status.LastUpdateTime
+	}
 }

--- a/pkg/dnsman2/.import-restrictions
+++ b/pkg/dnsman2/.import-restrictions
@@ -2,7 +2,6 @@ rules:
   - selectorRegexp: github[.]com/gardener/external-dns-management
     allowedPrefixes:
       - github.com/gardener/external-dns-management/pkg/apis
-      - github.com/gardener/external-dns-management/pkg/dns
       - github.com/gardener/external-dns-management/pkg/dnsman2
   - selectorRegexp: github[.]com/gardener/controller-manager-library
     forbiddenPrefixes:

--- a/pkg/dnsman2/apis/dns/crd-dns.gardener.cloud_dnsproviders.yaml
+++ b/pkg/dnsman2/apis/dns/crd-dns.gardener.cloud_dnsproviders.yaml
@@ -199,6 +199,62 @@ spec:
                       type: string
                     type: array
                 type: object
+              lastError:
+                description: lastError holds information about the last occurred error
+                  during an operation
+                properties:
+                  codes:
+                    description: Well-defined error codes of the last error(s).
+                    items:
+                      description: ErrorCode is a string alias.
+                      type: string
+                    type: array
+                  description:
+                    description: A human readable message indicating details about
+                      the last error.
+                    type: string
+                  lastUpdateTime:
+                    description: Last time the error was reported
+                    format: date-time
+                    type: string
+                  taskID:
+                    description: ID of the task which caused this last error
+                    type: string
+                required:
+                - description
+                type: object
+              lastOperation:
+                description: lastOperation holds information about the last operation
+                  on the provider
+                properties:
+                  description:
+                    description: A human readable message indicating details about
+                      the last operation.
+                    type: string
+                  lastUpdateTime:
+                    description: Last time the operation state transitioned from one
+                      to another.
+                    format: date-time
+                    type: string
+                  progress:
+                    description: The progress in percentage (0-100) of the last operation.
+                    format: int32
+                    type: integer
+                  state:
+                    description: Status of the last operation, one of Aborted, Processing,
+                      Succeeded, Error, Failed.
+                    type: string
+                  type:
+                    description: Type of the last operation, one of Create, Reconcile,
+                      Delete, Migrate, Restore.
+                    type: string
+                required:
+                - description
+                - lastUpdateTime
+                - progress
+                - state
+                - type
+                type: object
               lastUpdateTime:
                 description: lastUpdateTime contains the timestamp of the last status
                   update

--- a/pkg/dnsman2/controller/controlplane/dnsprovider/add.go
+++ b/pkg/dnsman2/controller/controlplane/dnsprovider/add.go
@@ -142,12 +142,13 @@ func (r *Reconciler) providersToReconcileOnSecretChanges(ctx context.Context, se
 	if !ok {
 		return nil
 	}
+	secretKey := client.ObjectKeyFromObject(secret)
 	providerList := &v1alpha1.DNSProviderList{}
 	if err := r.Client.List(ctx, providerList, client.InNamespace(r.Config.Namespace)); err != nil {
 		return nil
 	}
 	for _, provider := range dns.FilterProvidersByClass(providerList.Items, r.Class) {
-		if provider.Spec.SecretRef != nil && provider.Spec.SecretRef.Name == secret.GetName() && getSecretRefNamespace(&provider) == secret.GetNamespace() {
+		if key := getSpecSecretRefKey(&provider); key != nil && secretKey == *key {
 			requests = append(requests, reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Name:      provider.Name,

--- a/pkg/dnsman2/controller/controlplane/dnsprovider/reconciler.go
+++ b/pkg/dnsman2/controller/controlplane/dnsprovider/reconciler.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"time"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -28,6 +29,7 @@ import (
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns"
 	dnsprovider "github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/state"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/utils"
 )
 
 // Reconciler is a reconciler for DNSProvider resources on the control plane.
@@ -83,21 +85,17 @@ func (r *Reconciler) addFinalizer(ctx context.Context, c client.Client, provider
 	if err := controllerutils.AddFinalizers(ctx, c, provider, dns.FinalizerCompound); err != nil {
 		return err
 	}
-	if provider.Spec.SecretRef == nil {
-		return nil
-	}
 	if ptr.Deref(r.Config.MigrationMode, false) {
 		// In migration mode, do not add finalizers to secrets as they may be removed immediately after creation by the old controller.
 		// see pkg/dns/provider/state_secret.go, method UpdateSecret() for details.
 		return nil
 	}
-	secret := &corev1.Secret{}
-	if err := c.Get(ctx, client.ObjectKey{Namespace: getSecretRefNamespace(provider), Name: provider.Spec.SecretRef.Name}, secret); err != nil {
-		if apierrors.IsNotFound(err) {
-			// Secret does not exist, cannot add finalizer
-			return nil
-		}
-		return fmt.Errorf("error retrieving secret %s/%s: %w", getSecretRefNamespace(provider), provider.Spec.SecretRef.Name, err)
+	secret, err := getSpecSecret(ctx, r.Client, provider)
+	if err != nil {
+		return err
+	}
+	if secret == nil {
+		return nil
 	}
 	return controllerutils.AddFinalizers(ctx, c, secret, dns.FinalizerCompound)
 }
@@ -106,16 +104,12 @@ func (r *Reconciler) removeFinalizer(ctx context.Context, c client.Client, provi
 	if err := controllerutils.RemoveFinalizers(ctx, c, provider, dns.FinalizerCompound); err != nil {
 		return err
 	}
-	if provider.Spec.SecretRef == nil {
-		return nil
+	secret, err := getSpecSecret(ctx, r.Client, provider)
+	if err != nil {
+		return err
 	}
-	secret := &corev1.Secret{}
-	if err := c.Get(ctx, client.ObjectKey{Namespace: getSecretRefNamespace(provider), Name: provider.Spec.SecretRef.Name}, secret); err != nil {
-		if apierrors.IsNotFound(err) {
-			// Secret does not exist, cannot remove finalizer
-			return nil
-		}
-		return fmt.Errorf("error retrieving secret %s/%s: %w", getSecretRefNamespace(provider), provider.Spec.SecretRef.Name, err)
+	if secret == nil {
+		return nil
 	}
 	return controllerutils.RemoveFinalizers(ctx, c, secret, dns.FinalizerCompound)
 }
@@ -140,6 +134,33 @@ func (r *Reconciler) updateStatusFailed(ctx context.Context, provider *v1alpha1.
 		status.Domains = v1alpha1.DNSSelectionStatus{}
 		status.RateLimit = nil
 		status.DefaultTTL = nil
+
+		// Set LastError with error codes for Gardener integration
+		errorCodes := utils.DetermineErrorCodes(err)
+		status.LastError = &gardencorev1beta1.LastError{
+			Description: err.Error(),
+			Codes:       errorCodes,
+		}
+
+		// Set LastOperation to Failed/Error state
+		operationType := gardencorev1beta1.LastOperationTypeReconcile
+		if provider.DeletionTimestamp != nil {
+			operationType = gardencorev1beta1.LastOperationTypeDelete
+		}
+
+		operationState := gardencorev1beta1.LastOperationStateError
+		// Use Failed state for non-retryable errors
+		if utils.HasNonRetryableErrorCode(errorCodes) {
+			operationState = gardencorev1beta1.LastOperationStateFailed
+		}
+
+		status.LastOperation = &gardencorev1beta1.LastOperation{
+			Description: err.Error(),
+			Progress:    0,
+			State:       operationState,
+			Type:        operationType,
+		}
+
 		return nil
 	})
 }
@@ -155,39 +176,104 @@ func (r *Reconciler) updateStatus(ctx context.Context, provider *v1alpha1.DNSPro
 	if err := modify(&provider.Status); err != nil {
 		return err
 	}
-	provider.Status.SecretRef = provider.Spec.SecretRef
-	if !reflect.DeepEqual(oldStatus, &provider.Status) {
-		provider.Status.LastUpdateTime = &metav1.Time{Time: r.Clock.Now()}
+	specKey := getSpecSecretRefKey(provider)
+	if specKey == nil {
+		provider.Status.SecretRef = nil
+	} else {
+		provider.Status.SecretRef = &corev1.SecretReference{
+			Name:      specKey.Name,
+			Namespace: specKey.Namespace,
+		}
+	}
+	if !equivalentStatus(oldStatus, &provider.Status) {
+		timestamp := metav1.Time{Time: r.Clock.Now()}
+		provider.Status.LastUpdateTime = &timestamp
+	}
+	if provider.Status.LastOperation != nil {
+		provider.Status.LastOperation.LastUpdateTime = *provider.Status.LastUpdateTime
+	}
+	if provider.Status.LastError != nil {
+		provider.Status.LastError.LastUpdateTime = provider.Status.LastUpdateTime
 	}
 
 	return r.Client.Status().Patch(ctx, provider, patch)
 }
 
 func (r *Reconciler) checkChangedSecretRef(ctx context.Context, provider *v1alpha1.DNSProvider) error {
-	if provider.Status.SecretRef == nil {
+	statusKey := getStatusSecretRefKey(provider)
+	if statusKey == nil {
 		return nil
 	}
-	if reflect.DeepEqual(provider.Status.SecretRef, provider.Spec.SecretRef) {
+	specKey := getSpecSecretRefKey(provider)
+	if specKey != nil && *statusKey == *specKey {
 		return nil
 	}
 
-	secret := &corev1.Secret{}
-	if err := r.Client.Get(ctx, client.ObjectKey{Namespace: provider.Status.SecretRef.Namespace, Name: provider.Status.SecretRef.Name}, secret); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return fmt.Errorf("error retrieving old providere secret %s/%s: %w", provider.Status.SecretRef.Namespace, provider.Status.SecretRef.Name, err)
+	secret, err := getStatusSecret(ctx, r.Client, provider)
+	if err != nil {
+		return err
 	}
-
+	if secret == nil {
+		return nil
+	}
 	return controllerutils.RemoveFinalizers(ctx, r.Client, secret, dns.FinalizerCompound)
 }
 
-func getSecretRefNamespace(provider *v1alpha1.DNSProvider) string {
-	if provider.Spec.SecretRef == nil {
-		return ""
+func getSpecSecret(ctx context.Context, c client.Client, provider *v1alpha1.DNSProvider) (*corev1.Secret, error) {
+	return getSecret(ctx, c, provider, provider.Spec.SecretRef, "")
+}
+
+func getStatusSecret(ctx context.Context, c client.Client, provider *v1alpha1.DNSProvider) (*corev1.Secret, error) {
+	return getSecret(ctx, c, provider, provider.Status.SecretRef, "old ")
+}
+
+func getSecret(ctx context.Context, c client.Client, provider *v1alpha1.DNSProvider, secretRef *corev1.SecretReference, insert string) (*corev1.Secret, error) {
+	key := getSecretRefKey(provider, secretRef)
+	if key == nil {
+		return nil, nil
 	}
-	if provider.Spec.SecretRef.Namespace != "" {
-		return provider.Spec.SecretRef.Namespace
+
+	secret := &corev1.Secret{}
+	if err := c.Get(ctx, *key, secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("retrieving %sprovider secret failed (%s): %w", insert, *key, err)
 	}
-	return provider.Namespace
+	return secret, nil
+}
+
+func getSpecSecretRefKey(provider *v1alpha1.DNSProvider) *client.ObjectKey {
+	return getSecretRefKey(provider, provider.Spec.SecretRef)
+}
+
+func getStatusSecretRefKey(provider *v1alpha1.DNSProvider) *client.ObjectKey {
+	return getSecretRefKey(provider, provider.Status.SecretRef)
+}
+
+func getSecretRefKey(provider *v1alpha1.DNSProvider, secretRef *corev1.SecretReference) *client.ObjectKey {
+	if secretRef == nil {
+		return nil
+	}
+	// Namespace of secret ref is silently ignored. The provider namespace is always used.
+	// For compatibility with legacy dns-controller-manager SecretReferences are still necessary.
+	return &client.ObjectKey{Namespace: provider.Namespace, Name: secretRef.Name}
+}
+
+func equivalentStatus(oldStatus, newStatus *v1alpha1.DNSProviderStatus) bool {
+	oldStatusCopy := cleanTimeStamps(oldStatus)
+	newStatusCopy := cleanTimeStamps(newStatus)
+	return reflect.DeepEqual(oldStatusCopy, newStatusCopy)
+}
+
+func cleanTimeStamps(status *v1alpha1.DNSProviderStatus) *v1alpha1.DNSProviderStatus {
+	statusCopy := status.DeepCopy()
+	statusCopy.LastUpdateTime = nil
+	if statusCopy.LastError != nil {
+		statusCopy.LastError.LastUpdateTime = nil
+	}
+	if statusCopy.LastOperation != nil {
+		statusCopy.LastOperation.LastUpdateTime = metav1.Time{}
+	}
+	return statusCopy
 }

--- a/pkg/dnsman2/controller/controlplane/dnsprovider/reconciler_reconcile.go
+++ b/pkg/dnsman2/controller/controlplane/dnsprovider/reconciler_reconcile.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"time"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	securityv1alpha1constants "github.com/gardener/gardener/pkg/apis/security/v1alpha1/constants"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -109,9 +110,33 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, provider *v
 		if selectionResult.Error == "" {
 			status.Message = ptr.To("provider operational")
 			status.State = v1alpha1.StateReady
+			// Set LastOperation to Succeeded and clear LastError on success
+			status.LastOperation = &gardencorev1beta1.LastOperation{
+				Description: "Provider operational",
+				Progress:    100,
+				State:       gardencorev1beta1.LastOperationStateSucceeded,
+				Type:        gardencorev1beta1.LastOperationTypeReconcile,
+			}
+			status.LastError = nil
 		} else {
 			status.Message = ptr.To(selectionResult.Error)
 			status.State = v1alpha1.StateError
+			// Set LastError with error codes for selection errors
+			errorCodes := utils.DetermineErrorCodes(fmt.Errorf("%s", selectionResult.Error))
+			status.LastError = &gardencorev1beta1.LastError{
+				Description: selectionResult.Error,
+				Codes:       errorCodes,
+			}
+			operationState := gardencorev1beta1.LastOperationStateError
+			if utils.HasNonRetryableErrorCode(errorCodes) {
+				operationState = gardencorev1beta1.LastOperationStateFailed
+			}
+			status.LastOperation = &gardencorev1beta1.LastOperation{
+				Description: selectionResult.Error,
+				Progress:    0,
+				State:       operationState,
+				Type:        gardencorev1beta1.LastOperationTypeReconcile,
+			}
 		}
 		status.ObservedGeneration = provider.Generation
 		selectionResult.SetProviderStatusZonesAndDomains(status)
@@ -149,12 +174,13 @@ func (r *Reconciler) isEnabledProviderType(providerType string) bool {
 }
 
 func (r *Reconciler) getSecretRef(provider *v1alpha1.DNSProvider) *corev1.SecretReference {
-	if provider.Spec.SecretRef == nil {
+	key := getSpecSecretRefKey(provider)
+	if key == nil {
 		return nil
 	}
 	return &corev1.SecretReference{
-		Name:      provider.Spec.SecretRef.Name,
-		Namespace: getSecretRefNamespace(provider),
+		Name:      key.Name,
+		Namespace: key.Namespace,
 	}
 }
 

--- a/pkg/dnsman2/controller/controlplane/dnsprovider/reconciler_test.go
+++ b/pkg/dnsman2/controller/controlplane/dnsprovider/reconciler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -50,6 +51,34 @@ var _ = Describe("Reconcile", func() {
 			ExpectWithOffset(1, provider.Status.Zones).To(Equal(v1alpha1.DNSSelectionStatus{}))
 			ExpectWithOffset(1, provider.Status.DefaultTTL).To(BeNil())
 			ExpectWithOffset(1, provider.Status.RateLimit).To(BeNil())
+		}
+
+		checkLastOperationSucceeded = func() {
+			ExpectWithOffset(1, provider.Status.LastOperation).ToNot(BeNil())
+			ExpectWithOffset(1, provider.Status.LastOperation.State).To(Equal(gardencorev1beta1.LastOperationStateSucceeded))
+			ExpectWithOffset(1, provider.Status.LastOperation.Type).To(Equal(gardencorev1beta1.LastOperationTypeReconcile))
+			ExpectWithOffset(1, provider.Status.LastOperation.Progress).To(Equal(int32(100)))
+			ExpectWithOffset(1, provider.Status.LastOperation.Description).To(Equal("Provider operational"))
+			ExpectWithOffset(1, provider.Status.LastError).To(BeNil())
+		}
+
+		checkLastOperationFailed = func(expectedDescription string, nonRetryable bool, expectedErrorCodes ...gardencorev1beta1.ErrorCode) {
+			ExpectWithOffset(1, provider.Status.LastOperation).ToNot(BeNil())
+			if nonRetryable {
+				ExpectWithOffset(1, provider.Status.LastOperation.State).To(Equal(gardencorev1beta1.LastOperationStateFailed))
+			} else {
+				ExpectWithOffset(1, provider.Status.LastOperation.State).To(Equal(gardencorev1beta1.LastOperationStateError))
+			}
+			ExpectWithOffset(1, provider.Status.LastOperation.Type).To(Equal(gardencorev1beta1.LastOperationTypeReconcile))
+			ExpectWithOffset(1, provider.Status.LastOperation.Progress).To(Equal(int32(0)))
+			ExpectWithOffset(1, provider.Status.LastOperation.Description).To(Equal(expectedDescription))
+
+			ExpectWithOffset(1, provider.Status.LastError).ToNot(BeNil())
+			ExpectWithOffset(1, provider.Status.LastError.Description).To(Equal(expectedDescription))
+			if len(expectedErrorCodes) > 0 {
+				ExpectWithOffset(1, provider.Status.LastError.Codes).To(ConsistOf(expectedErrorCodes))
+			}
+			ExpectWithOffset(1, provider.Status.LastError.LastUpdateTime).ToNot(BeNil())
 		}
 	)
 
@@ -112,6 +141,8 @@ var _ = Describe("Reconcile", func() {
 		Expect(result).To(Equal(reconcile.Result{}))
 
 		checkFailed(v1alpha1.StateInvalid, `provider type "unsupported" is not supported`)
+		// "not supported" doesn't match any specific error code pattern, so retryable
+		checkLastOperationFailed(`provider type "unsupported" is not supported`, true, gardencorev1beta1.ErrorConfigurationProblem)
 	})
 
 	It("should update status for supported provider type", func() {
@@ -130,6 +161,9 @@ var _ = Describe("Reconcile", func() {
 		Expect(provider.Status.Zones).To(Equal(v1alpha1.DNSSelectionStatus{Included: []string{"test:example.com"}, Excluded: []string{"test:example2.com"}}))
 		Expect(provider.Status.DefaultTTL).To(Equal(ptr.To[int64](300)))
 		Expect(provider.Status.RateLimit).To(BeNil())
+
+		By("checking LastOperation is set to Succeeded")
+		checkLastOperationSucceeded()
 
 		clock.Step(1 * time.Minute)
 
@@ -188,6 +222,8 @@ var _ = Describe("Reconcile", func() {
 		Expect(result).To(Equal(reconcile.Result{}))
 
 		checkFailed(v1alpha1.StateInvalid, "no secret reference specified")
+		// Generic error without specific keywords, retryable
+		checkLastOperationFailed("no secret reference specified", false)
 	})
 
 	It("should update status for if secretRef is not existing", func() {
@@ -198,6 +234,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(result).To(Equal(reconcile.Result{}))
 
 		checkFailed(v1alpha1.StateError, "secret test/not-existing not found")
+		checkLastOperationFailed("secret test/not-existing not found", false)
 	})
 
 	It("should update status if account has no zones", func() {
@@ -213,6 +250,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(result).To(Equal(reconcile.Result{RequeueAfter: 5 * time.Minute}))
 
 		checkFailed(v1alpha1.StateError, "no hosted zones available in account")
+		checkLastOperationFailed("no hosted zones available in account", false)
 	})
 
 	It("should update status for if validation of secret fails", func() {
@@ -226,6 +264,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(result).To(Equal(reconcile.Result{}))
 
 		checkFailed(v1alpha1.StateError, "secret test/secret1 validation failed: 'bad_key' is not allowed in local provider properties: some-value")
+		checkLastOperationFailed("secret test/secret1 validation failed: 'bad_key' is not allowed in local provider properties: some-value", true, gardencorev1beta1.ErrorConfigurationProblem)
 	})
 
 	It("should update status if domain selection is empty", func() {
@@ -235,13 +274,15 @@ var _ = Describe("Reconcile", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result).To(Equal(reconcile.Result{RequeueAfter: 5 * time.Minute}))
 
-		checkFailedBasics(0, v1alpha1.StateError, "no domain matching hosting zones. Need to be a (sub)domain of [example.com]")
+		expectedMsg := "no domain matching hosting zones. Need to be a (sub)domain of [example.com]"
+		checkFailedBasics(0, v1alpha1.StateError, expectedMsg)
 		Expect(provider.Status.Domains).To(Equal(v1alpha1.DNSSelectionStatus{
 			Excluded: []string{"example.com", "example2.com"},
 		}))
 		Expect(provider.Status.Zones).To(Equal(v1alpha1.DNSSelectionStatus{
 			Excluded: []string{"test:example.com", "test:example2.com"},
 		}))
+		checkLastOperationFailed(expectedMsg, false)
 	})
 
 	It("should update status for provider handler if it fails to list zones", func() {
@@ -261,5 +302,6 @@ var _ = Describe("Reconcile", func() {
 		Expect(result).To(Equal(reconcile.Result{RequeueAfter: 5 * time.Minute}))
 
 		checkFailed(v1alpha1.StateError, "forced error by mockConfig.FailGetZones")
+		checkLastOperationFailed("forced error by mockConfig.FailGetZones", false)
 	})
 })

--- a/pkg/dnsman2/controller/controlplane/dnsprovider/reconciler_test.go
+++ b/pkg/dnsman2/controller/controlplane/dnsprovider/reconciler_test.go
@@ -37,48 +37,52 @@ var _ = Describe("Reconcile", func() {
 		clock       = &testing.FakeClock{}
 		startTime   = time.Now().Truncate(time.Second)
 
-		checkFailedBasics = func(offset int, expectedState string, expectedMessage string) {
-			ExpectWithOffset(offset+1, fakeClient.Get(ctx, providerKey, provider)).To(Succeed())
-			ExpectWithOffset(offset+1, provider.Status.ObservedGeneration).To(Equal(provider.Generation))
-			ExpectWithOffset(offset+1, provider.Status.State).To(Equal(expectedState))
-			ExpectWithOffset(offset+1, provider.Status.LastUpdateTime.Time).To(Equal(startTime))
-			ExpectWithOffset(offset+1, provider.Status.Message).To(Equal(ptr.To(expectedMessage)))
+		checkFailedBasics = func(expectedState string, expectedMessage string) {
+			GinkgoHelper()
+			Expect(fakeClient.Get(ctx, providerKey, provider)).To(Succeed())
+			Expect(provider.Status.ObservedGeneration).To(Equal(provider.Generation))
+			Expect(provider.Status.State).To(Equal(expectedState))
+			Expect(provider.Status.LastUpdateTime.Time).To(Equal(startTime))
+			Expect(provider.Status.Message).To(Equal(ptr.To(expectedMessage)))
 		}
 
 		checkFailed = func(expectedState string, expectedMessage string) {
-			checkFailedBasics(1, expectedState, expectedMessage)
-			ExpectWithOffset(1, provider.Status.Domains).To(Equal(v1alpha1.DNSSelectionStatus{}))
-			ExpectWithOffset(1, provider.Status.Zones).To(Equal(v1alpha1.DNSSelectionStatus{}))
-			ExpectWithOffset(1, provider.Status.DefaultTTL).To(BeNil())
-			ExpectWithOffset(1, provider.Status.RateLimit).To(BeNil())
+			GinkgoHelper()
+			checkFailedBasics(expectedState, expectedMessage)
+			Expect(provider.Status.Domains).To(Equal(v1alpha1.DNSSelectionStatus{}))
+			Expect(provider.Status.Zones).To(Equal(v1alpha1.DNSSelectionStatus{}))
+			Expect(provider.Status.DefaultTTL).To(BeNil())
+			Expect(provider.Status.RateLimit).To(BeNil())
 		}
 
 		checkLastOperationSucceeded = func() {
-			ExpectWithOffset(1, provider.Status.LastOperation).ToNot(BeNil())
-			ExpectWithOffset(1, provider.Status.LastOperation.State).To(Equal(gardencorev1beta1.LastOperationStateSucceeded))
-			ExpectWithOffset(1, provider.Status.LastOperation.Type).To(Equal(gardencorev1beta1.LastOperationTypeReconcile))
-			ExpectWithOffset(1, provider.Status.LastOperation.Progress).To(Equal(int32(100)))
-			ExpectWithOffset(1, provider.Status.LastOperation.Description).To(Equal("Provider operational"))
-			ExpectWithOffset(1, provider.Status.LastError).To(BeNil())
+			GinkgoHelper()
+			Expect(provider.Status.LastOperation).ToNot(BeNil())
+			Expect(provider.Status.LastOperation.State).To(Equal(gardencorev1beta1.LastOperationStateSucceeded))
+			Expect(provider.Status.LastOperation.Type).To(Equal(gardencorev1beta1.LastOperationTypeReconcile))
+			Expect(provider.Status.LastOperation.Progress).To(Equal(int32(100)))
+			Expect(provider.Status.LastOperation.Description).To(Equal("Provider operational"))
+			Expect(provider.Status.LastError).To(BeNil())
 		}
 
 		checkLastOperationFailed = func(expectedDescription string, nonRetryable bool, expectedErrorCodes ...gardencorev1beta1.ErrorCode) {
-			ExpectWithOffset(1, provider.Status.LastOperation).ToNot(BeNil())
+			GinkgoHelper()
+			Expect(provider.Status.LastOperation).ToNot(BeNil())
 			if nonRetryable {
-				ExpectWithOffset(1, provider.Status.LastOperation.State).To(Equal(gardencorev1beta1.LastOperationStateFailed))
+				Expect(provider.Status.LastOperation.State).To(Equal(gardencorev1beta1.LastOperationStateFailed))
 			} else {
-				ExpectWithOffset(1, provider.Status.LastOperation.State).To(Equal(gardencorev1beta1.LastOperationStateError))
+				Expect(provider.Status.LastOperation.State).To(Equal(gardencorev1beta1.LastOperationStateError))
 			}
-			ExpectWithOffset(1, provider.Status.LastOperation.Type).To(Equal(gardencorev1beta1.LastOperationTypeReconcile))
-			ExpectWithOffset(1, provider.Status.LastOperation.Progress).To(Equal(int32(0)))
-			ExpectWithOffset(1, provider.Status.LastOperation.Description).To(Equal(expectedDescription))
+			Expect(provider.Status.LastOperation.Type).To(Equal(gardencorev1beta1.LastOperationTypeReconcile))
+			Expect(provider.Status.LastOperation.Progress).To(Equal(int32(0)))
+			Expect(provider.Status.LastOperation.Description).To(Equal(expectedDescription))
 
-			ExpectWithOffset(1, provider.Status.LastError).ToNot(BeNil())
-			ExpectWithOffset(1, provider.Status.LastError.Description).To(Equal(expectedDescription))
+			Expect(provider.Status.LastError).ToNot(BeNil())
+			Expect(provider.Status.LastError.Description).To(Equal(expectedDescription))
 			if len(expectedErrorCodes) > 0 {
-				ExpectWithOffset(1, provider.Status.LastError.Codes).To(ConsistOf(expectedErrorCodes))
+				Expect(provider.Status.LastError.Codes).To(ConsistOf(expectedErrorCodes))
 			}
-			ExpectWithOffset(1, provider.Status.LastError.LastUpdateTime).ToNot(BeNil())
+			Expect(provider.Status.LastError.LastUpdateTime).ToNot(BeNil())
 		}
 	)
 
@@ -141,7 +145,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(result).To(Equal(reconcile.Result{}))
 
 		checkFailed(v1alpha1.StateInvalid, `provider type "unsupported" is not supported`)
-		// "not supported" doesn't match any specific error code pattern, so retryable
+		// "not supported" doesn't match any specific error code pattern, so it's not-retryable
 		checkLastOperationFailed(`provider type "unsupported" is not supported`, true, gardencorev1beta1.ErrorConfigurationProblem)
 	})
 
@@ -275,7 +279,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(result).To(Equal(reconcile.Result{RequeueAfter: 5 * time.Minute}))
 
 		expectedMsg := "no domain matching hosting zones. Need to be a (sub)domain of [example.com]"
-		checkFailedBasics(0, v1alpha1.StateError, expectedMsg)
+		checkFailedBasics(v1alpha1.StateError, expectedMsg)
 		Expect(provider.Status.Domains).To(Equal(v1alpha1.DNSSelectionStatus{
 			Excluded: []string{"example.com", "example2.com"},
 		}))

--- a/pkg/dnsman2/controller/source/dnsprovider/reconciler.go
+++ b/pkg/dnsman2/controller/source/dnsprovider/reconciler.go
@@ -149,7 +149,7 @@ func (r *Reconciler) updateStatus(ctx context.Context, provider *v1alpha1.DNSPro
 	}
 	provider.Status.SecretRef = provider.Spec.SecretRef
 	if !reflect.DeepEqual(oldStatus, &provider.Status) {
-		provider.Status.LastUpdateTime = &metav1.Time{Time: r.Clock.Now().UTC()}
+		provider.Status.LastUpdateTime = &metav1.Time{Time: r.Clock.Now()}
 	}
 
 	return r.Client.Status().Patch(ctx, provider, patch)

--- a/pkg/dnsman2/controller/source/dnsprovider/reconciler.go
+++ b/pkg/dnsman2/controller/source/dnsprovider/reconciler.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"reflect"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -111,6 +112,35 @@ func (r *Reconciler) updateStatusFailed(ctx context.Context, provider *v1alpha1.
 		status.Domains = v1alpha1.DNSSelectionStatus{}
 		status.RateLimit = nil
 		status.DefaultTTL = nil
+
+		// Set LastError with error codes for source controller errors
+		errorCodes := determineErrorCodes(msg)
+		status.LastError = &gardencorev1beta1.LastError{
+			Description:    msg,
+			Codes:          errorCodes,
+			LastUpdateTime: &metav1.Time{Time: r.Clock.Now()},
+		}
+
+		// Set LastOperation to Failed/Error state
+		operationType := gardencorev1beta1.LastOperationTypeReconcile
+		if provider.DeletionTimestamp != nil {
+			operationType = gardencorev1beta1.LastOperationTypeDelete
+		}
+
+		operationState := gardencorev1beta1.LastOperationStateError
+		// Use Failed state for non-retryable errors
+		if hasNonRetryableErrorCode(errorCodes) {
+			operationState = gardencorev1beta1.LastOperationStateFailed
+		}
+
+		status.LastOperation = &gardencorev1beta1.LastOperation{
+			Description:    msg,
+			LastUpdateTime: metav1.Time{Time: r.Clock.Now()},
+			Progress:       0,
+			State:          operationState,
+			Type:           operationType,
+		}
+
 		return nil
 	})
 }
@@ -138,4 +168,62 @@ func getSecretRefNamespace(provider *v1alpha1.DNSProvider) string {
 		return provider.Spec.SecretRef.Namespace
 	}
 	return provider.Namespace
+}
+
+// determineErrorCodes analyzes an error message and returns appropriate Gardener error codes.
+// This is a simplified version for the source controller that handles validation errors.
+func determineErrorCodes(msg string) []gardencorev1beta1.ErrorCode {
+	if msg == "" {
+		return nil
+	}
+
+	msgLower := msg
+	var codes []gardencorev1beta1.ErrorCode
+
+	// Check for validation and configuration errors
+	if containsAny(msgLower,
+		"not found",
+		"not set",
+		"validation",
+		"invalid",
+		"malformed") {
+		codes = append(codes, gardencorev1beta1.ErrorConfigurationProblem)
+	}
+
+	return codes
+}
+
+// hasNonRetryableErrorCode checks if any of the provided error codes indicate
+// a non-retryable error (e.g., configuration problem).
+func hasNonRetryableErrorCode(codes []gardencorev1beta1.ErrorCode) bool {
+	nonRetryableCodes := map[gardencorev1beta1.ErrorCode]bool{
+		gardencorev1beta1.ErrorInfraUnauthenticated:   true,
+		gardencorev1beta1.ErrorInfraUnauthorized:      true,
+		gardencorev1beta1.ErrorInfraQuotaExceeded:     true,
+		gardencorev1beta1.ErrorInfraDependencies:      true,
+		gardencorev1beta1.ErrorInfraResourcesDepleted: true,
+		gardencorev1beta1.ErrorConfigurationProblem:   true,
+		gardencorev1beta1.ErrorProblematicWebhook:     true,
+	}
+
+	for _, code := range codes {
+		if nonRetryableCodes[code] {
+			return true
+		}
+	}
+	return false
+}
+
+// containsAny checks if the string contains any of the provided substrings.
+func containsAny(s string, substrs ...string) bool {
+	for _, substr := range substrs {
+		if len(s) >= len(substr) {
+			for i := 0; i <= len(s)-len(substr); i++ {
+				if s[i:i+len(substr)] == substr {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }

--- a/pkg/dnsman2/controller/source/dnsprovider/reconciler.go
+++ b/pkg/dnsman2/controller/source/dnsprovider/reconciler.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gardener/external-dns-management/pkg/dnsman2/apis/config"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/utils"
 )
 
 // Reconciler is a reconciler for DNSProvider resources on the control plane.
@@ -58,9 +59,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	if provider.DeletionTimestamp != nil || !dns.EquivalentClass(provider.Annotations[dns.AnnotationClass], r.SourceClass) {
 		return r.delete(ctx, log, provider)
-	} else {
-		return r.reconcile(ctx, log, provider)
 	}
+	return r.reconcile(ctx, log, provider)
 }
 
 func addFinalizer(ctx context.Context, c client.Client, provider *v1alpha1.DNSProvider) error {
@@ -99,27 +99,15 @@ func removeFinalizer(ctx context.Context, c client.Client, provider *v1alpha1.DN
 	return controllerutils.RemoveFinalizers(ctx, c, secret, dns.FinalizerReplication)
 }
 
-func (r *Reconciler) updateStatusInvalid(ctx context.Context, provider *v1alpha1.DNSProvider, msg string) error {
-	return r.updateStatusFailed(ctx, provider, v1alpha1.StateInvalid, msg)
-}
-
-func (r *Reconciler) updateStatusFailed(ctx context.Context, provider *v1alpha1.DNSProvider, state string, msg string) error {
+func (r *Reconciler) updateStatusInvalid(ctx context.Context, provider *v1alpha1.DNSProvider, msg string, codes ...gardencorev1beta1.ErrorCode) error {
 	return r.updateStatus(ctx, provider, func(status *v1alpha1.DNSProviderStatus) error {
 		status.Message = ptr.To(msg)
-		status.State = state
+		status.State = v1alpha1.StateInvalid
 		status.ObservedGeneration = provider.Generation
 		status.Zones = v1alpha1.DNSSelectionStatus{}
 		status.Domains = v1alpha1.DNSSelectionStatus{}
 		status.RateLimit = nil
 		status.DefaultTTL = nil
-
-		// Set LastError with error codes for source controller errors
-		errorCodes := determineErrorCodes(msg)
-		status.LastError = &gardencorev1beta1.LastError{
-			Description:    msg,
-			Codes:          errorCodes,
-			LastUpdateTime: &metav1.Time{Time: r.Clock.Now()},
-		}
 
 		// Set LastOperation to Failed/Error state
 		operationType := gardencorev1beta1.LastOperationTypeReconcile
@@ -129,16 +117,23 @@ func (r *Reconciler) updateStatusFailed(ctx context.Context, provider *v1alpha1.
 
 		operationState := gardencorev1beta1.LastOperationStateError
 		// Use Failed state for non-retryable errors
-		if hasNonRetryableErrorCode(errorCodes) {
+		if utils.HasNonRetryableErrorCode(codes) {
 			operationState = gardencorev1beta1.LastOperationStateFailed
 		}
+		newLastOperation := gardencorev1beta1.LastOperation{
+			Description: msg,
+			Progress:    0,
+			State:       operationState,
+			Type:        operationType,
+		}
+		newLastOperation.LastUpdateTime = utils.LastOperationTimestamp(status.LastOperation, newLastOperation)
+		status.LastOperation = &newLastOperation
 
-		status.LastOperation = &gardencorev1beta1.LastOperation{
+		// Set LastError with error codes for source controller errors
+		status.LastError = &gardencorev1beta1.LastError{
 			Description:    msg,
-			LastUpdateTime: metav1.Time{Time: r.Clock.Now()},
-			Progress:       0,
-			State:          operationState,
-			Type:           operationType,
+			Codes:          codes,
+			LastUpdateTime: &newLastOperation.LastUpdateTime,
 		}
 
 		return nil
@@ -154,7 +149,7 @@ func (r *Reconciler) updateStatus(ctx context.Context, provider *v1alpha1.DNSPro
 	}
 	provider.Status.SecretRef = provider.Spec.SecretRef
 	if !reflect.DeepEqual(oldStatus, &provider.Status) {
-		provider.Status.LastUpdateTime = &metav1.Time{Time: r.Clock.Now()}
+		provider.Status.LastUpdateTime = &metav1.Time{Time: r.Clock.Now().UTC()}
 	}
 
 	return r.Client.Status().Patch(ctx, provider, patch)
@@ -168,62 +163,4 @@ func getSecretRefNamespace(provider *v1alpha1.DNSProvider) string {
 		return provider.Spec.SecretRef.Namespace
 	}
 	return provider.Namespace
-}
-
-// determineErrorCodes analyzes an error message and returns appropriate Gardener error codes.
-// This is a simplified version for the source controller that handles validation errors.
-func determineErrorCodes(msg string) []gardencorev1beta1.ErrorCode {
-	if msg == "" {
-		return nil
-	}
-
-	msgLower := msg
-	var codes []gardencorev1beta1.ErrorCode
-
-	// Check for validation and configuration errors
-	if containsAny(msgLower,
-		"not found",
-		"not set",
-		"validation",
-		"invalid",
-		"malformed") {
-		codes = append(codes, gardencorev1beta1.ErrorConfigurationProblem)
-	}
-
-	return codes
-}
-
-// hasNonRetryableErrorCode checks if any of the provided error codes indicate
-// a non-retryable error (e.g., configuration problem).
-func hasNonRetryableErrorCode(codes []gardencorev1beta1.ErrorCode) bool {
-	nonRetryableCodes := map[gardencorev1beta1.ErrorCode]bool{
-		gardencorev1beta1.ErrorInfraUnauthenticated:   true,
-		gardencorev1beta1.ErrorInfraUnauthorized:      true,
-		gardencorev1beta1.ErrorInfraQuotaExceeded:     true,
-		gardencorev1beta1.ErrorInfraDependencies:      true,
-		gardencorev1beta1.ErrorInfraResourcesDepleted: true,
-		gardencorev1beta1.ErrorConfigurationProblem:   true,
-		gardencorev1beta1.ErrorProblematicWebhook:     true,
-	}
-
-	for _, code := range codes {
-		if nonRetryableCodes[code] {
-			return true
-		}
-	}
-	return false
-}
-
-// containsAny checks if the string contains any of the provided substrings.
-func containsAny(s string, substrs ...string) bool {
-	for _, substr := range substrs {
-		if len(s) >= len(substr) {
-			for i := 0; i <= len(s)-len(substr); i++ {
-				if s[i:i+len(substr)] == substr {
-					return true
-				}
-			}
-		}
-	}
-	return false
 }

--- a/pkg/dnsman2/controller/source/dnsprovider/reconciler_reconcile.go
+++ b/pkg/dnsman2/controller/source/dnsprovider/reconciler_reconcile.go
@@ -172,6 +172,9 @@ func (r *Reconciler) createOrUpdateTargetProvider(
 		status.DefaultTTL = targetProvider.Status.DefaultTTL
 		status.LastUpdateTime = targetProvider.Status.LastUpdateTime
 		status.ObservedGeneration = targetProvider.Generation
+		// Copy LastOperation and LastError from target provider
+		status.LastOperation = targetProvider.Status.LastOperation
+		status.LastError = targetProvider.Status.LastError
 		return nil
 	})
 }

--- a/pkg/dnsman2/controller/source/dnsprovider/reconciler_reconcile.go
+++ b/pkg/dnsman2/controller/source/dnsprovider/reconciler_reconcile.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -150,9 +151,9 @@ func (r *Reconciler) createOrUpdateTargetProvider(
 
 	if targetSecret == nil {
 		if sourceProvider.Spec.SecretRef == nil {
-			return r.updateStatusInvalid(ctx, sourceProvider, "secretRef not set")
+			return r.updateStatusInvalid(ctx, sourceProvider, "secretRef not set", gardencorev1beta1.ErrorConfigurationProblem)
 		}
-		return r.updateStatusInvalid(ctx, sourceProvider, fmt.Sprintf("secret %s/%s not found", getSecretRefNamespace(sourceProvider), sourceProvider.Spec.SecretRef.Name))
+		return r.updateStatusInvalid(ctx, sourceProvider, fmt.Sprintf("secret %s/%s not found", getSecretRefNamespace(sourceProvider), sourceProvider.Spec.SecretRef.Name), gardencorev1beta1.ErrorRetryableConfigurationProblem)
 	}
 
 	if err := r.ensureOwnerReferenceOnSecret(ctx, targetSecret, targetProvider); err != nil {
@@ -160,7 +161,7 @@ func (r *Reconciler) createOrUpdateTargetProvider(
 	}
 
 	if validationErrorMsg := targetSecret.Annotations[dns.AnnotationValidationError]; validationErrorMsg != "" {
-		return r.updateStatusInvalid(ctx, sourceProvider, validationErrorMsg)
+		return r.updateStatusInvalid(ctx, sourceProvider, validationErrorMsg, gardencorev1beta1.ErrorConfigurationProblem)
 	}
 
 	return r.updateStatus(ctx, sourceProvider, func(status *v1alpha1.DNSProviderStatus) error {

--- a/pkg/dnsman2/controller/source/dnsprovider/reconciler_test.go
+++ b/pkg/dnsman2/controller/source/dnsprovider/reconciler_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"reflect"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -137,6 +138,24 @@ var _ = Describe("Reconciler", func() {
 			}
 		}
 
+		checkSourceProviderLastOperation = func(expectedState gardencorev1beta1.LastOperationState, expectedType gardencorev1beta1.LastOperationType) {
+			ExpectWithOffset(1, fakeClientSrc.Get(ctx, client.ObjectKeyFromObject(sourceProvider), sourceProvider)).To(Succeed(), "fetching source DNSProvider object failed")
+			ExpectWithOffset(1, sourceProvider.Status.LastOperation).NotTo(BeNil(), "LastOperation should not be nil")
+			ExpectWithOffset(1, sourceProvider.Status.LastOperation.State).To(Equal(expectedState), "LastOperation state does not match")
+			ExpectWithOffset(1, sourceProvider.Status.LastOperation.Type).To(Equal(expectedType), "LastOperation type does not match")
+		}
+
+		checkSourceProviderLastError = func(shouldExist bool, expectedErrorCodes ...gardencorev1beta1.ErrorCode) {
+			ExpectWithOffset(1, fakeClientSrc.Get(ctx, client.ObjectKeyFromObject(sourceProvider), sourceProvider)).To(Succeed(), "fetching source DNSProvider object failed")
+			if shouldExist {
+				ExpectWithOffset(1, sourceProvider.Status.LastError).NotTo(BeNil(), "LastError should not be nil")
+				ExpectWithOffset(1, sourceProvider.Status.LastError.Codes).To(ConsistOf(expectedErrorCodes), "LastError codes do not match")
+				ExpectWithOffset(1, sourceProvider.Status.LastError.Description).NotTo(BeEmpty(), "LastError description should not be empty")
+			} else {
+				ExpectWithOffset(1, sourceProvider.Status.LastError).To(BeNil(), "LastError should be nil")
+			}
+		}
+
 		patchTargetStateToReadyAndReconcileSource = func(actualTarget *dnsv1alpha1.DNSProvider) {
 			ExpectWithOffset(1, fakeClientCtrl.Get(ctx, client.ObjectKeyFromObject(actualTarget), actualTarget)).To(Succeed(), "fetching target DNSProvider object failed")
 			actualTarget.Status.State = "Ready"
@@ -239,6 +258,7 @@ var _ = Describe("Reconciler", func() {
 
 			patchTargetStateToReadyAndReconcileSource(actualTarget)
 			checkSourceProviderState("Ready")
+			checkSourceProviderLastError(false) // No error expected when Ready
 
 			testDeletion(actualTarget)
 		})
@@ -265,6 +285,7 @@ var _ = Describe("Reconciler", func() {
 
 			patchTargetStateToReadyAndReconcileSource(actualTarget)
 			checkSourceProviderState("Ready")
+			checkSourceProviderLastError(false) // No error expected when Ready
 
 			testDeletion(actualTarget)
 		})
@@ -277,6 +298,9 @@ var _ = Describe("Reconciler", func() {
 			})
 			Expect(actualTarget.Spec.SecretRef).To(BeNil())
 			checkSourceProviderState("Invalid", "secretRef not set")
+			// "not set" should be treated as retryable by the shared error determination logic
+			checkSourceProviderLastOperation(gardencorev1beta1.LastOperationStateFailed, gardencorev1beta1.LastOperationTypeReconcile)
+			checkSourceProviderLastError(true, gardencorev1beta1.ErrorConfigurationProblem)
 			testutils.AssertEvents(fakeRecorder.Events, "Normal DNSProviderCreated ")
 
 			testDeletion(actualTarget)
@@ -292,6 +316,9 @@ var _ = Describe("Reconciler", func() {
 			})
 			checkTargetSecret(actualTarget, nil)
 			checkSourceProviderState("Invalid", "'bad_key' is not allowed in local provider properties")
+			// Validation errors are treated as retryable by the shared error determination logic
+			checkSourceProviderLastOperation(gardencorev1beta1.LastOperationStateFailed, gardencorev1beta1.LastOperationTypeReconcile)
+			checkSourceProviderLastError(true, gardencorev1beta1.ErrorConfigurationProblem)
 			testutils.AssertEvents(fakeRecorder.Events, "Normal DNSProviderCreated ")
 
 			testDeletion(actualTarget)

--- a/pkg/dnsman2/dns/ignore.go
+++ b/pkg/dnsman2/dns/ignore.go
@@ -6,17 +6,16 @@ package dns
 
 import (
 	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
-	"github.com/gardener/external-dns-management/pkg/dns"
 )
 
 // IgnoreFullByAnnotation checks whether the given DNSEntry should be ignored fully based on its annotations.
 // It returns the annotation that caused ignoring it, a boolean indicating whether to ignore it even for deletion.
 func IgnoreFullByAnnotation(entry *v1alpha1.DNSEntry) (string, bool) {
-	if entry.Annotations[dns.AnnotationHardIgnore] == "true" {
-		return dns.AnnotationHardIgnore + "=true", true
+	if entry.Annotations[AnnotationHardIgnore] == "true" {
+		return AnnotationHardIgnore + "=true", true
 	}
-	if entry.Annotations[dns.AnnotationIgnore] == dns.AnnotationIgnoreValueFull {
-		return dns.AnnotationIgnore + "=" + dns.AnnotationIgnoreValueFull, true
+	if entry.Annotations[AnnotationIgnore] == AnnotationIgnoreValueFull {
+		return AnnotationIgnore + "=" + AnnotationIgnoreValueFull, true
 	}
 	return "", false
 }
@@ -24,8 +23,8 @@ func IgnoreFullByAnnotation(entry *v1alpha1.DNSEntry) (string, bool) {
 // IgnoreReconcileByAnnotation checks whether the given DNSEntry should be ignored only for reconciliation based on its annotations.
 // It returns the annotation that caused ignoring it, a boolean indicating whether to ignore it.
 func IgnoreReconcileByAnnotation(entry *v1alpha1.DNSEntry) (string, bool) {
-	if value := entry.Annotations[dns.AnnotationIgnore]; value == dns.AnnotationIgnoreValueReconcile || value == dns.AnnotationIgnoreValueTrue {
-		return dns.AnnotationIgnore + "=" + value, true
+	if value := entry.Annotations[AnnotationIgnore]; value == AnnotationIgnoreValueReconcile || value == AnnotationIgnoreValueTrue {
+		return AnnotationIgnore + "=" + value, true
 	}
 	return "", false
 }

--- a/pkg/dnsman2/dns/provider/errors/handlererror.go
+++ b/pkg/dnsman2/dns/provider/errors/handlererror.go
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package errors
+
+import (
+	"fmt"
+)
+
+type handlerError struct {
+	err error
+}
+
+// WrapAsHandlerError wraps an error as a handler error with a message.
+func WrapAsHandlerError(err error, msg string) error {
+	return fmt.Errorf("%s: %w", msg, &handlerError{err: err})
+}
+
+// WrapfAsHandlerError wraps an error as a handler error with a formatted message.
+func WrapfAsHandlerError(err error, msg string, args ...any) error {
+	s := fmt.Sprintf(msg, args...)
+	return WrapAsHandlerError(err, s)
+}
+
+// IsHandlerError returns true if the error is a handler error.
+func IsHandlerError(err error) bool {
+	_, ok := err.(*handlerError)
+	return ok
+}
+
+// Error returns the error message.
+func (e *handlerError) Error() string {
+	return e.err.Error()
+}
+
+// Cause returns the underlying error.
+func (e *handlerError) Cause() error {
+	return e.err
+}

--- a/pkg/dnsman2/dns/provider/errors/throttlingerror.go
+++ b/pkg/dnsman2/dns/provider/errors/throttlingerror.go
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package errors
+
+import "fmt"
+
+// NewThrottlingError creates a new ThrottlingError.
+func NewThrottlingError(err error) *ThrottlingError {
+	return &ThrottlingError{err: err}
+}
+
+// ThrottlingError wraps an error related to throttling.
+type ThrottlingError struct {
+	err error
+}
+
+// Error returns the error message with throttling prefix.
+func (e *ThrottlingError) Error() string {
+	return fmt.Sprintf("Throttling: %s", e.err)
+}
+
+// IsThrottlingError returns true if the error is a throttling error.
+func IsThrottlingError(err error) bool {
+	_, ok := err.(*ThrottlingError)
+	return ok
+}

--- a/pkg/dnsman2/dns/provider/handler/alicloud/handler.go
+++ b/pkg/dnsman2/dns/provider/handler/alicloud/handler.go
@@ -13,10 +13,10 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/utils/ptr"
 
-	perrs "github.com/gardener/external-dns-management/pkg/dns/provider/errors"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/apis/config"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider"
+	perrs "github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/errors"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/raw"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/utils"
 )

--- a/pkg/dnsman2/dns/provider/handler/aws/execution.go
+++ b/pkg/dnsman2/dns/provider/handler/aws/execution.go
@@ -18,9 +18,9 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/client-go/util/flowcontrol"
 
-	dnserrors "github.com/gardener/external-dns-management/pkg/dns/provider/errors"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider"
+	dnserrors "github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/errors"
 )
 
 type wrappedChange struct {

--- a/pkg/dnsman2/dns/provider/handler/azure-private/handler.go
+++ b/pkg/dnsman2/dns/provider/handler/azure-private/handler.go
@@ -16,10 +16,10 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/utils/ptr"
 
-	perrs "github.com/gardener/external-dns-management/pkg/dns/provider/errors"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/apis/config"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider"
+	perrs "github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/errors"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/handler/azure-private/utils"
 	azutils "github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/handler/azure/utils"
 	dnsutils "github.com/gardener/external-dns-management/pkg/dnsman2/dns/utils"

--- a/pkg/dnsman2/dns/provider/handler/azure/handler.go
+++ b/pkg/dnsman2/dns/provider/handler/azure/handler.go
@@ -14,10 +14,10 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/utils/ptr"
 
-	perrs "github.com/gardener/external-dns-management/pkg/dns/provider/errors"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/apis/config"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider"
+	perrs "github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/errors"
 	azutils "github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/handler/azure/utils"
 	dnsutils "github.com/gardener/external-dns-management/pkg/dnsman2/dns/utils"
 )

--- a/pkg/dnsman2/dns/provider/handler/azure/utils/utils.go
+++ b/pkg/dnsman2/dns/provider/handler/azure/utils/utils.go
@@ -23,8 +23,8 @@ import (
 	securityv1alpha1constants "github.com/gardener/gardener/pkg/apis/security/v1alpha1/constants"
 
 	workloadidentityazure "github.com/gardener/external-dns-management/pkg/apis/dns/workloadidentity/azure"
-	perrs "github.com/gardener/external-dns-management/pkg/dns/provider/errors"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider"
+	perrs "github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/errors"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/handler/azure/constants"
 )
 

--- a/pkg/dnsman2/dns/utils/errors.go
+++ b/pkg/dnsman2/dns/utils/errors.go
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"strings"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+)
+
+// DetermineErrorCodes analyzes an error message and returns appropriate Gardener error codes.
+// This enables Gardener to distinguish between user configuration errors and system-level failures,
+// allowing for proper retry logic and error propagation to Shoot status.
+func DetermineErrorCodes(err error) []gardencorev1beta1.ErrorCode {
+	if err == nil {
+		return nil
+	}
+
+	errStr := strings.ToLower(err.Error())
+	var codes []gardencorev1beta1.ErrorCode
+
+	// Check for authentication/authorization issues
+	// These are typically user configuration errors (invalid credentials/tokens)
+	if containsAny(errStr,
+		"unauthenticated",
+		"authentication failed",
+		"invalid token",
+		"invalid credentials",
+		"invalid api token",
+		"invalid access token",
+		"invalid api key",
+		"authentication error",
+		"auth failed",
+		"bad credentials",
+		"signaturedoesnotmatch") {
+		codes = append(codes, gardencorev1beta1.ErrorInfraUnauthenticated)
+	}
+
+	if containsAny(errStr,
+		"unauthorized",
+		"forbidden",
+		"access denied",
+		"permission denied",
+		"insufficient permissions") {
+		codes = append(codes, gardencorev1beta1.ErrorInfraUnauthorized)
+	}
+
+	// Rate limiting - these are retryable errors
+	if containsAny(errStr,
+		"rate limit",
+		"ratelimit",
+		"throttl",
+		"too many requests",
+		"request limit exceeded") {
+		codes = append(codes, gardencorev1beta1.ErrorInfraRateLimitsExceeded)
+	}
+
+	// Quota issues - non-retryable, user needs to increase quota
+	if containsAny(errStr,
+		"quota exceeded",
+		"quota limit",
+		"insufficient quota") {
+		codes = append(codes, gardencorev1beta1.ErrorInfraQuotaExceeded)
+	}
+
+	// Generic configuration problem if no specific code matched but looks like config issue
+	if len(codes) == 0 && containsAny(errStr,
+		"invalid",
+		"malformed",
+		"bad request",
+		"configuration error",
+		"config error",
+		"validation error",
+		"validation failed",
+		"not supported") {
+		codes = append(codes, gardencorev1beta1.ErrorConfigurationProblem)
+	}
+
+	return codes
+}
+
+var nonRetryableCodes = map[gardencorev1beta1.ErrorCode]bool{
+	gardencorev1beta1.ErrorInfraUnauthenticated:   true,
+	gardencorev1beta1.ErrorInfraUnauthorized:      true,
+	gardencorev1beta1.ErrorInfraQuotaExceeded:     true,
+	gardencorev1beta1.ErrorInfraDependencies:      true,
+	gardencorev1beta1.ErrorInfraResourcesDepleted: true,
+	gardencorev1beta1.ErrorConfigurationProblem:   true,
+	gardencorev1beta1.ErrorProblematicWebhook:     true,
+}
+
+// HasNonRetryableErrorCode checks if any of the provided error codes indicate
+// a non-retryable error (e.g., authentication failure, configuration problem).
+func HasNonRetryableErrorCode(codes []gardencorev1beta1.ErrorCode) bool {
+	for _, code := range codes {
+		if nonRetryableCodes[code] {
+			return true
+		}
+	}
+	return false
+}
+
+// containsAny checks if the string contains any of the provided substrings.
+func containsAny(s string, substrs ...string) bool {
+	for _, substr := range substrs {
+		if strings.Contains(s, substr) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/dnsman2/dns/utils/errors.go
+++ b/pkg/dnsman2/dns/utils/errors.go
@@ -68,9 +68,7 @@ func DetermineErrorCodes(err error) []gardencorev1beta1.ErrorCode {
 
 	// Generic configuration problem if no specific code matched but looks like config issue
 	if len(codes) == 0 && containsAny(errStr,
-		"invalid",
 		"malformed",
-		"bad request",
 		"configuration error",
 		"config error",
 		"validation error",

--- a/pkg/dnsman2/dns/utils/errors.go
+++ b/pkg/dnsman2/dns/utils/errors.go
@@ -34,7 +34,8 @@ func DetermineErrorCodes(err error) []gardencorev1beta1.ErrorCode {
 		"authentication error",
 		"auth failed",
 		"bad credentials",
-		"signaturedoesnotmatch") {
+		"signaturedoesnotmatch",
+		"invalid_grant") {
 		codes = append(codes, gardencorev1beta1.ErrorInfraUnauthenticated)
 	}
 

--- a/pkg/dnsman2/dns/utils/errors_test.go
+++ b/pkg/dnsman2/dns/utils/errors_test.go
@@ -100,12 +100,6 @@ var _ = Describe("Error Code Determination", func() {
 		})
 
 		Context("when error contains configuration keywords", func() {
-			It("should return ErrorConfigurationProblem for invalid configuration", func() {
-				err := errors.New("Invalid DNS zone configuration")
-				codes := DetermineErrorCodes(err)
-				Expect(codes).To(ConsistOf(gardencorev1beta1.ErrorConfigurationProblem))
-			})
-
 			It("should return ErrorConfigurationProblem for malformed request", func() {
 				err := errors.New("Malformed API request")
 				codes := DetermineErrorCodes(err)

--- a/pkg/dnsman2/dns/utils/errors_test.go
+++ b/pkg/dnsman2/dns/utils/errors_test.go
@@ -40,6 +40,21 @@ var _ = Describe("Error Code Determination", func() {
 				codes := DetermineErrorCodes(err)
 				Expect(codes).To(ConsistOf(gardencorev1beta1.ErrorInfraUnauthenticated))
 			})
+
+			It("should return ErrorInfraUnauthenticated for Aws Route53 invalid access", func() {
+				err := errors.New(`ListHostedZones failed: api error SignatureDoesNotMatch: The request
+      signature we calculated does not match the signature you provided. Check your
+      AWS Secret Access Key and signing method. Consult the service documentation
+      for details.`)
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(ConsistOf(gardencorev1beta1.ErrorInfraUnauthenticated))
+			})
+
+			It("should return ErrorInfraUnauthenticated for Google Cloud DNS invalid grant", func() {
+				err := errors.New(`Response: {"error":"invalid_grant","error_description":"Invalid grant: account not found"}`)
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(ConsistOf(gardencorev1beta1.ErrorInfraUnauthenticated))
+			})
 		})
 
 		Context("when error contains authorization keywords", func() {

--- a/pkg/dnsman2/dns/utils/errors_test.go
+++ b/pkg/dnsman2/dns/utils/errors_test.go
@@ -1,0 +1,216 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"errors"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Error Code Determination", func() {
+	Describe("DetermineErrorCodes", func() {
+		Context("when error is nil", func() {
+			It("should return nil codes", func() {
+				codes := DetermineErrorCodes(nil)
+				Expect(codes).To(BeNil())
+			})
+		})
+
+		Context("when error contains authentication keywords", func() {
+			It("should return ErrorInfraUnauthenticated for invalid token", func() {
+				err := errors.New("Cloudflare API error: Invalid access token (HTTP 403)")
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(HaveLen(1))
+				Expect(codes).To(ContainElement(gardencorev1beta1.ErrorInfraUnauthenticated))
+			})
+
+			It("should return ErrorInfraUnauthenticated for invalid API key", func() {
+				err := errors.New("Invalid API key provided")
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(ConsistOf(gardencorev1beta1.ErrorInfraUnauthenticated))
+			})
+
+			It("should return ErrorInfraUnauthenticated for bad credentials", func() {
+				err := errors.New("Authentication failed: bad credentials")
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(ConsistOf(gardencorev1beta1.ErrorInfraUnauthenticated))
+			})
+		})
+
+		Context("when error contains authorization keywords", func() {
+			It("should return ErrorInfraUnauthorized for forbidden", func() {
+				err := errors.New("Access forbidden: insufficient permissions")
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(ConsistOf(gardencorev1beta1.ErrorInfraUnauthorized))
+			})
+
+			It("should return ErrorInfraUnauthorized for access denied", func() {
+				err := errors.New("Access denied for this resource")
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(ConsistOf(gardencorev1beta1.ErrorInfraUnauthorized))
+			})
+		})
+
+		Context("when error contains rate limiting keywords", func() {
+			It("should return ErrorInfraRateLimitsExceeded for rate limit error", func() {
+				err := errors.New("Rate limit exceeded, please retry later")
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(ConsistOf(gardencorev1beta1.ErrorInfraRateLimitsExceeded))
+			})
+
+			It("should return ErrorInfraRateLimitsExceeded for too many requests", func() {
+				err := errors.New("Too many requests (HTTP 429)")
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(ConsistOf(gardencorev1beta1.ErrorInfraRateLimitsExceeded))
+			})
+
+			It("should return ErrorInfraRateLimitsExceeded for throttling", func() {
+				err := errors.New("Request throttled by provider")
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(ConsistOf(gardencorev1beta1.ErrorInfraRateLimitsExceeded))
+			})
+		})
+
+		Context("when error contains quota keywords", func() {
+			It("should return ErrorInfraQuotaExceeded for quota error", func() {
+				err := errors.New("Quota exceeded for DNS zones")
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(ConsistOf(gardencorev1beta1.ErrorInfraQuotaExceeded))
+			})
+		})
+
+		Context("when error contains configuration keywords", func() {
+			It("should return ErrorConfigurationProblem for invalid configuration", func() {
+				err := errors.New("Invalid DNS zone configuration")
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(ConsistOf(gardencorev1beta1.ErrorConfigurationProblem))
+			})
+
+			It("should return ErrorConfigurationProblem for malformed request", func() {
+				err := errors.New("Malformed API request")
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(ConsistOf(gardencorev1beta1.ErrorConfigurationProblem))
+			})
+
+			It("should return ErrorConfigurationProblem for unsupported provider", func() {
+				err := errors.New("provider type \"foo\" is not supported")
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(ConsistOf(gardencorev1beta1.ErrorConfigurationProblem))
+			})
+		})
+
+		Context("when error contains multiple error patterns", func() {
+			It("should return multiple error codes", func() {
+				err := errors.New("Invalid token and rate limit exceeded")
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(HaveLen(2))
+				Expect(codes).To(ConsistOf(
+					gardencorev1beta1.ErrorInfraUnauthenticated,
+					gardencorev1beta1.ErrorInfraRateLimitsExceeded,
+				))
+			})
+		})
+
+		Context("when error does not match any pattern", func() {
+			It("should return no error codes", func() {
+				err := errors.New("Generic error message without keywords")
+				codes := DetermineErrorCodes(err)
+				Expect(codes).To(BeEmpty())
+			})
+		})
+	})
+
+	Describe("hasNonRetryableErrorCode", func() {
+		Context("when codes list is empty", func() {
+			It("should return false for nil codes", func() {
+				Expect(HasNonRetryableErrorCode(nil)).To(BeFalse())
+			})
+
+			It("should return false for empty codes slice", func() {
+				Expect(HasNonRetryableErrorCode([]gardencorev1beta1.ErrorCode{})).To(BeFalse())
+			})
+		})
+
+		Context("when codes contain only retryable errors", func() {
+			It("should return false for rate limit error", func() {
+				codes := []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorInfraRateLimitsExceeded}
+				Expect(HasNonRetryableErrorCode(codes)).To(BeFalse())
+			})
+
+			It("should return false for retryable configuration problem", func() {
+				codes := []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorRetryableConfigurationProblem}
+				Expect(HasNonRetryableErrorCode(codes)).To(BeFalse())
+			})
+
+			It("should return false for retryable infra dependencies", func() {
+				codes := []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorRetryableInfraDependencies}
+				Expect(HasNonRetryableErrorCode(codes)).To(BeFalse())
+			})
+		})
+
+		Context("when codes contain non-retryable errors", func() {
+			It("should return true for unauthenticated error", func() {
+				codes := []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorInfraUnauthenticated}
+				Expect(HasNonRetryableErrorCode(codes)).To(BeTrue())
+			})
+
+			It("should return true for unauthorized error", func() {
+				codes := []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorInfraUnauthorized}
+				Expect(HasNonRetryableErrorCode(codes)).To(BeTrue())
+			})
+
+			It("should return true for configuration problem", func() {
+				codes := []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorConfigurationProblem}
+				Expect(HasNonRetryableErrorCode(codes)).To(BeTrue())
+			})
+
+			It("should return true for quota exceeded error", func() {
+				codes := []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorInfraQuotaExceeded}
+				Expect(HasNonRetryableErrorCode(codes)).To(BeTrue())
+			})
+		})
+
+		Context("when codes contain mixed retryable and non-retryable errors", func() {
+			It("should return true if any code is non-retryable", func() {
+				codes := []gardencorev1beta1.ErrorCode{
+					gardencorev1beta1.ErrorInfraRateLimitsExceeded,
+					gardencorev1beta1.ErrorInfraUnauthenticated,
+				}
+				Expect(HasNonRetryableErrorCode(codes)).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("containsAny", func() {
+		Context("when substring list is empty", func() {
+			It("should return false", func() {
+				Expect(containsAny("hello world")).To(BeFalse())
+			})
+		})
+
+		Context("when string contains one of the substrings", func() {
+			It("should return true for single match", func() {
+				Expect(containsAny("invalid token provided", "invalid", "error")).To(BeTrue())
+			})
+
+			It("should return true for multiple matches", func() {
+				Expect(containsAny("invalid token provided", "invalid", "token")).To(BeTrue())
+			})
+		})
+
+		Context("when string contains none of the substrings", func() {
+			It("should return false", func() {
+				Expect(containsAny("hello world", "foo", "bar")).To(BeFalse())
+			})
+
+			It("should be case sensitive", func() {
+				Expect(containsAny("hello world", "Hello")).To(BeFalse())
+			})
+		})
+	})
+})

--- a/pkg/dnsman2/dns/utils/lastoperation.go
+++ b/pkg/dnsman2/dns/utils/lastoperation.go
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// LastOperationTimestamp returns the timestamp for a LastOperation update. If the old operation is nil or any field has changed, it returns the current time; otherwise, it returns the previous update time.
+func LastOperationTimestamp(oldOperation *gardencorev1beta1.LastOperation, newOperation gardencorev1beta1.LastOperation) metav1.Time {
+	if oldOperation == nil {
+		return metav1.Now()
+	}
+	if oldOperation.State != newOperation.State ||
+		oldOperation.Type != newOperation.Type ||
+		oldOperation.Description != newOperation.Description ||
+		oldOperation.Progress != newOperation.Progress {
+		return metav1.Now()
+	}
+	return oldOperation.LastUpdateTime
+}

--- a/test/integration/providerSecret_test.go
+++ b/test/integration/providerSecret_test.go
@@ -7,9 +7,11 @@ package integration
 import (
 	"fmt"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"github.com/gardener/external-dns-management/pkg/controller/provider/local"
@@ -80,11 +82,58 @@ var _ = Describe("ProviderSecret", func() {
 
 		checkProvider(pr)
 
-		_, data, err := testEnv.GetProvider(pr.GetName())
+		_, provider, err := testEnv.GetProvider(pr.GetName())
 		Ω(err).ShouldNot(HaveOccurred())
 
-		Ω(data.Status.Zones.Included).Should(ConsistOf(prefix + "pr1a.mock.xx"))
-		Ω(data.Status.Zones.Excluded).Should(ConsistOf(prefix+"pr1b.mock.xx", prefix+"pr1c.mock.xx", prefix+"pr1d.mock.xx", prefix+"pr1e.mock.xx"))
-		Ω(data.Status.Domains.Included).Should(ConsistOf("pr1a.mock.xx"))
+		Ω(provider.Status.Zones.Included).Should(ConsistOf(prefix + "pr1a.mock.xx"))
+		Ω(provider.Status.Zones.Excluded).Should(ConsistOf(prefix+"pr1b.mock.xx", prefix+"pr1c.mock.xx", prefix+"pr1d.mock.xx", prefix+"pr1e.mock.xx"))
+		Ω(provider.Status.Domains.Included).Should(ConsistOf("pr1a.mock.xx"))
+
+		Ω(provider.Status.LastOperation).ShouldNot(BeNil())
+		Ω(provider.Status.LastOperation.Description).Should(Equal("Provider operational"))
+		Ω(string(provider.Status.LastOperation.State)).Should(Equal("Succeeded"))
+		Ω(string(provider.Status.LastOperation.Type)).Should(Equal("Reconcile"))
+
+		Ω(provider.Status.LastError).Should(BeNil())
+	})
+
+	It("should set provider status to error if secret validation fails", func() {
+		secretName := testEnv.SecretName(0)
+		secret, err := testEnv.CreateSecretEx(&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testEnv.Namespace,
+				Name:      secretName,
+			},
+			Data: map[string][]byte{
+				"bad_key": []byte("bad_value"),
+			},
+		})
+		Ω(err).ShouldNot(HaveOccurred())
+
+		pr, _, _, err := testEnv.CreateProvider("inmemory.mock", 0, secret.GetName())
+		Ω(err).ShouldNot(HaveOccurred())
+		defer testEnv.DeleteProviderAndSecret(pr)
+
+		checkHasFinalizer(pr)
+
+		err = testEnv.AwaitProviderState(pr.GetName(), "Error")
+		Ω(err).ShouldNot(HaveOccurred())
+
+		_, provider, err := testEnv.GetProvider(pr.GetName())
+		Ω(err).ShouldNot(HaveOccurred())
+
+		expectedSubstring := "'bad_key' is not allowed in local provider properties"
+
+		Ω(provider.Status.Message).ShouldNot(BeNil())
+		Ω(*provider.Status.Message).Should(ContainSubstring(expectedSubstring))
+
+		Ω(provider.Status.LastOperation).ShouldNot(BeNil())
+		Ω(provider.Status.LastOperation.Description).Should(ContainSubstring(expectedSubstring))
+		Ω(string(provider.Status.LastOperation.State)).Should(Equal("Failed"))
+		Ω(string(provider.Status.LastOperation.Type)).Should(Equal("Reconcile"))
+
+		Ω(provider.Status.LastError).ShouldNot(BeNil())
+		Ω(provider.Status.LastError.Description).Should(ContainSubstring(expectedSubstring))
+		Ω(provider.Status.LastError.Codes).Should(ConsistOf(gardencorev1beta1.ErrorConfigurationProblem))
 	})
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR enhances the DNSProvider resource status to include Gardener-standard `lastOperation` and `lastError` fields, improving integration with Gardener's error handling and retry logic. These fields enable better observability and allow Gardener to distinguish between retryable system errors and non-retryable configuration problems.
                                                                                                                                                                                                                                                                                                                                  
  **Key Changes:**                                                                                                                                                                                                                                                                                                                
  - Added `LastOperation` and `LastError` fields to `DNSProviderStatus` spec
  - Implemented intelligent error code detection for various DNS provider failures                                                                                                                                                                                                                                                
  - Updated both legacy (`pkg/dns`) and nextgen (`pkg/dnsman2`) controllers to populate these fields                                                                                                                                                                                                                              
  - Added comprehensive test coverage for error code determination and status updates                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
  ## Behavior Changes                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                  
  ### Success Case                                                                                                                                                                                                                                                                                                                
  When a DNSProvider reconciles successfully:                                                                                                                                                                                                                                                                                   
  ```yaml                                                                                                                                                                                                                                                                                                                         
  status:                                                                                                                                                                                                                                                                                                                         
    state: Ready                                                                                                                                                                                                                                                                                                                  
    lastOperation:                                                                                                                                                                                                                                                                                                                
      type: Reconcile                                                                                                                                                                                                                                                                                                             
      state: Succeeded                                                                                                                                                                                                                                                                                                            
      progress: 100                                                                                                                                                                                                                                                                                                               
      description: "Provider operational"                                                                                                                                                                                                                                                                                         
    lastError: null                                                                                                                                                                                                                                                                                                               
  ```
                                                                                                                                                                                                                                                                                                         
  ### Error Cases                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                  
  #### Configuration Error (Non-Retryable):           
  ```yaml                                                                                                                                                                                                                                                                                    
  status:                                                                                                                                                                                                                                                                                                                       
    state: Error                                                                                                                                                                                                                                                                                                                  
    lastOperation:                                                                                                                                                                                                                                                                                                              
      type: Reconcile                                                                                                                                                                                                                                                                                                             
      state: Failed  # Non-retryable
      progress: 0                                                                                                                                                                                                                                                                                                                 
      description: "secret validation failed: 'bad_key' is not allowed"                                                                                                                                                                                                                                                           
    lastError:                                                         
      codes: [ERR_CONFIGURATION_PROBLEM]                                                                                                                                                                                                                                                                                          
      description: "secret validation failed: 'bad_key' is not allowed"                                                                                                                                                                                                                                                         
  ```                                                                                                                                                                                                                                                                                                                                
  #### Authentication Error (Non-Retryable): 
  ```yaml                                                                                                                                                                                                                                                                                             
  status:                                                                                                                                                                                                                                                                                                                         
    lastOperation:                                                                                                                                                                                                                                                                                                                
      state: Failed                                                                                                                                                                                                                                                                                                               
    lastError:                                                                                                                                                                                                                                                                                                                    
      codes: [ERR_INFRA_UNAUTHENTICATED]                                                                                                                                                                                                                                                                                          
      description: "Invalid API token"                                                                                                                                                                                                                                                                                            
  ```                                                                                                                                                                                                                                                                                                                
  #### Rate Limit Error (Retryable):  
  ```yaml                                                                                                                                                                                                                                                                                                    
  status:                                                                                                                                                                                                                                                                                                                         
    lastOperation:                                                                                                                                                                                                                                                                                                                
      state: Error  # Retryable                                                                                                                                                                                                                                                                                                   
    lastError:                                                                                                                                                                                                                                                                                                                    
      codes: [ERR_INFRA_RATE_LIMITS_EXCEEDED]                                                                                                                                                                                                                                                                                     
      description: "Rate limit exceeded"                                                                                                                                                                                                                                                                                          
   ```                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                  
  ## Migration Notes                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                  
  - Backwards Compatible: Existing DNSProviders will be updated with the new fields on next reconciliation                                                                                                                                                                                                                        
  - No Breaking Changes: The new fields are optional additions to the status subresource                                                                                                                                                                                                                                          
  - Timestamp Behavior: Changed from storing timestamps in UTC explicitly to using metav1.Time's natural timezone handling  
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Related to https://github.com/gardener/gardener-extension-shoot-dns-service/issues/628

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Enhances the DNSProvider resource status to include Gardener-standard `lastOperation` and `lastError` fields
```
