### PR TITLE
[dnsman-nextgeneration]: support secondary DNS classes with automatic migration  

### DIFF
--- a/cmd/nextgen/app/app.go
+++ b/cmd/nextgen/app/app.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gardener/external-dns-management/pkg/dnsman2/app"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/app/appcontext"
 	dnsmanclient "github.com/gardener/external-dns-management/pkg/dnsman2/client"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/metrics"
 )
 
@@ -138,6 +139,32 @@ func (o *options) Complete() error {
 
 // Validate validates the provided command options.
 func (o *options) Validate() error {
+	if !dns.IsValidClass(o.config.Class) {
+		return fmt.Errorf("invalid primary class: %q", o.config.Class)
+	}
+	// Check for duplicates within secondary classes
+	seen := make(map[string]string, len(o.config.SecondaryClasses))
+	for _, secondaryClass := range o.config.SecondaryClasses {
+		if !dns.IsValidClass(secondaryClass) {
+			return fmt.Errorf("invalid secondary class: %q", secondaryClass)
+		}
+		normalized := dns.NormalizeClass(secondaryClass)
+		if original, exists := seen[normalized]; exists {
+			return fmt.Errorf("duplicate secondary class found: %q and %q are equivalent", original, secondaryClass)
+		}
+		seen[normalized] = secondaryClass
+
+		// Check if secondary class is equivalent to primary class
+		if dns.EquivalentClass(o.config.Class, secondaryClass) {
+			return fmt.Errorf("secondary class %q is equivalent to primary class %q", secondaryClass, o.config.Class)
+		}
+	}
+	if sourceClass := o.config.Controllers.Source.SourceClass; sourceClass != nil && !dns.IsValidClass(*sourceClass) {
+		return fmt.Errorf("invalid source-controllers source class: %q", *sourceClass)
+	}
+	if targetClass := o.config.Controllers.Source.TargetClass; targetClass != nil && !dns.IsValidClass(*targetClass) {
+		return fmt.Errorf("invalid source-controllers target class: %q", *targetClass)
+	}
 	return nil
 }
 

--- a/cmd/nextgen/app/app_test.go
+++ b/cmd/nextgen/app/app_test.go
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/gardener/external-dns-management/pkg/dnsman2/apis/config"
+)
+
+func TestApp(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "App Suite")
+}
+
+var _ = Describe("Options Validation", func() {
+	Describe("#Validate", func() {
+		DescribeTable("validation scenarios",
+			func(primaryClass string, secondaryClasses []string, shouldSucceed bool, errorSubstring string) {
+				opts := &options{
+					config: &config.DNSManagerConfiguration{
+						Class:            primaryClass,
+						SecondaryClasses: secondaryClasses,
+					},
+				}
+
+				err := opts.Validate()
+				if shouldSucceed {
+					Expect(err).To(Succeed())
+				} else {
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring(errorSubstring))
+				}
+			},
+			Entry("no secondary classes", "primary", nil, true, ""),
+			Entry("valid secondary classes", "primary", []string{"secondary1", "secondary2"}, true, ""),
+			Entry("multiple different secondary classes", "primary", []string{"secondary1", "secondary2", "secondary3"}, true, ""),
+			Entry("secondary class equals primary class", "primary", []string{"primary"}, false, "equivalent to primary class"),
+			Entry("secondary class equivalent to primary (default class)", "", []string{"gardendns"}, false, "equivalent to primary class"),
+			Entry("secondary class equivalent to default class", "gardendns", []string{""}, false, "equivalent to primary class"),
+			Entry("duplicate secondary classes (exact match)", "primary", []string{"secondary1", "secondary1"}, false, "duplicate secondary class found"),
+			Entry("duplicate secondary classes (empty strings)", "primary", []string{"", ""}, false, "duplicate secondary class found"),
+			Entry("equivalent secondary classes (default variations)", "primary", []string{"gardendns", ""}, false, "duplicate secondary class found"),
+		)
+	})
+})

--- a/docs/api-reference/config.md
+++ b/docs/api-reference/config.md
@@ -516,7 +516,19 @@ string
 </em>
 </td>
 <td>
-<p>Class is the "dns.gardener.cloud/class" the dns-controller-manager is responsible for.<br />If not set, the default class "gardendns" is used.</p>
+<p>Class is the primary "dns.gardener.cloud/class" the dns-controller-manager is responsible for.<br />If not set, the default class "gardendns" is used.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>secondaryClasses</code></br>
+<em>
+string array
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SecondaryClasses are additional classes, the "dns.gardener.cloud/class" the dns-controller-manager is responsible for.<br />DNSProviders and DNSEntries with such classes will be processed, but the class annotation will be changed to the primary one.</p>
 </td>
 </tr>
 <tr>

--- a/docs/usage/secondary-classes.md
+++ b/docs/usage/secondary-classes.md
@@ -1,0 +1,170 @@
+# Secondary DNS Classes
+
+## Overview
+
+The secondary DNS classes feature allows the DNS controller manager to manage DNSProviders and DNSEntries from multiple DNS classes simultaneously. Resources with secondary classes are automatically migrated to the primary class during reconciliation, enabling smooth transitions between DNS class configurations.
+
+## Use Cases
+
+### 1. Rolling Updates Between DNS Classes
+
+When migrating from one DNS class to another across a large infrastructure:
+
+**Before secondary classes:**
+- Switching DNS class required coordination across multiple clusters
+- Risk of DNS outage during the transition
+- Manual cleanup of old class resources
+
+**With secondary classes:**
+- Deploy new DNS controller with secondary class configuration
+- Existing resources continue to be managed
+- Resources are automatically migrated to the new primary class
+- No DNS service interruption
+
+### 2. Multi-Tenant Environments
+
+In shared environments where different teams use different DNS classes:
+
+- A single DNS controller instance can manage resources from multiple classes
+- Gradual consolidation of DNS classes without disruption
+- Simplified operations by reducing the number of controller instances
+
+### 3. Blue-Green Deployments
+
+During DNS controller upgrades or configuration changes:
+
+- Deploy new controller with different primary class
+- Configure old class as secondary
+- Resources seamlessly transition
+- Rollback capability by reversing primary/secondary configuration
+
+## Configuration
+
+### Controller Configuration
+
+Add secondary classes to the DNS manager configuration:
+
+```yaml
+apiVersion: dnsman2.gardener.cloud/v1alpha1
+kind: DNSManagerConfiguration
+class: "new-class"
+secondaryClasses:
+  - "old-class"
+  - "legacy-class"
+```
+
+### Validation
+
+The controller validates the configuration at startup:
+
+- **No duplicates**: Secondary classes cannot contain duplicates (including normalized equivalents)
+- **No conflicts**: Secondary classes cannot be equivalent to the primary class
+- **Class normalization**: Empty string `""` and `"gardendns"` are treated as equivalent (default class)
+
+## Migration Behavior
+
+### Automatic Migration
+
+When a DNSProvider or DNSEntry with a secondary class is reconciled:
+
+1. **Class annotation update**:
+   - If primary class is default (`gardendns`): annotation is removed
+   - Otherwise: annotation is set to the primary class value
+
+2. **Finalizer migration**:
+   - Secondary class finalizers are removed (e.g., `old-class.dns.gardener.cloud/compound`)
+   - Primary class finalizer is added (e.g., `new-class.dns.gardener.cloud/compound`)
+
+3. **Secret handling** (DNSProvider only):
+   - Associated secrets have their finalizers migrated as well
+   - Ensures proper cleanup lifecycle
+
+### Migration Example
+
+**Before migration:**
+```yaml
+apiVersion: dns.gardener.cloud/v1alpha1
+kind: DNSEntry
+metadata:
+  name: my-entry
+  annotations:
+    dns.gardener.cloud/class: "old-class"
+  finalizers:
+    - old-class.dns.gardener.cloud/compound
+spec:
+  dnsName: "example.com"
+```
+
+**After migration** (with `class: "new-class"`, `secondaryClasses: ["old-class"]`):
+```yaml
+apiVersion: dns.gardener.cloud/v1alpha1
+kind: DNSEntry
+metadata:
+  name: my-entry
+  annotations:
+    dns.gardener.cloud/class: "new-class"
+  finalizers:
+    - new-class.dns.gardener.cloud/compound
+spec:
+  dnsName: "example.com"
+```
+
+### Timing
+
+Migration happens during the reconciliation loop:
+- **Before** regular reconciliation logic
+- Ensures clean state before processing
+- No requeue required - continues with normal reconciliation
+
+## Rollout Strategy
+
+### Step-by-Step Migration Guide
+
+**Phase 1: Preparation**
+
+1. Identify current DNS class in use (check existing resources)
+2. Choose new primary class name
+3. Update DNS controller configuration with secondary classes
+4. Validate configuration locally
+
+**Phase 2: Deployment**
+
+1. Deploy updated DNS controller with secondary classes configured:
+   ```yaml
+   class: "new-primary"
+   secondaryClasses:
+     - "old-primary"
+   ```
+
+2. Controller will automatically start managing resources from both classes
+
+**Phase 3: Migration**
+
+3. Monitor logs for migration activity
+4. Verify resources are being updated:
+   ```bash
+   kubectl get dnsentries -A -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.annotations.dns\.gardener\.cloud/class}{"\n"}{end}'
+   ```
+
+5. Check finalizers are migrated:
+   ```bash
+   kubectl get dnsproviders -A -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.finalizers}{"\n"}{end}'
+   ```
+
+**Phase 4: Cleanup**
+
+6. Once all resources are migrated, remove secondary classes from configuration
+7. Deploy final configuration with only the new primary class
+
+**Phase 5: Verification**
+
+8. Confirm no resources remain with old class annotation
+9. Verify DNS resolution continues to work
+10. Monitor for any issues in the first 24 hours
+
+
+## Related Documentation
+
+- [DNS Class Configuration](./dns-classes.md)
+- [Controller Configuration Reference](../api-reference/config.md)
+- [Migration Best Practices](./migration.md)

--- a/docs/usage/secondary-classes.md
+++ b/docs/usage/secondary-classes.md
@@ -2,7 +2,8 @@
 
 ## Overview
 
-The secondary DNS classes feature allows the DNS controller manager to manage DNSProviders and DNSEntries from multiple DNS classes simultaneously. Resources with secondary classes are automatically migrated to the primary class during reconciliation, enabling smooth transitions between DNS class configurations.
+The secondary DNS classes feature allows the DNS controller manager to manage `DNSProviders` and `DNSEntries` from multiple DNS classes simultaneously.
+Resources with secondary classes are automatically migrated to the primary class during reconciliation, enabling smooth transitions between DNS class configurations.
 
 ## Use Cases
 
@@ -165,6 +166,4 @@ Migration happens during the reconciliation loop:
 
 ## Related Documentation
 
-- [DNS Class Configuration](./dns-classes.md)
 - [Controller Configuration Reference](../api-reference/config.md)
-- [Migration Best Practices](./migration.md)

--- a/pkg/dnsman2/apis/config/types.go
+++ b/pkg/dnsman2/apis/config/types.go
@@ -34,9 +34,12 @@ type DNSManagerConfiguration struct {
 	Debugging *componentbaseconfig.DebuggingConfiguration
 	// Controllers defines the configuration of the controllers.
 	Controllers ControllerConfiguration
-	// Class is the "dns.gardener.cloud/class" the dns-controller-manager is responsible for.
+	// Class is the primary "dns.gardener.cloud/class" the dns-controller-manager is responsible for.
 	// If not set, the default class "gardendns" is used.
 	Class string
+	// SecondaryClasses are additional classes, the "dns.gardener.cloud/class" the dns-controller-manager is responsible for.
+	// DNSProviders and DNSEntries with such classes will be processed, but the class annotation will be changed to the primary one.
+	SecondaryClasses []string
 	// DeployCRDs indicates whether the required CRDs should be deployed to the main cluster on startup.
 	// This does not include the control plane cluster, if different.
 	DeployCRDs *bool

--- a/pkg/dnsman2/apis/config/v1alpha1/types.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/types.go
@@ -39,9 +39,13 @@ type DNSManagerConfiguration struct {
 	Debugging *componentbaseconfigv1alpha1.DebuggingConfiguration `json:"debugging,omitempty"`
 	// Controllers defines the configuration of the controllers.
 	Controllers ControllerConfiguration `json:"controllers"`
-	// Class is the "dns.gardener.cloud/class" the dns-controller-manager is responsible for.
+	// Class is the primary "dns.gardener.cloud/class" the dns-controller-manager is responsible for.
 	// If not set, the default class "gardendns" is used.
 	Class string `json:"class"`
+	// SecondaryClasses are additional classes, the "dns.gardener.cloud/class" the dns-controller-manager is responsible for.
+	// DNSProviders and DNSEntries with such classes will be processed, but the class annotation will be changed to the primary one.
+	// +optional
+	SecondaryClasses []string `json:"secondaryClasses,omitempty"`
 	// DeployCRDs indicates whether the required CRDs should be deployed to the main cluster on startup.
 	// This does not include the control plane cluster, if different.
 	// +optional

--- a/pkg/dnsman2/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/zz_generated.conversion.go
@@ -347,6 +347,7 @@ func autoConvert_v1alpha1_DNSManagerConfiguration_To_config_DNSManagerConfigurat
 		return err
 	}
 	out.Class = in.Class
+	out.SecondaryClasses = *(*[]string)(unsafe.Pointer(&in.SecondaryClasses))
 	out.DeployCRDs = (*bool)(unsafe.Pointer(in.DeployCRDs))
 	out.ConditionalDeployCRDs = (*bool)(unsafe.Pointer(in.ConditionalDeployCRDs))
 	out.AddShootNoCleanupLabelToCRDs = (*bool)(unsafe.Pointer(in.AddShootNoCleanupLabelToCRDs))
@@ -383,6 +384,7 @@ func autoConvert_config_DNSManagerConfiguration_To_v1alpha1_DNSManagerConfigurat
 		return err
 	}
 	out.Class = in.Class
+	out.SecondaryClasses = *(*[]string)(unsafe.Pointer(&in.SecondaryClasses))
 	out.DeployCRDs = (*bool)(unsafe.Pointer(in.DeployCRDs))
 	out.ConditionalDeployCRDs = (*bool)(unsafe.Pointer(in.ConditionalDeployCRDs))
 	out.AddShootNoCleanupLabelToCRDs = (*bool)(unsafe.Pointer(in.AddShootNoCleanupLabelToCRDs))

--- a/pkg/dnsman2/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -208,6 +208,11 @@ func (in *DNSManagerConfiguration) DeepCopyInto(out *DNSManagerConfiguration) {
 		(*in).DeepCopyInto(*out)
 	}
 	in.Controllers.DeepCopyInto(&out.Controllers)
+	if in.SecondaryClasses != nil {
+		in, out := &in.SecondaryClasses, &out.SecondaryClasses
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.DeployCRDs != nil {
 		in, out := &in.DeployCRDs, &out.DeployCRDs
 		*out = new(bool)

--- a/pkg/dnsman2/apis/config/zz_generated.deepcopy.go
+++ b/pkg/dnsman2/apis/config/zz_generated.deepcopy.go
@@ -208,6 +208,11 @@ func (in *DNSManagerConfiguration) DeepCopyInto(out *DNSManagerConfiguration) {
 		**out = **in
 	}
 	in.Controllers.DeepCopyInto(&out.Controllers)
+	if in.SecondaryClasses != nil {
+		in, out := &in.SecondaryClasses, &out.SecondaryClasses
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.DeployCRDs != nil {
 		in, out := &in.DeployCRDs, &out.DeployCRDs
 		*out = new(bool)

--- a/pkg/dnsman2/app/controllerswitches.go
+++ b/pkg/dnsman2/app/controllerswitches.go
@@ -122,9 +122,14 @@ func AddSourceDNSEntryController(ctx context.Context, mgr manager.Manager) error
 	if err != nil {
 		return err
 	}
-	if mgr == appCtx.ControlPlane && dns.EquivalentClass(appCtx.Config.Class, ptr.Deref(appCtx.Config.Controllers.Source.SourceClass, "")) {
-		appCtx.Log.Info("Skipping addition of DNSEntry source controller in single cluster deployment")
-		return nil
+	if mgr == appCtx.ControlPlane {
+		sourceClass := ptr.Deref(appCtx.Config.Controllers.Source.SourceClass, "")
+		for _, class := range append([]string{sourceClass}, appCtx.Config.SecondaryClasses...) {
+			if dns.EquivalentClass(appCtx.Config.Class, class) {
+				appCtx.Log.Info("Skipping addition of DNSEntry source controller in single cluster deployment")
+				return nil
+			}
+		}
 	}
 	return common.NewSourceReconciler(&sourcednsentry.Actuator{}).AddToManager(mgr, appCtx.ControlPlane, appCtx.Config, nil)
 }

--- a/pkg/dnsman2/controller/controller_suite_test.go
+++ b/pkg/dnsman2/controller/controller_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Controller Suite")
+}

--- a/pkg/dnsman2/controller/controlplane/dnsentry/add.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/add.go
@@ -45,6 +45,7 @@ const ControllerName = "dnsentry"
 func (r *Reconciler) AddToManager(mgr manager.Manager, controlPlaneCluster cluster.Cluster, cfg *config.DNSManagerConfiguration) error {
 	r.Config = cfg.Controllers.DNSEntry
 	r.Class = cfg.Class
+	r.SecondaryClasses = cfg.SecondaryClasses
 	r.Namespace = cfg.Controllers.DNSProvider.Namespace
 	r.Client = controlPlaneCluster.GetClient()
 	if r.Clock == nil {
@@ -70,7 +71,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, controlPlaneCluster clust
 		WatchesRawSource(source.Kind[client.Object](controlPlaneCluster.GetCache(),
 			&v1alpha1.DNSEntry{},
 			&handler.EnqueueRequestForObject{},
-			dnsman2controller.DNSClassPredicate(r.Class),
+			dnsman2controller.DNSClassesPredicate(r.Class, r.SecondaryClasses),
 			dnsman2controller.FilterPredicate(func(obj client.Object) bool {
 				return obj.GetNamespace() == r.Namespace
 			}),
@@ -80,7 +81,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, controlPlaneCluster clust
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, provider client.Object) []reconcile.Request {
 				return r.entriesToReconcileOnProviderChanges(ctx, provider)
 			}),
-			dnsman2controller.DNSClassPredicate(r.Class),
+			dnsman2controller.DNSClassesPredicate(r.Class, r.SecondaryClasses),
 		))
 
 	if r.Config.SyncPeriod != nil && r.Config.SyncPeriod.Duration > 0 {
@@ -163,7 +164,7 @@ func (r *Reconciler) allEntriesToReconcile(ctx context.Context) []reconcile.Requ
 	if err := r.Client.List(ctx, entryList, client.InNamespace(r.Namespace)); err != nil {
 		return nil
 	}
-	for _, entry := range dns.FilterEntriesByClass(entryList.Items, r.Class) {
+	for _, entry := range dns.FilterEntriesByClass(entryList.Items, r.Class, r.SecondaryClasses) {
 		requests = append(requests, reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Name:      entry.Name,

--- a/pkg/dnsman2/controller/controlplane/dnsentry/common/entrycontext.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/common/entrycontext.go
@@ -19,11 +19,13 @@ import (
 
 // EntryContext holds context and references for a DNSEntry reconciliation.
 type EntryContext struct {
-	Client client.Client
-	Clock  clock.Clock
-	Ctx    context.Context
-	Log    logr.Logger
-	Entry  *v1alpha1.DNSEntry
+	Client           client.Client
+	Clock            clock.Clock
+	Ctx              context.Context
+	Log              logr.Logger
+	Class            string
+	SecondaryClasses []string
+	Entry            *v1alpha1.DNSEntry
 }
 
 // StatusUpdater returns a new EntryStatusUpdater for this EntryContext.

--- a/pkg/dnsman2/controller/controlplane/dnsentry/common/statusupdater.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/common/statusupdater.go
@@ -62,7 +62,7 @@ func (u *EntryStatusUpdater) AddFinalizer() *ReconcileResult {
 	if u.Entry.DeletionTimestamp != nil {
 		return nil
 	}
-	if err := controllerutils.AddFinalizers(u.Ctx, u.Client, u.Entry, dns.FinalizerCompound); err != nil {
+	if err := controllerutils.AddFinalizers(u.Ctx, u.Client, u.Entry, u.finalizerName()); err != nil {
 		u.Log.Error(err, "failed to add finalizer")
 		return &ReconcileResult{Err: err}
 	}
@@ -71,11 +71,15 @@ func (u *EntryStatusUpdater) AddFinalizer() *ReconcileResult {
 
 // RemoveFinalizer removes the DNS finalizer from the DNSEntry resource.
 func (u *EntryStatusUpdater) RemoveFinalizer() *ReconcileResult {
-	if err := controllerutils.RemoveFinalizers(u.Ctx, u.Client, u.Entry, dns.FinalizerCompound); err != nil {
+	if err := controllerutils.RemoveFinalizers(u.Ctx, u.Client, u.Entry, u.finalizerName()); err != nil {
 		u.Log.Error(err, "failed to remove finalizer")
 		return &ReconcileResult{Err: err}
 	}
 	return nil
+}
+
+func (u *EntryStatusUpdater) finalizerName() string {
+	return dns.ClassFinalizerName(u.Class)
 }
 
 // dropReconcileAnnotation removes the reconcile annotation from the DNSEntry resource if it exists.

--- a/pkg/dnsman2/controller/controlplane/dnsentry/migration_test.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/migration_test.go
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dnsentry
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/controller/controlplane/dnsentry/common"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns"
+)
+
+var _ = Describe("DNS Class Migration Logic", func() {
+	DescribeTable("needsToMigrateDNSClassOrFinalizers",
+		func(annotations map[string]string, finalizers []string, class string, secondaryClasses []string, expected bool) {
+			entry := &v1alpha1.DNSEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: annotations,
+					Finalizers:  finalizers,
+				},
+			}
+
+			r := &entryReconciliation{
+				EntryContext: common.EntryContext{
+					Class:            class,
+					SecondaryClasses: secondaryClasses,
+					Entry:            entry,
+				},
+			}
+
+			Expect(r.needsToMigrateDNSClassOrFinalizers()).To(Equal(expected))
+		},
+		Entry("when secondary class finalizer is present", nil, []string{"class-b.dns.gardener.cloud/compound"}, "", []string{"class-b"}, true),
+		Entry("when class annotation mismatches", map[string]string{dns.AnnotationClass: "class-a"}, []string{dns.FinalizerCompound}, "", nil, true),
+		Entry("when no migration is needed", nil, []string{dns.FinalizerCompound}, "", []string{"class-b"}, false),
+		Entry("when no migration is needed for non-default primary class",
+			map[string]string{dns.AnnotationClass: "class-a"},
+			[]string{dns.ClassFinalizerName("class-a")},
+			"class-a",
+			[]string{"class-b"},
+			false,
+		),
+		Entry("when no migration is needed for non-default primary class without secondary classes",
+			map[string]string{dns.AnnotationClass: "class-a"},
+			[]string{dns.ClassFinalizerName("class-a")},
+			"class-a",
+			nil,
+			false,
+		),
+	)
+})

--- a/pkg/dnsman2/controller/controlplane/dnsentry/providerselector/providerselector.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/providerselector/providerselector.go
@@ -33,11 +33,10 @@ type NewProviderData struct {
 }
 
 // CalcNewProvider is a utility function to calculate a new DNS provider for the given EntryContext, namespace, and class.
-func CalcNewProvider(ec common.EntryContext, namespace, class string, state *state.State) (*NewProviderData, *common.ReconcileResult) {
+func CalcNewProvider(ec common.EntryContext, namespace string, state *state.State) (*NewProviderData, *common.ReconcileResult) {
 	selector := providerSelector{
 		EntryContext: ec,
 		namespace:    namespace,
-		class:        class,
 		state:        state,
 	}
 	return selector.calcNewProvider()
@@ -46,7 +45,6 @@ func CalcNewProvider(ec common.EntryContext, namespace, class string, state *sta
 type providerSelector struct {
 	common.EntryContext
 	namespace string
-	class     string
 	state     *state.State
 }
 
@@ -55,7 +53,7 @@ func (s *providerSelector) calcNewProvider() (*NewProviderData, *common.Reconcil
 	if err := s.Client.List(s.Ctx, providerList, client.InNamespace(s.namespace)); err != nil {
 		return nil, &common.ReconcileResult{Err: err}
 	}
-	providers := dns.FilterProvidersByClass(providerList.Items, s.class)
+	providers := dns.FilterProvidersByClass(providerList.Items, s.Class, s.SecondaryClasses)
 	if res := s.haveAllProvidersBeenReconciled(providers); res != nil {
 		return nil, res
 	}

--- a/pkg/dnsman2/controller/controlplane/dnsentry/reconciler.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/reconciler.go
@@ -37,6 +37,7 @@ type Reconciler struct {
 	Clock                          clock.Clock
 	Namespace                      string
 	Class                          string
+	SecondaryClasses               []string
 	MigrationMode                  bool
 	defaultCNAMELookupInterval     int64
 	reconciliationDelayAfterUpdate time.Duration
@@ -70,14 +71,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, ptr.Deref(r.Config.ReconciliationTimeout, metav1.Duration{Duration: 2 * time.Minute}).Duration)
 	er := entryReconciliation{
 		EntryContext: common.EntryContext{
-			Client: r.Client,
-			Clock:  r.Clock,
-			Ctx:    logr.NewContext(ctxWithTimeout, log),
-			Log:    log,
-			Entry:  entry,
+			Client:           r.Client,
+			Clock:            r.Clock,
+			Ctx:              logr.NewContext(ctxWithTimeout, log),
+			Log:              log,
+			Class:            r.Class,
+			SecondaryClasses: r.SecondaryClasses,
+			Entry:            entry,
 		},
 		namespace:                  r.Namespace,
-		class:                      r.Class,
 		migrationMode:              r.MigrationMode,
 		lookupProcessor:            r.lookupProcessor,
 		state:                      r.state,

--- a/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_reconcile.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_reconcile.go
@@ -30,7 +30,6 @@ import (
 type entryReconciliation struct {
 	common.EntryContext
 	namespace                  string
-	class                      string
 	migrationMode              bool
 	state                      *state.State
 	lookupProcessor            lookup.LookupProcessor
@@ -73,6 +72,10 @@ func (r *entryReconciliation) reconcile() common.ReconcileResult {
 }
 
 func (r *entryReconciliation) doReconcile() common.ReconcileResult {
+	if res := r.migrateDNSClass(); res != nil {
+		return *res
+	}
+
 	if res := r.ignoredByAnnotation(); res != nil {
 		return *res
 	}
@@ -87,7 +90,7 @@ func (r *entryReconciliation) doReconcile() common.ReconcileResult {
 		return *common.InvalidReconcileResult(fmt.Sprintf("validation failed: %s", err))
 	}
 
-	newProviderData, res := providerselector.CalcNewProvider(r.EntryContext, r.namespace, r.class, r.state)
+	newProviderData, res := providerselector.CalcNewProvider(r.EntryContext, r.namespace, r.state)
 	if res != nil {
 		return *res
 	}
@@ -123,6 +126,34 @@ func (r *entryReconciliation) doReconcile() common.ReconcileResult {
 	}
 
 	return r.updateStatusWithProvider(targetsData)
+}
+
+func (r *entryReconciliation) migrateDNSClass() *common.ReconcileResult {
+	if !r.needsToMigrateDNSClassOrFinalizers() {
+		return nil
+	}
+
+	patch := client.MergeFrom(r.Entry.DeepCopy())
+
+	if dns.IsDefaultClass(r.Class) {
+		utils.RemoveAnnotation(r.Entry, dns.AnnotationClass)
+	} else {
+		utils.SetAnnotation(r.Entry, dns.AnnotationClass, r.Class)
+	}
+	dns.MigrateSecondaryClassFinalizers(r.Entry, r.Class, r.SecondaryClasses)
+
+	if err := r.Client.Patch(r.Ctx, r.Entry, patch); err != nil {
+		return &common.ReconcileResult{Err: fmt.Errorf("failed to patch entry for DNS class migration: %w", err)}
+	}
+	r.Log.Info("patched entry for DNS class migration", "newClass", r.Class)
+	return nil
+}
+
+func (r *entryReconciliation) needsToMigrateDNSClassOrFinalizers() bool {
+	if !dns.EquivalentClass(r.Entry.Annotations[dns.AnnotationClass], r.Class) {
+		return true
+	}
+	return dns.HasSecondaryClassFinalizerNames(r.Entry, r.SecondaryClasses)
 }
 
 func (r *entryReconciliation) lockDNSNames() (func(), *common.ReconcileResult) {

--- a/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_test.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_test.go
@@ -894,4 +894,123 @@ var _ = Describe("Reconcile", func() {
 			checkEntryStatus(entryA, "test/p1", zoneID1, "Ready", defaultTTL, "1.2.3.4")
 		})
 	})
+
+	Context("Secondary Classes Migration", func() {
+		BeforeEach(func() {
+			createProvider("p1", []string{"example.com"}, nil, v1alpha1.StateReady, mockConfig1)
+			reconciler.Class = "" // default class
+		})
+
+		type migrationTestCase struct {
+			initialAnnotations       map[string]string
+			initialFinalizers        []string
+			reconcilerClass          string
+			reconcilerSecondaryClass []string
+			setupProvider            bool
+			providerClass            string
+			expectedAnnotation       *string
+			expectedFinalizers       []string
+			unexpectedFinalizers     []string
+		}
+
+		DescribeTable("DNS class migration scenarios",
+			func(tc migrationTestCase) {
+				// Setup entry
+				if tc.initialAnnotations != nil {
+					entryA.Annotations = tc.initialAnnotations
+				}
+				entryA.Finalizers = tc.initialFinalizers
+				Expect(fakeClient.Create(ctx, entryA)).To(Succeed())
+
+				// Setup provider if needed
+				if tc.setupProvider {
+					deleteProvider("p1")
+					p1 := createProvider("p1", []string{"example.com"}, nil, v1alpha1.StateReady, mockConfig1)
+					if tc.providerClass != "" {
+						p1.Annotations = map[string]string{dns.AnnotationClass: tc.providerClass}
+						Expect(fakeClient.Update(ctx, p1)).To(Succeed())
+					}
+				}
+
+				// Setup reconciler
+				reconciler.Class = tc.reconcilerClass
+				reconciler.SecondaryClasses = tc.reconcilerSecondaryClass
+
+				// Reconcile
+				key := client.ObjectKeyFromObject(entryA)
+				result, err := reconcileEntry(key)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+
+				// Verify results
+				Expect(fakeClient.Get(ctx, key, entryA)).To(Succeed())
+				if tc.expectedAnnotation != nil {
+					Expect(entryA.Annotations[dns.AnnotationClass]).To(Equal(*tc.expectedAnnotation))
+				} else {
+					Expect(entryA.Annotations).NotTo(HaveKey(dns.AnnotationClass))
+				}
+				for _, expectedFinalizer := range tc.expectedFinalizers {
+					Expect(entryA.Finalizers).To(ContainElement(expectedFinalizer))
+				}
+				for _, unexpectedFinalizer := range tc.unexpectedFinalizers {
+					Expect(entryA.Finalizers).NotTo(ContainElement(unexpectedFinalizer))
+				}
+			},
+			Entry("migrate secondary class finalizer to primary class (default)", migrationTestCase{
+				initialFinalizers:        []string{"class-b.dns.gardener.cloud/compound"},
+				reconcilerClass:          "",
+				reconcilerSecondaryClass: []string{"class-b"},
+				expectedFinalizers:       []string{dns.FinalizerCompound},
+				unexpectedFinalizers:     []string{"class-b.dns.gardener.cloud/compound"},
+			}),
+			Entry("migrate multiple secondary class finalizers to primary class (default)", migrationTestCase{
+				initialFinalizers:        []string{"class-b.dns.gardener.cloud/compound", "class-c.dns.gardener.cloud/compound"},
+				reconcilerClass:          "",
+				reconcilerSecondaryClass: []string{"class-b", "class-c"},
+				expectedFinalizers:       []string{dns.FinalizerCompound},
+				unexpectedFinalizers:     []string{"class-b.dns.gardener.cloud/compound", "class-c.dns.gardener.cloud/compound"},
+			}),
+			Entry("migrate entry from secondary class to default class", migrationTestCase{
+				initialAnnotations:       map[string]string{dns.AnnotationClass: "class-b"},
+				initialFinalizers:        []string{"class-b.dns.gardener.cloud/compound"},
+				reconcilerClass:          dns.DefaultClass,
+				reconcilerSecondaryClass: []string{"class-b"},
+				expectedFinalizers:       []string{dns.FinalizerCompound},
+				unexpectedFinalizers:     []string{"class-b.dns.gardener.cloud/compound"},
+			}),
+			Entry("migrate entry from secondary class to non-default primary class", migrationTestCase{
+				initialAnnotations:       map[string]string{dns.AnnotationClass: "class-b"},
+				initialFinalizers:        []string{"class-b.dns.gardener.cloud/compound"},
+				reconcilerClass:          "class-a",
+				reconcilerSecondaryClass: []string{"class-b"},
+				setupProvider:            true,
+				providerClass:            "class-a",
+				expectedAnnotation:       ptr.To("class-a"),
+				expectedFinalizers:       []string{"class-a.dns.gardener.cloud/compound"},
+				unexpectedFinalizers:     []string{"class-b.dns.gardener.cloud/compound"},
+			}),
+			Entry("no migration if class and finalizers already match (default class)", migrationTestCase{
+				initialFinalizers:        []string{dns.FinalizerCompound},
+				reconcilerClass:          dns.DefaultClass,
+				reconcilerSecondaryClass: []string{"class-b"},
+				expectedFinalizers:       []string{dns.FinalizerCompound},
+				unexpectedFinalizers:     []string{"class-b.dns.gardener.cloud/compound"},
+			}),
+			Entry("migrate when only class annotation mismatches (no secondary finalizers)", migrationTestCase{
+				initialAnnotations:       map[string]string{dns.AnnotationClass: "wrong-class"},
+				initialFinalizers:        []string{dns.FinalizerCompound},
+				reconcilerClass:          dns.DefaultClass,
+				reconcilerSecondaryClass: nil,
+				expectedFinalizers:       []string{dns.FinalizerCompound},
+			}),
+			Entry("handle migration with both class mismatch and secondary class finalizers", migrationTestCase{
+				initialAnnotations:       map[string]string{dns.AnnotationClass: "class-b"},
+				initialFinalizers:        []string{"class-c.dns.gardener.cloud/compound", "class-d.dns.gardener.cloud/compound"},
+				reconcilerClass:          dns.DefaultClass,
+				reconcilerSecondaryClass: []string{"class-b", "class-c", "class-d"},
+				expectedFinalizers:       []string{dns.FinalizerCompound},
+				unexpectedFinalizers:     []string{"class-b.dns.gardener.cloud/compound", "class-c.dns.gardener.cloud/compound", "class-d.dns.gardener.cloud/compound"},
+			}),
+		)
+	})
 })

--- a/pkg/dnsman2/controller/controlplane/dnsprovider/add.go
+++ b/pkg/dnsman2/controller/controlplane/dnsprovider/add.go
@@ -40,6 +40,7 @@ const ControllerName = "dnsprovider"
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager, controlPlaneCluster cluster.Cluster, cfg *config.DNSManagerConfiguration) error {
 	r.Class = cfg.Class
+	r.SecondaryClasses = cfg.SecondaryClasses
 	r.GlobalConfig = cfg
 	r.Config = cfg.Controllers.DNSProvider
 	r.Client = controlPlaneCluster.GetClient()
@@ -66,7 +67,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, controlPlaneCluster clust
 			predicate.NewPredicateFuncs(func(obj client.Object) bool {
 				return obj.GetNamespace() == r.Config.Namespace
 			}),
-			dnsman2controller.DNSClassPredicate(r.Class),
+			dnsman2controller.DNSClassesPredicate(r.Class, r.SecondaryClasses),
 		)).
 		WatchesRawSource(source.Kind[client.Object](controlPlaneCluster.GetCache(),
 			&corev1.Secret{},
@@ -125,7 +126,7 @@ func (r *Reconciler) allProvidersToReconcile(ctx context.Context) []reconcile.Re
 	if err := r.Client.List(ctx, providerList, client.InNamespace(r.Config.Namespace)); err != nil {
 		return nil
 	}
-	for _, provider := range dns.FilterProvidersByClass(providerList.Items, r.Class) {
+	for _, provider := range dns.FilterProvidersByClass(providerList.Items, r.Class, r.SecondaryClasses) {
 		requests = append(requests, reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Name:      provider.Name,
@@ -147,7 +148,7 @@ func (r *Reconciler) providersToReconcileOnSecretChanges(ctx context.Context, se
 	if err := r.Client.List(ctx, providerList, client.InNamespace(r.Config.Namespace)); err != nil {
 		return nil
 	}
-	for _, provider := range dns.FilterProvidersByClass(providerList.Items, r.Class) {
+	for _, provider := range dns.FilterProvidersByClass(providerList.Items, r.Class, r.SecondaryClasses) {
 		if key := getSpecSecretRefKey(&provider); key != nil && secretKey == *key {
 			requests = append(requests, reconcile.Request{
 				NamespacedName: types.NamespacedName{

--- a/pkg/dnsman2/controller/controlplane/dnsprovider/reconciler.go
+++ b/pkg/dnsman2/controller/controlplane/dnsprovider/reconciler.go
@@ -14,6 +14,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/controllerutils"
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,6 +41,7 @@ type Reconciler struct {
 	Config            config.DNSProviderControllerConfig
 	GlobalConfig      *config.DNSManagerConfiguration
 	Class             string
+	SecondaryClasses  []string
 	DNSHandlerFactory dnsprovider.DNSHandlerFactory
 
 	state *state.State
@@ -81,8 +83,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	return result, err
 }
 
-func (r *Reconciler) addFinalizer(ctx context.Context, c client.Client, provider *v1alpha1.DNSProvider) error {
-	if err := controllerutils.AddFinalizers(ctx, c, provider, dns.FinalizerCompound); err != nil {
+func (r *Reconciler) addFinalizer(ctx context.Context, provider *v1alpha1.DNSProvider) error {
+	if err := controllerutils.AddFinalizers(ctx, r.Client, provider, r.finalizerName()); err != nil {
 		return err
 	}
 	if ptr.Deref(r.Config.MigrationMode, false) {
@@ -97,11 +99,11 @@ func (r *Reconciler) addFinalizer(ctx context.Context, c client.Client, provider
 	if secret == nil {
 		return nil
 	}
-	return controllerutils.AddFinalizers(ctx, c, secret, dns.FinalizerCompound)
+	return controllerutils.AddFinalizers(ctx, r.Client, secret, r.finalizerName())
 }
 
-func (r *Reconciler) removeFinalizer(ctx context.Context, c client.Client, provider *v1alpha1.DNSProvider) error {
-	if err := controllerutils.RemoveFinalizers(ctx, c, provider, dns.FinalizerCompound); err != nil {
+func (r *Reconciler) removeFinalizer(ctx context.Context, provider *v1alpha1.DNSProvider) error {
+	if err := controllerutils.RemoveFinalizers(ctx, r.Client, provider, r.finalizerName()); err != nil {
 		return err
 	}
 	secret, err := getSpecSecret(ctx, r.Client, provider)
@@ -111,7 +113,65 @@ func (r *Reconciler) removeFinalizer(ctx context.Context, c client.Client, provi
 	if secret == nil {
 		return nil
 	}
-	return controllerutils.RemoveFinalizers(ctx, c, secret, dns.FinalizerCompound)
+	return controllerutils.RemoveFinalizers(ctx, r.Client, secret, r.finalizerName())
+}
+
+func (r *Reconciler) finalizerName() string {
+	return dns.ClassFinalizerName(r.Class)
+}
+
+func (r *Reconciler) migrateDNSClass(ctx context.Context, log logr.Logger, provider *v1alpha1.DNSProvider) error {
+	providerNeedsMigration := r.needsToMigrateDNSClassOrFinalizers(provider)
+
+	// If there are no secondary classes configured, the secret can't possibly
+	// carry a stale secondary-class finalizer, so skip the secret fetch entirely.
+	if !providerNeedsMigration && len(r.SecondaryClasses) == 0 {
+		return nil
+	}
+
+	secret, err := getSpecSecret(ctx, r.Client, provider)
+	if err != nil {
+		return err
+	}
+	secretNeedsMigration := secret != nil && dns.HasSecondaryClassFinalizerNames(secret, r.SecondaryClasses)
+
+	if !providerNeedsMigration && !secretNeedsMigration {
+		return nil
+	}
+
+	patch := client.MergeFrom(provider.DeepCopy())
+
+	if dns.IsDefaultClass(r.Class) {
+		utils.RemoveAnnotation(provider, dns.AnnotationClass)
+	} else {
+		utils.SetAnnotation(provider, dns.AnnotationClass, r.Class)
+	}
+	dns.MigrateSecondaryClassFinalizers(provider, r.Class, r.SecondaryClasses)
+
+	if err := r.Client.Patch(ctx, provider, patch); err != nil {
+		return fmt.Errorf("failed to patch provider for DNS class migration: %w", err)
+	}
+	log.Info("patched provider for DNS class migration", "newClass", r.Class)
+
+	if secretNeedsMigration {
+		patch := client.MergeFrom(secret.DeepCopy())
+
+		dns.MigrateSecondaryClassFinalizers(secret, r.Class, r.SecondaryClasses)
+
+		if err := r.Client.Patch(ctx, secret, patch); err != nil {
+			return fmt.Errorf("failed to patch secret for DNS class migration: %w", err)
+		}
+		log.Info("patched secret for DNS class migration", "newClass", r.Class)
+	}
+
+	return nil
+}
+
+func (r *Reconciler) needsToMigrateDNSClassOrFinalizers(provider *v1alpha1.DNSProvider) bool {
+	if !dns.EquivalentClass(provider.Annotations[dns.AnnotationClass], r.Class) {
+		return true
+	}
+	return dns.HasSecondaryClassFinalizerNames(provider, r.SecondaryClasses)
 }
 
 func (r *Reconciler) updateStatusError(ctx context.Context, provider *v1alpha1.DNSProvider, err error) error {

--- a/pkg/dnsman2/controller/controlplane/dnsprovider/reconciler_delete.go
+++ b/pkg/dnsman2/controller/controlplane/dnsprovider/reconciler_delete.go
@@ -21,6 +21,10 @@ import (
 func (r *Reconciler) delete(ctx context.Context, log logr.Logger, provider *v1alpha1.DNSProvider) (reconcile.Result, error) {
 	log.Info("delete")
 
+	if err := r.migrateDNSClass(ctx, log, provider); err != nil {
+		return reconcile.Result{}, err
+	}
+
 	entries := v1alpha1.DNSEntryList{}
 	if err := r.Client.List(ctx, &entries, client.InNamespace(provider.Namespace), client.MatchingFields{EntryStatusProvider: client.ObjectKeyFromObject(provider).String()}); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error listing DNSEntries for provider %s: %w", provider.Name, err)
@@ -53,7 +57,7 @@ func (r *Reconciler) delete(ctx context.Context, log logr.Logger, provider *v1al
 		})
 	}
 
-	if err := r.removeFinalizer(ctx, r.Client, provider); err != nil {
+	if err := r.removeFinalizer(ctx, provider); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error removing finalizer from provider %s: %w", provider.Name, err)
 	}
 

--- a/pkg/dnsman2/controller/controlplane/dnsprovider/reconciler_reconcile.go
+++ b/pkg/dnsman2/controller/controlplane/dnsprovider/reconciler_reconcile.go
@@ -30,6 +30,10 @@ import (
 func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, provider *v1alpha1.DNSProvider) (reconcile.Result, error) {
 	log.Info("reconcile")
 
+	if err := r.migrateDNSClass(ctx, log, provider); err != nil {
+		return reconcile.Result{}, err
+	}
+
 	if !r.isEnabledProviderType(provider.Spec.Type) {
 		return reconcile.Result{}, r.updateStatusInvalid(ctx, provider, fmt.Errorf("provider type %q is not enabled", provider.Spec.Type))
 	}
@@ -38,7 +42,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, provider *v
 		return reconcile.Result{}, r.updateStatusInvalid(ctx, provider, fmt.Errorf("provider type %q is not supported", provider.Spec.Type))
 	}
 
-	if err := r.addFinalizer(ctx, r.Client, provider); err != nil {
+	if err := r.addFinalizer(ctx, provider); err != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/dnsman2/controller/controlplane/dnsprovider/reconciler_test.go
+++ b/pkg/dnsman2/controller/controlplane/dnsprovider/reconciler_test.go
@@ -308,4 +308,154 @@ var _ = Describe("Reconcile", func() {
 		checkFailed(v1alpha1.StateError, "forced error by mockConfig.FailGetZones")
 		checkLastOperationFailed("forced error by mockConfig.FailGetZones", false)
 	})
+
+	Context("DNS class migration", func() {
+		type migrationTestCase struct {
+			description              string
+			initialAnnotations       map[string]string
+			initialFinalizers        []string
+			secretInitialFinalizers  []string
+			reconcilerClass          string
+			reconcilerSecondaryClass []string
+			expectedAnnotation       *string
+			expectedFinalizers       []string
+			unexpectedFinalizers     []string
+			secretExpectedFinalizers []string
+		}
+
+		DescribeTable("DNS class migration scenarios",
+			func(tc migrationTestCase) {
+				// Setup provider
+				if tc.initialAnnotations != nil {
+					provider.Annotations = tc.initialAnnotations
+				}
+				provider.Finalizers = tc.initialFinalizers
+				Expect(fakeClient.Create(ctx, provider)).To(Succeed())
+
+				// Setup secret finalizers if needed
+				if len(tc.secretInitialFinalizers) > 0 {
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secret1), secret1)).To(Succeed())
+					secret1.Finalizers = tc.secretInitialFinalizers
+					Expect(fakeClient.Update(ctx, secret1)).To(Succeed())
+				}
+
+				// Setup reconciler
+				reconciler.Class = tc.reconcilerClass
+				reconciler.SecondaryClasses = tc.reconcilerSecondaryClass
+
+				// Reconcile
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: providerKey})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+
+				// Verify provider results
+				Expect(fakeClient.Get(ctx, providerKey, provider)).To(Succeed())
+				if tc.expectedAnnotation != nil {
+					Expect(provider.Annotations).To(HaveKeyWithValue("dns.gardener.cloud/class", *tc.expectedAnnotation))
+				} else {
+					Expect(provider.Annotations).NotTo(HaveKey("dns.gardener.cloud/class"))
+				}
+				for _, expectedFinalizer := range tc.expectedFinalizers {
+					Expect(provider.Finalizers).To(ContainElement(expectedFinalizer))
+				}
+				for _, unexpectedFinalizer := range tc.unexpectedFinalizers {
+					Expect(provider.Finalizers).NotTo(ContainElement(unexpectedFinalizer))
+				}
+
+				// Verify secret results if expected
+				if len(tc.secretExpectedFinalizers) > 0 {
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secret1), secret1)).To(Succeed())
+					Expect(secret1.Finalizers).To(ConsistOf(tc.secretExpectedFinalizers))
+				}
+			},
+			Entry("migrate secondary class finalizer to primary class (default)", migrationTestCase{
+				description:              "migrate secondary class finalizer to default class",
+				initialFinalizers:        []string{"class-b.dns.gardener.cloud/compound"},
+				reconcilerClass:          "",
+				reconcilerSecondaryClass: []string{"class-b"},
+				expectedFinalizers:       []string{"dns.gardener.cloud/compound"},
+				unexpectedFinalizers:     []string{"class-b.dns.gardener.cloud/compound"},
+				secretExpectedFinalizers: []string{"dns.gardener.cloud/compound"},
+			}),
+			Entry("migrate multiple secondary class finalizers to primary class (default)", migrationTestCase{
+				description:              "migrate multiple secondary class finalizers to default class",
+				initialFinalizers:        []string{"class-b.dns.gardener.cloud/compound", "class-c.dns.gardener.cloud/compound"},
+				reconcilerClass:          "",
+				reconcilerSecondaryClass: []string{"class-b", "class-c"},
+				expectedFinalizers:       []string{"dns.gardener.cloud/compound"},
+				unexpectedFinalizers:     []string{"class-b.dns.gardener.cloud/compound", "class-c.dns.gardener.cloud/compound"},
+				secretExpectedFinalizers: []string{"dns.gardener.cloud/compound"},
+			}),
+			Entry("migrate provider from secondary class to default class", migrationTestCase{
+				description:              "migrate provider class annotation from secondary to default",
+				initialAnnotations:       map[string]string{"dns.gardener.cloud/class": "class-b"},
+				initialFinalizers:        []string{"class-b.dns.gardener.cloud/compound"},
+				reconcilerClass:          "",
+				reconcilerSecondaryClass: []string{"class-b"},
+				expectedFinalizers:       []string{"dns.gardener.cloud/compound"},
+				unexpectedFinalizers:     []string{"class-b.dns.gardener.cloud/compound"},
+				secretExpectedFinalizers: []string{"dns.gardener.cloud/compound"},
+			}),
+			Entry("migrate provider from secondary class to non-default primary class", migrationTestCase{
+				description:              "migrate provider class annotation from secondary to non-default primary",
+				initialAnnotations:       map[string]string{"dns.gardener.cloud/class": "class-b"},
+				initialFinalizers:        []string{"class-b.dns.gardener.cloud/compound"},
+				reconcilerClass:          "class-a",
+				reconcilerSecondaryClass: []string{"class-b"},
+				expectedAnnotation:       ptr.To("class-a"),
+				expectedFinalizers:       []string{"class-a.dns.gardener.cloud/compound"},
+				unexpectedFinalizers:     []string{"class-b.dns.gardener.cloud/compound"},
+				secretExpectedFinalizers: []string{"class-a.dns.gardener.cloud/compound"},
+			}),
+			Entry("no migration if class and finalizers already match (default class)", migrationTestCase{
+				description:              "no migration when everything matches default class",
+				initialFinalizers:        []string{"dns.gardener.cloud/compound"},
+				reconcilerClass:          "",
+				reconcilerSecondaryClass: []string{"class-b"},
+				expectedFinalizers:       []string{"dns.gardener.cloud/compound"},
+				unexpectedFinalizers:     []string{"class-b.dns.gardener.cloud/compound"},
+				secretExpectedFinalizers: []string{"dns.gardener.cloud/compound"},
+			}),
+			Entry("migrate when only class annotation mismatches (no secondary finalizers)", migrationTestCase{
+				description:              "migrate when class annotation is wrong but finalizers correct",
+				initialAnnotations:       map[string]string{"dns.gardener.cloud/class": "wrong-class"},
+				initialFinalizers:        []string{"dns.gardener.cloud/compound"},
+				reconcilerClass:          "",
+				reconcilerSecondaryClass: nil,
+				expectedFinalizers:       []string{"dns.gardener.cloud/compound"},
+				secretExpectedFinalizers: []string{"dns.gardener.cloud/compound"},
+			}),
+			Entry("handle migration with both class mismatch and secondary class finalizers", migrationTestCase{
+				description:              "migrate both class annotation and multiple secondary finalizers",
+				initialAnnotations:       map[string]string{"dns.gardener.cloud/class": "class-b"},
+				initialFinalizers:        []string{"class-c.dns.gardener.cloud/compound", "class-d.dns.gardener.cloud/compound"},
+				reconcilerClass:          "",
+				reconcilerSecondaryClass: []string{"class-b", "class-c", "class-d"},
+				expectedFinalizers:       []string{"dns.gardener.cloud/compound"},
+				unexpectedFinalizers:     []string{"class-b.dns.gardener.cloud/compound", "class-c.dns.gardener.cloud/compound", "class-d.dns.gardener.cloud/compound"},
+				secretExpectedFinalizers: []string{"dns.gardener.cloud/compound"},
+			}),
+			Entry("migrate secret with secondary class finalizers", migrationTestCase{
+				description:              "migrate secret finalizers from secondary classes",
+				initialFinalizers:        []string{"dns.gardener.cloud/compound"},
+				secretInitialFinalizers:  []string{"class-b.dns.gardener.cloud/compound", "class-c.dns.gardener.cloud/compound"},
+				reconcilerClass:          "",
+				reconcilerSecondaryClass: []string{"class-b", "class-c"},
+				expectedFinalizers:       []string{"dns.gardener.cloud/compound"},
+				secretExpectedFinalizers: []string{"dns.gardener.cloud/compound"},
+			}),
+			Entry("migrate both provider and secret from secondary class to non-default primary", migrationTestCase{
+				description:              "migrate both provider and secret to non-default primary class",
+				initialAnnotations:       map[string]string{"dns.gardener.cloud/class": "class-b"},
+				initialFinalizers:        []string{"class-b.dns.gardener.cloud/compound"},
+				secretInitialFinalizers:  []string{"class-b.dns.gardener.cloud/compound"},
+				reconcilerClass:          "class-a",
+				reconcilerSecondaryClass: []string{"class-b"},
+				expectedAnnotation:       ptr.To("class-a"),
+				expectedFinalizers:       []string{"class-a.dns.gardener.cloud/compound"},
+				unexpectedFinalizers:     []string{"class-b.dns.gardener.cloud/compound"},
+				secretExpectedFinalizers: []string{"class-a.dns.gardener.cloud/compound"},
+			}),
+		)
+	})
 })

--- a/pkg/dnsman2/controller/predicate.go
+++ b/pkg/dnsman2/controller/predicate.go
@@ -26,8 +26,8 @@ func DNSClassesPredicate(primaryClass string, secondaryClasses []string) predica
 		if dns.EquivalentClass(class, primaryClass) {
 			return true
 		}
-		for _, secondClass := range secondaryClasses {
-			if dns.EquivalentClass(class, secondClass) {
+		for _, secondaryClass := range secondaryClasses {
+			if dns.EquivalentClass(class, secondaryClass) {
 				return true
 			}
 		}

--- a/pkg/dnsman2/controller/predicate.go
+++ b/pkg/dnsman2/controller/predicate.go
@@ -15,10 +15,23 @@ import (
 )
 
 // DNSClassPredicate returns a predicate that filters objects by their class.
-func DNSClassPredicate(expectedClass string) predicate.Predicate {
+func DNSClassPredicate(class string) predicate.Predicate {
+	return DNSClassesPredicate(class, nil)
+}
+
+// DNSClassesPredicate returns a predicate that filters objects by their classes.
+func DNSClassesPredicate(primaryClass string, secondaryClasses []string) predicate.Predicate {
 	return FilterPredicate(func(obj client.Object) bool {
 		class := obj.GetAnnotations()[dns.AnnotationClass]
-		return dns.EquivalentClass(class, expectedClass)
+		if dns.EquivalentClass(class, primaryClass) {
+			return true
+		}
+		for _, secondClass := range secondaryClasses {
+			if dns.EquivalentClass(class, secondClass) {
+				return true
+			}
+		}
+		return false
 	})
 }
 

--- a/pkg/dnsman2/controller/predicate_test.go
+++ b/pkg/dnsman2/controller/predicate_test.go
@@ -1,0 +1,198 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/controller"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns"
+)
+
+var _ = Describe("Predicate", func() {
+	Describe("#DNSClassesPredicate", func() {
+		var (
+			primaryClass      = "myclass"
+			secondaryClasses  = []string{"secondary1", "secondary2"}
+			predicate         = controller.DNSClassesPredicate(primaryClass, secondaryClasses)
+			dnsEntryWithClass = func(class string) *dnsv1alpha1.DNSEntry {
+				return &dnsv1alpha1.DNSEntry{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							dns.AnnotationClass: class,
+						},
+					},
+				}
+			}
+		)
+
+		Context("Create events", func() {
+			It("should return true for object with expected class", func() {
+				obj := dnsEntryWithClass(primaryClass)
+				Expect(predicate.Create(event.CreateEvent{Object: obj})).To(BeTrue())
+			})
+
+			It("should return true for object with secondary class", func() {
+				obj := dnsEntryWithClass("secondary1")
+				Expect(predicate.Create(event.CreateEvent{Object: obj})).To(BeTrue())
+			})
+
+			It("should return true for object with another secondary class", func() {
+				obj := dnsEntryWithClass("secondary2")
+				Expect(predicate.Create(event.CreateEvent{Object: obj})).To(BeTrue())
+			})
+
+			It("should return false for object with different class", func() {
+				obj := dnsEntryWithClass("otherclass")
+				Expect(predicate.Create(event.CreateEvent{Object: obj})).To(BeFalse())
+			})
+
+			It("should return true for object with empty class and expected class is default", func() {
+				p := controller.DNSClassesPredicate(dns.DefaultClass, nil)
+				obj := dnsEntryWithClass("")
+				Expect(p.Create(event.CreateEvent{Object: obj})).To(BeTrue())
+			})
+
+			It("should return false for object without annotation", func() {
+				obj := &dnsv1alpha1.DNSEntry{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+				}
+				Expect(predicate.Create(event.CreateEvent{Object: obj})).To(BeFalse())
+			})
+
+			It("should return false for object with nil annotations", func() {
+				obj := &dnsv1alpha1.DNSEntry{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: nil,
+					},
+				}
+				Expect(predicate.Create(event.CreateEvent{Object: obj})).To(BeFalse())
+			})
+		})
+
+		Context("Update events", func() {
+			It("should return true if old object matches expected class", func() {
+				oldObj := dnsEntryWithClass(primaryClass)
+				newObj := dnsEntryWithClass("otherclass")
+				Expect(predicate.Update(event.UpdateEvent{ObjectOld: oldObj, ObjectNew: newObj})).To(BeTrue())
+			})
+
+			It("should return true if new object matches expected class", func() {
+				oldObj := dnsEntryWithClass("otherclass")
+				newObj := dnsEntryWithClass(primaryClass)
+				Expect(predicate.Update(event.UpdateEvent{ObjectOld: oldObj, ObjectNew: newObj})).To(BeTrue())
+			})
+
+			It("should return true if old object matches secondary class", func() {
+				oldObj := dnsEntryWithClass("secondary1")
+				newObj := dnsEntryWithClass("otherclass")
+				Expect(predicate.Update(event.UpdateEvent{ObjectOld: oldObj, ObjectNew: newObj})).To(BeTrue())
+			})
+
+			It("should return true if new object matches secondary class", func() {
+				oldObj := dnsEntryWithClass("otherclass")
+				newObj := dnsEntryWithClass("secondary2")
+				Expect(predicate.Update(event.UpdateEvent{ObjectOld: oldObj, ObjectNew: newObj})).To(BeTrue())
+			})
+
+			It("should return false if neither old nor new object match any class", func() {
+				oldObj := dnsEntryWithClass("otherclass1")
+				newObj := dnsEntryWithClass("otherclass2")
+				Expect(predicate.Update(event.UpdateEvent{ObjectOld: oldObj, ObjectNew: newObj})).To(BeFalse())
+			})
+
+			It("should return true if both objects match expected class", func() {
+				oldObj := dnsEntryWithClass(primaryClass)
+				newObj := dnsEntryWithClass(primaryClass)
+				Expect(predicate.Update(event.UpdateEvent{ObjectOld: oldObj, ObjectNew: newObj})).To(BeTrue())
+			})
+		})
+
+		Context("Delete events", func() {
+			It("should return true for object with expected class", func() {
+				obj := dnsEntryWithClass(primaryClass)
+				Expect(predicate.Delete(event.DeleteEvent{Object: obj})).To(BeTrue())
+			})
+
+			It("should return true for object with secondary class", func() {
+				obj := dnsEntryWithClass("secondary1")
+				Expect(predicate.Delete(event.DeleteEvent{Object: obj})).To(BeTrue())
+			})
+
+			It("should return false for object with different class", func() {
+				obj := dnsEntryWithClass("otherclass")
+				Expect(predicate.Delete(event.DeleteEvent{Object: obj})).To(BeFalse())
+			})
+		})
+
+		Context("Generic events", func() {
+			It("should return true for object with expected class", func() {
+				obj := dnsEntryWithClass(primaryClass)
+				Expect(predicate.Generic(event.GenericEvent{Object: obj})).To(BeTrue())
+			})
+
+			It("should return true for object with secondary class", func() {
+				obj := dnsEntryWithClass("secondary2")
+				Expect(predicate.Generic(event.GenericEvent{Object: obj})).To(BeTrue())
+			})
+
+			It("should return false for object with different class", func() {
+				obj := dnsEntryWithClass("otherclass")
+				Expect(predicate.Generic(event.GenericEvent{Object: obj})).To(BeFalse())
+			})
+		})
+
+		Context("Without secondary classes", func() {
+			It("should work with nil secondary classes", func() {
+				p := controller.DNSClassesPredicate(primaryClass, nil)
+				obj := dnsEntryWithClass(primaryClass)
+				Expect(p.Create(event.CreateEvent{Object: obj})).To(BeTrue())
+			})
+
+			It("should work with empty secondary classes", func() {
+				p := controller.DNSClassesPredicate(primaryClass, []string{})
+				obj := dnsEntryWithClass(primaryClass)
+				Expect(p.Create(event.CreateEvent{Object: obj})).To(BeTrue())
+			})
+
+			It("should reject object with class not in empty secondary list", func() {
+				p := controller.DNSClassesPredicate(primaryClass, []string{})
+				obj := dnsEntryWithClass("secondary1")
+				Expect(p.Create(event.CreateEvent{Object: obj})).To(BeFalse())
+			})
+		})
+	})
+
+	Describe("#DNSClassPredicate", func() {
+		It("should work as wrapper for DNSClassesPredicate with nil secondary classes", func() {
+			expectedClass := "testclass"
+			p := controller.DNSClassPredicate(expectedClass)
+
+			obj := &dnsv1alpha1.DNSEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						dns.AnnotationClass: expectedClass,
+					},
+				},
+			}
+			Expect(p.Create(event.CreateEvent{Object: obj})).To(BeTrue())
+
+			objOther := &dnsv1alpha1.DNSEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						dns.AnnotationClass: "otherclass",
+					},
+				},
+			}
+			Expect(p.Create(event.CreateEvent{Object: objOther})).To(BeFalse())
+		})
+	})
+})

--- a/pkg/dnsman2/controller/source/dnsprovider/add.go
+++ b/pkg/dnsman2/controller/source/dnsprovider/add.go
@@ -93,7 +93,7 @@ func (r *Reconciler) providersToReconcileOnSecretChanges(ctx context.Context, cl
 	if err := r.Client.List(ctx, providerList); err != nil {
 		return nil
 	}
-	for _, provider := range dns.FilterProvidersByClass(providerList.Items, class) {
+	for _, provider := range dns.FilterProvidersByClass(providerList.Items, class, nil) {
 		if provider.Spec.SecretRef.Name == secret.GetName() && getSecretRefNamespace(&provider) == secret.GetNamespace() {
 			requests = append(requests, reconcile.Request{
 				NamespacedName: types.NamespacedName{

--- a/pkg/dnsman2/dns/class.go
+++ b/pkg/dnsman2/dns/class.go
@@ -4,7 +4,13 @@
 
 package dns
 
-import "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+import (
+	"slices"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+)
 
 // FilterProvidersByClass filters a list of DNS providers by the specified class and secondary classes.
 func FilterProvidersByClass(providers []v1alpha1.DNSProvider, class string, secondaryClasses []string) []v1alpha1.DNSProvider {
@@ -58,4 +64,34 @@ func IsDefaultClass(class string) bool {
 // EquivalentClass returns true if the annotation class are equivalent, i.e. equal after normalizing.
 func EquivalentClass(cls1, cls2 string) bool {
 	return NormalizeClass(cls1) == NormalizeClass(cls2)
+}
+
+// ClassFinalizerName returns the finalizer name for the provided class, which is either the default finalizer or the class name followed by the default finalizer.
+func ClassFinalizerName(class string) string {
+	if IsDefaultClass(class) {
+		return FinalizerCompound
+	}
+	return class + "." + FinalizerCompound
+}
+
+// HasSecondaryClassFinalizerNames returns true if the provided object has any of the finalizer names for the provided secondary classes.
+func HasSecondaryClassFinalizerNames(obj client.Object, secondaryClasses []string) bool {
+	for _, secondaryClass := range secondaryClasses {
+		if slices.Contains(obj.GetFinalizers(), ClassFinalizerName(secondaryClass)) {
+			return true
+		}
+	}
+	return false
+}
+
+// MigrateSecondaryClassFinalizers removes the finalizer names for the provided secondary classes from the provided object and adds the finalizer name for the provided class if it is not already present.
+func MigrateSecondaryClassFinalizers(obj client.Object, class string, secondaryClasses []string) {
+	for _, secondaryClass := range secondaryClasses {
+		if idx := slices.Index(obj.GetFinalizers(), ClassFinalizerName(secondaryClass)); idx >= 0 {
+			obj.SetFinalizers(slices.Delete(obj.GetFinalizers(), idx, idx+1))
+		}
+	}
+	if !slices.Contains(obj.GetFinalizers(), ClassFinalizerName(class)) {
+		obj.SetFinalizers(append(obj.GetFinalizers(), ClassFinalizerName(class)))
+	}
 }

--- a/pkg/dnsman2/dns/class.go
+++ b/pkg/dnsman2/dns/class.go
@@ -20,8 +20,8 @@ func FilterProvidersByClass(providers []v1alpha1.DNSProvider, class string, seco
 		if EquivalentClass(provider.Annotations[AnnotationClass], class) {
 			filtered = append(filtered, provider)
 		} else {
-			for _, secondClass := range secondaryClasses {
-				if EquivalentClass(provider.Annotations[AnnotationClass], secondClass) {
+			for _, secondaryClass := range secondaryClasses {
+				if EquivalentClass(provider.Annotations[AnnotationClass], secondaryClass) {
 					filtered = append(filtered, provider)
 					break
 				}
@@ -38,8 +38,8 @@ func FilterEntriesByClass(entries []v1alpha1.DNSEntry, class string, secondaryCl
 		if EquivalentClass(entry.Annotations[AnnotationClass], class) {
 			filtered = append(filtered, entry)
 		} else {
-			for _, secondClass := range secondaryClasses {
-				if EquivalentClass(entry.Annotations[AnnotationClass], secondClass) {
+			for _, secondaryClass := range secondaryClasses {
+				if EquivalentClass(entry.Annotations[AnnotationClass], secondaryClass) {
 					filtered = append(filtered, entry)
 					break
 				}
@@ -88,8 +88,8 @@ func HasSecondaryClassFinalizerNames(obj client.Object, secondaryClasses []strin
 // MigrateSecondaryClassFinalizers removes the finalizer names for the provided secondary classes from the provided object and adds the finalizer name for the provided class if it is not already present.
 func MigrateSecondaryClassFinalizers(obj client.Object, class string, secondaryClasses []string) {
 	finalizers := slices.Clone(obj.GetFinalizers())
-	for _, sec := range secondaryClasses {
-		finalizers = slices.DeleteFunc(finalizers, func(f string) bool { return f == ClassFinalizerName(sec) })
+	for _, secondaryClass := range secondaryClasses {
+		finalizers = slices.DeleteFunc(finalizers, func(f string) bool { return f == ClassFinalizerName(secondaryClass) })
 	}
 	if !slices.Contains(finalizers, ClassFinalizerName(class)) {
 		finalizers = append(finalizers, ClassFinalizerName(class))

--- a/pkg/dnsman2/dns/class.go
+++ b/pkg/dnsman2/dns/class.go
@@ -5,6 +5,7 @@
 package dns
 
 import (
+	"regexp"
 	"slices"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -86,12 +87,20 @@ func HasSecondaryClassFinalizerNames(obj client.Object, secondaryClasses []strin
 
 // MigrateSecondaryClassFinalizers removes the finalizer names for the provided secondary classes from the provided object and adds the finalizer name for the provided class if it is not already present.
 func MigrateSecondaryClassFinalizers(obj client.Object, class string, secondaryClasses []string) {
-	for _, secondaryClass := range secondaryClasses {
-		if idx := slices.Index(obj.GetFinalizers(), ClassFinalizerName(secondaryClass)); idx >= 0 {
-			obj.SetFinalizers(slices.Delete(obj.GetFinalizers(), idx, idx+1))
-		}
+	finalizers := slices.Clone(obj.GetFinalizers())
+	for _, sec := range secondaryClasses {
+		finalizers = slices.DeleteFunc(finalizers, func(f string) bool { return f == ClassFinalizerName(sec) })
 	}
-	if !slices.Contains(obj.GetFinalizers(), ClassFinalizerName(class)) {
-		obj.SetFinalizers(append(obj.GetFinalizers(), ClassFinalizerName(class)))
+	if !slices.Contains(finalizers, ClassFinalizerName(class)) {
+		finalizers = append(finalizers, ClassFinalizerName(class))
 	}
+	obj.SetFinalizers(finalizers)
+}
+
+var validClassRegex = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
+
+// IsValidClass checks if the class is a valid DNS sublabel, as it may be used for finalizer names.
+func IsValidClass(class string) bool {
+	class = NormalizeClass(class)
+	return validClassRegex.MatchString(class)
 }

--- a/pkg/dnsman2/dns/class.go
+++ b/pkg/dnsman2/dns/class.go
@@ -6,24 +6,37 @@ package dns
 
 import "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 
-// FilterProvidersByClass filters a list of DNS providers by the specified class.
-func FilterProvidersByClass(providers []v1alpha1.DNSProvider, class string) []v1alpha1.DNSProvider {
-	class = NormalizeClass(class)
+// FilterProvidersByClass filters a list of DNS providers by the specified class and secondary classes.
+func FilterProvidersByClass(providers []v1alpha1.DNSProvider, class string, secondaryClasses []string) []v1alpha1.DNSProvider {
 	var filtered []v1alpha1.DNSProvider
 	for _, provider := range providers {
-		if NormalizeClass(provider.Annotations[AnnotationClass]) == class {
+		if EquivalentClass(provider.Annotations[AnnotationClass], class) {
 			filtered = append(filtered, provider)
+		} else {
+			for _, secondClass := range secondaryClasses {
+				if EquivalentClass(provider.Annotations[AnnotationClass], secondClass) {
+					filtered = append(filtered, provider)
+					break
+				}
+			}
 		}
 	}
 	return filtered
 }
 
-// FilterEntriesByClass filters a list of DNS entries by the specified class.
-func FilterEntriesByClass(entries []v1alpha1.DNSEntry, class string) []v1alpha1.DNSEntry {
+// FilterEntriesByClass filters a list of DNS entries by the specified class and secondary classes.
+func FilterEntriesByClass(entries []v1alpha1.DNSEntry, class string, secondaryClasses []string) []v1alpha1.DNSEntry {
 	var filtered []v1alpha1.DNSEntry
 	for _, entry := range entries {
-		if NormalizeClass(entry.Annotations[AnnotationClass]) == class {
+		if EquivalentClass(entry.Annotations[AnnotationClass], class) {
 			filtered = append(filtered, entry)
+		} else {
+			for _, secondClass := range secondaryClasses {
+				if EquivalentClass(entry.Annotations[AnnotationClass], secondClass) {
+					filtered = append(filtered, entry)
+					break
+				}
+			}
 		}
 	}
 	return filtered

--- a/pkg/dnsman2/dns/class_test.go
+++ b/pkg/dnsman2/dns/class_test.go
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dns_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	. "github.com/gardener/external-dns-management/pkg/dnsman2/dns"
+)
+
+var _ = Describe("Class", func() {
+	Describe("#IsDefaultClass", func() {
+		DescribeTable("should return true for default class variants",
+			func(class string, expected bool) {
+				Expect(IsDefaultClass(class)).To(Equal(expected))
+			},
+			Entry("empty string", "", true),
+			Entry("default class name", DefaultClass, true),
+			Entry("non-default class", "customclass", false),
+			Entry("similar but different", "gardendns2", false),
+		)
+	})
+
+	Describe("#EquivalentClass", func() {
+		DescribeTable("should compare classes after normalization",
+			func(cls1, cls2 string, expected bool) {
+				Expect(EquivalentClass(cls1, cls2)).To(Equal(expected))
+			},
+			Entry("both empty", "", "", true),
+			Entry("both default", DefaultClass, DefaultClass, true),
+			Entry("empty and default class", "", DefaultClass, true),
+			Entry("default class and empty", DefaultClass, "", true),
+			Entry("same custom class", "myclass", "myclass", true),
+			Entry("different classes", "myclass", "otherclass", false),
+			Entry("default and custom", DefaultClass, "custom", false),
+		)
+	})
+
+	Describe("#ClassFinalizerName", func() {
+		DescribeTable("should return correct finalizer name",
+			func(class, expected string) {
+				Expect(ClassFinalizerName(class)).To(Equal(expected))
+			},
+			Entry("empty class returns default finalizer", "", FinalizerCompound),
+			Entry("default class returns default finalizer", DefaultClass, FinalizerCompound),
+			Entry("custom class prefixes finalizer", "myclass", "myclass."+FinalizerCompound),
+			Entry("another custom class", "secondary", "secondary."+FinalizerCompound),
+		)
+	})
+
+	Describe("#MigrateSecondaryClassFinalizers", func() {
+		newEntry := func(finalizers ...string) *dnsv1alpha1.DNSEntry {
+			return &dnsv1alpha1.DNSEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: finalizers,
+				},
+			}
+		}
+
+		It("should add primary class finalizer and remove secondary finalizers", func() {
+			obj := newEntry(ClassFinalizerName("secondary1"), ClassFinalizerName("secondary2"))
+			MigrateSecondaryClassFinalizers(obj, "primary", []string{"secondary1", "secondary2"})
+			Expect(obj.GetFinalizers()).To(ConsistOf(ClassFinalizerName("primary")))
+		})
+
+		It("should not duplicate primary finalizer if already present", func() {
+			obj := newEntry(ClassFinalizerName("primary"), ClassFinalizerName("secondary1"))
+			MigrateSecondaryClassFinalizers(obj, "primary", []string{"secondary1"})
+			Expect(obj.GetFinalizers()).To(ConsistOf(ClassFinalizerName("primary")))
+		})
+
+		It("should preserve unrelated finalizers", func() {
+			obj := newEntry("some.other/finalizer", ClassFinalizerName("secondary1"))
+			MigrateSecondaryClassFinalizers(obj, "primary", []string{"secondary1"})
+			Expect(obj.GetFinalizers()).To(ConsistOf("some.other/finalizer", ClassFinalizerName("primary")))
+		})
+
+		It("should handle empty secondary classes", func() {
+			obj := newEntry(ClassFinalizerName("primary"))
+			MigrateSecondaryClassFinalizers(obj, "primary", []string{})
+			Expect(obj.GetFinalizers()).To(ConsistOf(ClassFinalizerName("primary")))
+		})
+
+		It("should handle object with no finalizers", func() {
+			obj := newEntry()
+			MigrateSecondaryClassFinalizers(obj, "primary", []string{"secondary1"})
+			Expect(obj.GetFinalizers()).To(ConsistOf(ClassFinalizerName("primary")))
+		})
+
+		It("should work with default class", func() {
+			obj := newEntry(ClassFinalizerName("secondary1"))
+			MigrateSecondaryClassFinalizers(obj, DefaultClass, []string{"secondary1"})
+			Expect(obj.GetFinalizers()).To(ConsistOf(FinalizerCompound))
+		})
+
+		It("should not mutate original finalizer slice", func() {
+			original := []string{ClassFinalizerName("secondary1")}
+			obj := newEntry(original...)
+			MigrateSecondaryClassFinalizers(obj, "primary", []string{"secondary1"})
+			Expect(original).To(Equal([]string{ClassFinalizerName("secondary1")}))
+		})
+	})
+
+	Describe("#IsValidClass", func() {
+		DescribeTable("should validate class names",
+			func(class string, expected bool) {
+				Expect(IsValidClass(class)).To(Equal(expected))
+			},
+			Entry("empty becomes default class (valid)", "", true),
+			Entry("default class", DefaultClass, true),
+			Entry("lowercase alphanumeric", "myclass", true),
+			Entry("with hyphen in middle", "my-class", true),
+			Entry("single character", "a", true),
+			Entry("numbers only", "123", true),
+			Entry("alphanumeric with numbers", "class1", true),
+			Entry("uppercase", "MYCLASS", false),
+			Entry("starts with hyphen", "-myclass", false),
+			Entry("ends with hyphen", "myclass-", false),
+			Entry("contains underscore", "my_class", false),
+			Entry("contains dot", "my.class", false),
+			Entry("contains space", "my class", false),
+			Entry("contains slash", "my/class", false),
+		)
+	})
+})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

  ## Summary            
  - Introduces `secondaryClasses` config field so the DNS controller can manage DNSProviders/DNSEntries from multiple DNS classes simultaneously.
  - Resources annotated with a secondary class are automatically migrated to the primary class on reconcile (annotation update + finalizer rewrite, including provider secret finalizers).                                                                                                                                           
  - Adds startup validation (no duplicates, no overlap with primary, valid sublabel format) and disables the source DNSEntry controller when the source class matches the primary or any secondary class in single-cluster deployments.                                                                                              
                                                                                                                                                                                                                                                                                                                                     
  ## Motivation                                                                                                                                                                                                                                                                                                                      
  Enables rolling migrations between DNS classes without service interruption — operators deploy with the new class as primary and the old one as secondary, resources transition automatically, then the secondary entry is removed from config.                                                                                    
                                                                                                                                                                                                                                                                                                                                     
  ## Changes                        
  - `pkg/dnsman2/dns/class.go`: new helpers `ClassFinalizerName`, `HasSecondaryClassFinalizerNames`, `MigrateSecondaryClassFinalizers`, `IsValidClass`; `FilterProvidersByClass`/`FilterEntriesByClass` extended with secondary classes.                                                                                             
  - `pkg/dnsman2/controller/predicate.go`: new `DNSClassesPredicate` (multi-class).                                                                                                                                                                                                                                                  
  - `dnsentry` and `dnsprovider` controllers: per-class finalizers and a `migrateDNSClass` step at the top of reconcile/delete.                                                                                                                                                                                                      
  - `cmd/nextgen/app`: config validation for primary/secondary/source/target classes.                                                                                                                                                                                                                                                
  - New docs: `docs/usage/secondary-classes.md`.  


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
