### PR TITLE
[alicloud-dns provider] Set `user-agent`

### DIFF
--- a/pkg/controller/provider/alicloud/access.go
+++ b/pkg/controller/provider/alicloud/access.go
@@ -63,7 +63,7 @@ func NewAccess(accessKeyId, accessKeySecret string, metrics provider.Metrics, ra
 	config := &openapi.Config{
 		AccessKeyId:     &accessKeyId,
 		AccessKeySecret: &accessKeySecret,
-		UserAgent:       ptr.To("gardener/external-dns-management"),
+		UserAgent:       ptr.To("gardener-external-dns-management"),
 		RegionId:        ptr.To("cn-shanghai"),
 	}
 	client, err := alidns.NewClient(config)

--- a/pkg/controller/provider/alicloud/access.go
+++ b/pkg/controller/provider/alicloud/access.go
@@ -63,6 +63,7 @@ func NewAccess(accessKeyId, accessKeySecret string, metrics provider.Metrics, ra
 	config := &openapi.Config{
 		AccessKeyId:     &accessKeyId,
 		AccessKeySecret: &accessKeySecret,
+		UserAgent:       ptr.To("gardener/external-dns-management"),
 		RegionId:        ptr.To("cn-shanghai"),
 	}
 	client, err := alidns.NewClient(config)

--- a/pkg/dnsman2/dns/provider/handler/alicloud/access.go
+++ b/pkg/dnsman2/dns/provider/handler/alicloud/access.go
@@ -67,6 +67,7 @@ func newAccess(accessKeyId, accessKeySecret string, metrics provider.Metrics, ra
 	config := &openapi.Config{
 		AccessKeyId:     &accessKeyId,
 		AccessKeySecret: &accessKeySecret,
+		UserAgent:       ptr.To("gardener/external-dns-management/nextgen"),
 		RegionId:        ptr.To("cn-shanghai"), // Currently hardcoded, the limitation is documented.
 	}
 	client, err := alidns.NewClient(config)

--- a/pkg/dnsman2/dns/provider/handler/alicloud/access.go
+++ b/pkg/dnsman2/dns/provider/handler/alicloud/access.go
@@ -67,7 +67,7 @@ func newAccess(accessKeyId, accessKeySecret string, metrics provider.Metrics, ra
 	config := &openapi.Config{
 		AccessKeyId:     &accessKeyId,
 		AccessKeySecret: &accessKeySecret,
-		UserAgent:       ptr.To("gardener/external-dns-management/nextgen"),
+		UserAgent:       ptr.To("gardener-external-dns-management/nextgen"),
 		RegionId:        ptr.To("cn-shanghai"), // Currently hardcoded, the limitation is documented.
 	}
 	client, err := alidns.NewClient(config)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Set the user agent on request to the Alicloud API endpoint to simplify troubleshooting.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```

/cc @marc1404 