### PR TITLE
Fix type-name in GDC-ag credentials validation

### DIFF
--- a/pkg/controller/provider/gdch/validation/adaptor.go
+++ b/pkg/controller/provider/gdch/validation/adaptor.go
@@ -66,8 +66,8 @@ func ValidateServiceAccountJSON(data []byte) (LightCredentialsFile, error) {
 	if !projectIDRegexp.MatchString(credInfo.Project) {
 		return credInfo, fmt.Errorf("'serviceaccount.json' field 'project' is not a valid project")
 	}
-	if credInfo.Type != "service_account" {
-		return credInfo, fmt.Errorf("'serviceaccount.json' field 'type' is not 'service_account'")
+	if credInfo.Type != "gdch_service_account" {
+		return credInfo, fmt.Errorf("'serviceaccount.json' field 'type' is not 'gdch_service_account'")
 	}
 	return credInfo, nil
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind bug
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**: The GDC-ag validation introduced last year by me references an incorrect service-account type. The correct type-string to look for is `gdch_service_account`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
fix validation of GDC-ag credentials: check for correct type-string
```
