### PR TITLE
[Controller-Runtime-Rewrite] Allow cross-namespace references in `DNSAnnotation`

### DIFF
--- a/pkg/dnsman2/controller/dnsannotation/reconciler_reconcile.go
+++ b/pkg/dnsman2/controller/dnsannotation/reconciler_reconcile.go
@@ -16,14 +16,6 @@ import (
 
 func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, annotation *v1alpha1.DNSAnnotation) (reconcile.Result, error) {
 	log.Info("reconcile")
-	if annotation.Spec.ResourceRef.Namespace != annotation.Namespace {
-		log.Info("cross-namespace annotation not allowed")
-		return reconcile.Result{}, r.updateStatus(ctx, annotation, func(status *v1alpha1.DNSAnnotationStatus) error {
-			status.Message = "cross-namespace annotation not allowed"
-			status.Active = false
-			return nil
-		})
-	}
 	if err := r.state.SetResourceAnnotations(annotation.Spec.ResourceRef, client.ObjectKeyFromObject(annotation), annotation.Spec.Annotations); err != nil {
 		log.Info("failed to set resource annotations in state", "error", err.Error())
 		return reconcile.Result{}, r.updateStatus(ctx, annotation, func(status *v1alpha1.DNSAnnotationStatus) error {

--- a/pkg/dnsman2/controller/dnsannotation/reconciler_test.go
+++ b/pkg/dnsman2/controller/dnsannotation/reconciler_test.go
@@ -151,14 +151,26 @@ var _ = Describe("Reconcile", func() {
 		Expect(annotation2.Status.Active).To(BeFalse())
 	})
 
-	It("should not allow to annotate a reference in another namespace", func() {
+	It("should allow to annotate a reference in another namespace", func() {
 		annotation.Spec.ResourceRef.Namespace = "other-namespace"
 		Expect(fakeClient.Create(ctx, annotation)).To(Succeed())
 		result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: annotationKey})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result).To(Equal(reconcile.Result{}))
-		Expect(fakeClient.Get(ctx, annotationKey, annotation)).To(Succeed())
-		Expect(annotation.Status.Message).To(ContainSubstring("cross-namespace annotation not allowed"))
-		Expect(annotation.Status.Active).To(BeFalse())
+
+		annotations, message, active := state.GetState().GetAnnotationState().GetResourceAnnotationStatus(annotation.Spec.ResourceRef)
+		Expect(annotations).To(Equal(map[string]string{
+			"foo":                      "bar",
+			"dns.gardener.cloud/class": "other-class",
+		}))
+		Expect(message).To(BeEmpty())
+		Expect(active).To(BeFalse())
+
+		Expect(state.GetState().GetAnnotationState().UpdateStatus(ctx, fakeClient, annotation.Spec.ResourceRef, true)).To(Succeed())
+
+		updatedAnnotation := &v1alpha1.DNSAnnotation{}
+		Expect(fakeClient.Get(ctx, annotationKey, updatedAnnotation)).To(Succeed())
+		Expect(updatedAnnotation.Status.Message).To(BeEmpty())
+		Expect(updatedAnnotation.Status.Active).To(BeTrue())
 	})
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Cross-namespace references in `DNSAnnotations` are a common use case. It was originally disallowed in the next-generation controller, but it is needed. Therefore it should be allowed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
