### PR TITLE
[docu/nextgeneration] Move api-references to docs folder and fix forwarding links

### DIFF
--- a/docs/api-reference/config.md
+++ b/docs/api-reference/config.md
@@ -110,7 +110,7 @@ for the primary cluster (certificates and source resources).
 <td>
 <code>ClientConnectionConfiguration</code></br>
 <em>
-<a href="#clientconnectionconfiguration">ClientConnectionConfiguration</a>
+<a href="https://pkg.go.dev/k8s.io/component-base/config/v1alpha1#ClientConnectionConfiguration">ClientConnectionConfiguration</a>
 </em>
 </td>
 <td>
@@ -159,7 +159,7 @@ for the cluster containing the provided issuers.
 <td>
 <code>ClientConnectionConfiguration</code></br>
 <em>
-<a href="#clientconnectionconfiguration">ClientConnectionConfiguration</a>
+<a href="https://pkg.go.dev/k8s.io/component-base/config/v1alpha1#ClientConnectionConfiguration">ClientConnectionConfiguration</a>
 </em>
 </td>
 <td>
@@ -445,7 +445,7 @@ DNSManagerConfiguration defines the configuration for the Gardener dns-controlle
 <td>
 <code>leaderElection</code></br>
 <em>
-<a href="#leaderelectionconfiguration">LeaderElectionConfiguration</a>
+<a href="https://pkg.go.dev/k8s.io/component-base/config/v1alpha1#LeaderElectionConfiguration">LeaderElectionConfiguration</a>
 </em>
 </td>
 <td>
@@ -489,7 +489,7 @@ string
 <td>
 <code>debugging</code></br>
 <em>
-<a href="#debuggingconfiguration">DebuggingConfiguration</a>
+<a href="https://pkg.go.dev/k8s.io/component-base/config/v1alpha1#DebuggingConfiguration">DebuggingConfiguration</a>
 </em>
 </td>
 <td>

--- a/hack/api-reference/config.yaml
+++ b/hack/api-reference/config.yaml
@@ -24,3 +24,12 @@ render:
     - name: IntOrString
       package: k8s.io/apimachinery/pkg/util/intstr
       link: https://pkg.go.dev/k8s.io/apimachinery/pkg/util/intstr#IntOrString
+    - name: ClientConnectionConfiguration
+      package: k8s.io/component-base/config/v1alpha1
+      link: https://pkg.go.dev/k8s.io/component-base/config/v1alpha1#ClientConnectionConfiguration
+    - name: LeaderElectionConfiguration
+      package: k8s.io/component-base/config/v1alpha1
+      link: https://pkg.go.dev/k8s.io/component-base/config/v1alpha1#LeaderElectionConfiguration
+    - name: DebuggingConfiguration
+      package: k8s.io/component-base/config/v1alpha1
+      link: https://pkg.go.dev/k8s.io/component-base/config/v1alpha1#DebuggingConfiguration

--- a/pkg/dnsman2/apis/config/v1alpha1/doc.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/doc.go
@@ -7,7 +7,7 @@
 // +k8s:openapi-gen=true
 // +k8s:defaulter-gen=TypeMeta
 
-//go:generate crd-ref-docs --source-path=. --config=../../../../../hack/api-reference/config.yaml --renderer=markdown --templates-dir=$GARDENER_HACK_DIR/api-reference/template --log-level=ERROR --output-path=../../../../../hack/api-reference/config.md
+//go:generate crd-ref-docs --source-path=. --config=../../../../../hack/api-reference/config.yaml --renderer=markdown --templates-dir=$GARDENER_HACK_DIR/api-reference/template --log-level=ERROR --output-path=../../../../../docs/api-reference/config.md
 
 // +groupName=config.dns.gardener.cloud
 package v1alpha1 // import "github.com/gardener/external-dns-management/pkg/dnsman2/apis/config/v1alpha1"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind task

**What this PR does / why we need it**:
Move api-references for the next generation `DNSManagerConfiguration` to the docs folder and fix forwarding links for external structs like `ClientConnectionConfiguration` and `LeaderElectionConfiguration`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc operator
NONE
```
