### PR TITLE
[dnsman-nextgeneration]: Fix registration of metrics

### DIFF
--- a/pkg/dnsman2/dns/metrics/metrics.go
+++ b/pkg/dnsman2/dns/metrics/metrics.go
@@ -11,25 +11,26 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns"
 )
 
-// RegisterAll registers all metrics handlers and the /metrics endpoint.
+// RegisterAll registers all metrics with the controller-runtime registry, which is served by the metrics server.
 func RegisterAll() {
-	prometheus.MustRegister(Requests)
-	prometheus.MustRegister(ZoneRequests)
-	prometheus.MustRegister(ZoneCacheDiscardings)
-	prometheus.MustRegister(Accounts)
-	prometheus.MustRegister(Entries)
-	prometheus.MustRegister(StaleEntries)
-	prometheus.MustRegister(LookupProcessorJobs)
-	prometheus.MustRegister(LookupProcessorSkips)
-	prometheus.MustRegister(LookupProcessorLookups)
-	prometheus.MustRegister(LookupProcessorHosts)
-	prometheus.MustRegister(LookupProcessorErrors)
-	prometheus.MustRegister(LookupProcessorLookupChanged)
-	prometheus.MustRegister(LookupProcessorSeconds)
+	ctrlmetrics.Registry.MustRegister(Requests)
+	ctrlmetrics.Registry.MustRegister(ZoneRequests)
+	ctrlmetrics.Registry.MustRegister(ZoneCacheDiscardings)
+	ctrlmetrics.Registry.MustRegister(Accounts)
+	ctrlmetrics.Registry.MustRegister(Entries)
+	ctrlmetrics.Registry.MustRegister(StaleEntries)
+	ctrlmetrics.Registry.MustRegister(LookupProcessorJobs)
+	ctrlmetrics.Registry.MustRegister(LookupProcessorSkips)
+	ctrlmetrics.Registry.MustRegister(LookupProcessorLookups)
+	ctrlmetrics.Registry.MustRegister(LookupProcessorHosts)
+	ctrlmetrics.Registry.MustRegister(LookupProcessorErrors)
+	ctrlmetrics.Registry.MustRegister(LookupProcessorLookupChanged)
+	ctrlmetrics.Registry.MustRegister(LookupProcessorSeconds)
 }
 
 var (


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
The `external_dns_management_*` metrics are not visible for the next-generation dns-controller-manager.
The controller-runtime uses its own isolated `prometheus.NewRegistry()` (not the default registry), while `metrics.RegisterAll()` calls prometheus.MustRegister(...) which registers to `prometheus.DefaultRegisterer`. The metrics server only serves `metrics.Registry` (the controller-runtime one), so the custom metrics are never exposed. 
The fix is to use the registry of the controller-runtime.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
