### PR TITLE
[dnsman-nextgeneration]: Implement `external_dns_management_dns_entries` metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ For extending or adapting this project with your own source or provisioning cont
     - [Setting Up a Controller Manager](#setting-up-a-controller-manager)
     - [Using the standard Compound Provisioning Controller](#using-the-standard-compound-provisioning-controller)
     - [Multiple Cluster Support](#multiple-cluster-support)
+  - [DNS Controller Manager Next Generation](#dns-controller-manager-next-generation)
   - [Why not use the community `external-dns` solution?](#why-not-use-the-community-external-dns-solution)
 
 ## Important Note: Support for owner identifiers is discontinued
@@ -1170,6 +1171,12 @@ this cluster. If no such option is specified the default is used.
 Therefore, even if the configuration is prepared for multiple clusters,
 such a controller manager can easily work on a single cluster if no special
 options are given on the command line.
+
+## DNS Controller Manager Next Generation
+
+The DNS controller manager is being rewritten using [controller-runtime](https://sigs.k8s.io/controller-runtime)
+with significant architectural improvements. For details, see the
+[DNS Controller Manager Next Generation documentation](docs/dnsman2/README.md).
 
 ## Why not use the community `external-dns` solution?
 

--- a/docs/api-reference/config.md
+++ b/docs/api-reference/config.md
@@ -404,7 +404,7 @@ integer
 </td>
 <td>
 <em>(Optional)</em>
-<p>ZoneMetricsInterval is the interval for refreshing the per-zone DNS entry count metrics.<br />A value of 0 disables the periodic update. Default value is 1 minute.</p>
+<p>ZoneMetricsInterval is the interval for refreshing the per-zone DNS entry count metrics.<br />A value of 0 disables the periodic update. Default value is 30 seconds	.</p>
 </td>
 </tr>
 

--- a/docs/api-reference/config.md
+++ b/docs/api-reference/config.md
@@ -395,6 +395,18 @@ integer
 <p>ReconciliationDelayAfterUpdate is the duration to wait after a DNSEntry object has been updated before its reconciliation is performed.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>zoneMetricsInterval</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#duration-v1-meta">Duration</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ZoneMetricsInterval is the interval for refreshing the per-zone DNS entry count metrics.<br />A value of 0 disables the periodic update. Default value is 1 minute.</p>
+</td>
+</tr>
 
 </tbody>
 </table>

--- a/docs/dnsman2/README.md
+++ b/docs/dnsman2/README.md
@@ -1,10 +1,27 @@
-# Controller-Runtime-Rewrite
+# DNS Controller Manager Next Generation
 
 This folder contains documentation for the next generation of the dns-controller-manager,
 which is being rewritten using the [controller-runtime](https://sigs.k8s.io/controller-runtime).
-The rewrite is mostly completed. Support for annotations on Istio Gateways is not yet merged, and the rewrite is not yet recommended for production usage.
+The rewrite is mostly completed.
 
 Additionally, it contains some major changes to the architecture and features of the dns-controller-manager.
+
+## Table of Contents
+
+- [Major Changes](#major-changes)
+- [Configuration](#configuration)
+  - [Usage](#usage)
+  - [Default Configuration](#default-configuration)
+  - [Example Configuration File](#example-configuration-file)
+- [Migration From Legacy Version](#migration-from-legacy-version)
+  - [Controller Name Mapping](#controller-name-mapping)
+  - [Mapping of Important Flags](#mapping-of-important-flags)
+- [Development](#development)
+- [Reference](#reference)
+  - [Metrics](metrics.md)
+  - [DNSEntry Status](../usage/dnsentry_status.md)
+  - [DNSEntry Translation](../usage/dnsentry_translation.md)
+  - [DNSProvider Status](../usage/dnsprovider_status.md)
 
 ## Major Changes
 - On reconciling `DNSEntry`, the current state is retrieved by DNS queries to the authoritative nameservers, which are used instead of the API endpoints of the DNS providers. This significantly reduces calls to the API endpoints and makes existing rate limits much less problematic.

--- a/docs/dnsman2/metrics.md
+++ b/docs/dnsman2/metrics.md
@@ -1,0 +1,64 @@
+# Metrics (Next-Generation dns-controller-manager)
+
+The next-generation dns-controller-manager exposes [Prometheus](https://prometheus.io/) metrics on a dedicated HTTP endpoint. By default the metrics server listens on port **2753** (configurable via `server.metrics.port` in the `DNSManagerConfiguration`).
+
+**Endpoint:** `GET /metrics`
+
+All metric names are prefixed with `external_dns_management_`.
+
+## Provider & Account Metrics
+
+| Name | Type | Labels | Description |
+|------|------|--------|-------------|
+| `external_dns_management_account_providers` | Gauge | `providertype`, `accounthash` | Current number of `DNSProvider` resources active for a given provider type and credential set. Updated whenever a provider is added, removed, or its credentials change. Removed when the account is deleted. |
+| `external_dns_management_total_provider_requests` | Counter | `providertype`, `accounthash`, `requesttype` | Cumulative number of API calls made to a DNS provider, broken down by provider type, credential set, and request type (e.g. `list_zones`, `list_records`, `update_records`, `create_records`, `delete_records`, `cached_getzones`). |
+| `external_dns_management_requests_per_zone` | Counter | `providertype`, `accounthash`, `requesttype`, `zone` | Same as `external_dns_management_total_provider_requests` but further broken down by the DNS zone that was targeted. Only incremented when a zone context is available. |
+
+## Zone Metrics
+
+The next-generation dns-controller-manager periodically lists all `DNSEntry` resources and aggregates them by hosted zone and reconciliation state. The interval is controlled by `controllers.dnsEntry.zoneMetricsInterval` in the `DNSManagerConfiguration` (default: 30 seconds; set to `0` to disable).
+
+| Name | Type | Labels | Description |
+|------|------|--------|-------------|
+| `external_dns_management_dns_entries` | Gauge | `providertype`, `zone`, `state` | Current number of DNS entries (`DNSEntry` resources) grouped by their target hosted zone and the value of `status.state` (e.g. `Ready`, `Pending`, `Error`, `Invalid`, `Stale`, or empty if not yet set). Entries that are not yet bound to a zone (`status.zone` not set) are reported with `providertype=""` and `zone=""`. Stale label combinations are removed automatically when no entry matches them anymore. |
+
+## Lookup Processor Metrics
+
+The lookup processor resolves hostnames referenced in `DNSEntry` resources (targets using DNS names instead of IP addresses) and queues re-reconciliations when results change.
+
+| Name | Type | Labels | Description |
+|------|------|--------|-------------|
+| `external_dns_management_lookup_processor_jobs` | Gauge | _(none)_ | Current number of pending jobs in the lookup processor queue. |
+| `external_dns_management_lookup_processor_skips` | Counter | _(none)_ | Cumulative number of hostname lookups skipped because the processor was overloaded. An increasing value indicates backpressure on the lookup queue. |
+| `external_dns_management_lookup_processor_lookups` | Counter | `namespace` | Cumulative number of hostname lookup cycles executed per namespace. Each cycle resolves all hostnames for one `DNSEntry`. |
+| `external_dns_management_lookup_processor_hosts` | Counter | `namespace` | Cumulative number of individual hostname resolution calls made per namespace. A single lookup cycle may resolve multiple hostnames. |
+| `external_dns_management_lookup_processor_errors` | Counter | `namespace` | Cumulative number of failed hostname resolution calls per namespace. Compare with `external_dns_management_lookup_processor_hosts` to derive an error rate. |
+| `external_dns_management_lookup_processor_lookup_changed` | Counter | `namespace` | Cumulative number of lookup cycles where the resolved addresses differed from the previously cached result. Each increment triggers a re-reconciliation of the affected `DNSEntry`. |
+| `external_dns_management_lookup_processor_seconds` | Histogram | _(none)_ | Duration of individual hostname lookup calls in seconds. Buckets: 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 20. Use this to detect slow upstream DNS resolvers. |
+
+## Label Reference
+
+| Label | Description |
+|-------|-------------|
+| `providertype` | DNS provider type, e.g. `aws-route53`, `google-clouddns`, `azure-dns` |
+| `accounthash` | Hash of the provider credentials, used to distinguish accounts of the same provider type without exposing secrets |
+| `requesttype` | API operation performed against the provider, e.g. `list_zones`, `list_records`, `update_records`, `create_records`, `delete_records`, `cached_getzones` |
+| `zone` | Provider-specific zone identifier (empty for entries not yet bound to a zone) |
+| `namespace` | Kubernetes namespace of the `DNSEntry` resource |
+| `state` | Value of `status.state` of the `DNSEntry` (e.g. `Ready`, `Pending`, `Error`, `Invalid`, `Stale`, `Ignored`; empty string if not set) |
+
+## Metrics Not Present in the Next-Generation Version
+
+The following metrics exist in the **legacy** dns-controller-manager but are **not registered** in the next-generation version:
+
+| Name | Description                                    |
+|------|------------------------------------------------|
+| `external_dns_management_remoteaccess_logins` | Remote access feature not present in next-gen  |
+| `external_dns_management_remoteaccess_requests` | Remote access feature not present in next-gen  |
+| `external_dns_management_remoteaccess_seconds` | Remote access feature not present in next-gen  |
+| `external_dns_management_remoteaccess_transport_credentials` | Remote access feature not present in next-gen  |
+| `external_dns_management_entry_reconciliations_total` | Not implemented in next-gen              |
+| `external_dns_management_zone_reconciliations_total` | There are no zone reconciliations in next-gen |
+| `external_dns_management_zone_reconciliations_seconds` | There are no zone reconciliations in next-gen |
+| `external_dns_management_zone_cache_discardings` | The next-gen does not maintain a per-zone in-memory cache that gets discarded |
+| `external_dns_management_dns_entries_stale` | Replaced by the `state` label on `external_dns_management_dns_entries` |

--- a/pkg/dnsman2/apis/config/types.go
+++ b/pkg/dnsman2/apis/config/types.go
@@ -158,6 +158,9 @@ type DNSEntryControllerConfig struct {
 	DefaultCNAMELookupInterval *int64
 	// ReconciliationDelayAfterUpdate is the duration to wait after a DNSEntry object has been updated before its reconciliation is performed.
 	ReconciliationDelayAfterUpdate *metav1.Duration
+	// ZoneMetricsInterval is the interval for refreshing the per-zone DNS entry count metrics.
+	// A value of 0 disables the periodic update. Default value is 1 minute.
+	ZoneMetricsInterval *metav1.Duration
 }
 
 // DNSAnnotationControllerConfig is the configuration for the DNSAnnotation controller.

--- a/pkg/dnsman2/apis/config/types.go
+++ b/pkg/dnsman2/apis/config/types.go
@@ -159,7 +159,7 @@ type DNSEntryControllerConfig struct {
 	// ReconciliationDelayAfterUpdate is the duration to wait after a DNSEntry object has been updated before its reconciliation is performed.
 	ReconciliationDelayAfterUpdate *metav1.Duration
 	// ZoneMetricsInterval is the interval for refreshing the per-zone DNS entry count metrics.
-	// A value of 0 disables the periodic update. Default value is 1 minute.
+	// A value of 0 disables the periodic update. Default value is 30 seconds.
 	ZoneMetricsInterval *metav1.Duration
 }
 

--- a/pkg/dnsman2/apis/config/v1alpha1/defaults.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/defaults.go
@@ -148,6 +148,9 @@ func SetDefaults_DNSEntryControllerConfig(obj *DNSEntryControllerConfig) {
 	if obj.ReconciliationTimeout == nil {
 		obj.ReconciliationTimeout = &metav1.Duration{Duration: 2 * time.Minute}
 	}
+	if obj.ZoneMetricsInterval == nil {
+		obj.ZoneMetricsInterval = &metav1.Duration{Duration: 30 * time.Second}
+	}
 }
 
 // SetDefaults_SourceControllerConfig sets defaults for the SourceControllerConfig object.

--- a/pkg/dnsman2/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/defaults_test.go
@@ -196,6 +196,7 @@ var _ = Describe("Defaults", func() {
 					Expect(obj.ConcurrentSyncs).To(PointTo(Equal(5)))
 					Expect(obj.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Hour})))
 					Expect(obj.ReconciliationTimeout).To(PointTo(Equal(metav1.Duration{Duration: 2 * time.Minute})))
+					Expect(obj.ZoneMetricsInterval).To(PointTo(Equal(metav1.Duration{Duration: 30 * time.Second})))
 				})
 
 				It("should not overwrite existing values", func() {
@@ -203,6 +204,7 @@ var _ = Describe("Defaults", func() {
 						ConcurrentSyncs:       ptr.To(7),
 						SyncPeriod:            &metav1.Duration{Duration: 0 * time.Second},
 						ReconciliationTimeout: &metav1.Duration{Duration: 30 * time.Second},
+						ZoneMetricsInterval:   &metav1.Duration{Duration: 0},
 					}
 
 					SetDefaults_DNSEntryControllerConfig(obj)
@@ -210,6 +212,7 @@ var _ = Describe("Defaults", func() {
 					Expect(obj.ConcurrentSyncs).To(PointTo(Equal(7)))
 					Expect(obj.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 0})))
 					Expect(obj.ReconciliationTimeout).To(PointTo(Equal(metav1.Duration{Duration: 30 * time.Second})))
+					Expect(obj.ZoneMetricsInterval).To(PointTo(Equal(metav1.Duration{Duration: 0})))
 				})
 			})
 			Describe("Source controller", func() {

--- a/pkg/dnsman2/apis/config/v1alpha1/types.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/types.go
@@ -187,6 +187,10 @@ type DNSEntryControllerConfig struct {
 	// ReconciliationDelayAfterUpdate is the duration to wait after a DNSEntry object has been updated before its reconciliation is performed.
 	// +optional
 	ReconciliationDelayAfterUpdate *metav1.Duration `json:"reconciliationDelayAfterUpdate,omitempty"`
+	// ZoneMetricsInterval is the interval for refreshing the per-zone DNS entry count metrics.
+	// A value of 0 disables the periodic update. Default value is 1 minute.
+	// +optional
+	ZoneMetricsInterval *metav1.Duration `json:"zoneMetricsInterval,omitempty"`
 }
 
 // DNSAnnotationControllerConfig is the configuration for the DNSAnnotation controller.

--- a/pkg/dnsman2/apis/config/v1alpha1/types.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/types.go
@@ -188,7 +188,7 @@ type DNSEntryControllerConfig struct {
 	// +optional
 	ReconciliationDelayAfterUpdate *metav1.Duration `json:"reconciliationDelayAfterUpdate,omitempty"`
 	// ZoneMetricsInterval is the interval for refreshing the per-zone DNS entry count metrics.
-	// A value of 0 disables the periodic update. Default value is 1 minute.
+	// A value of 0 disables the periodic update. Default value is 30 seconds	.
 	// +optional
 	ZoneMetricsInterval *metav1.Duration `json:"zoneMetricsInterval,omitempty"`
 }

--- a/pkg/dnsman2/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/zz_generated.conversion.go
@@ -300,6 +300,7 @@ func autoConvert_v1alpha1_DNSEntryControllerConfig_To_config_DNSEntryControllerC
 	out.MaxConcurrentLookups = (*int)(unsafe.Pointer(in.MaxConcurrentLookups))
 	out.DefaultCNAMELookupInterval = (*int64)(unsafe.Pointer(in.DefaultCNAMELookupInterval))
 	out.ReconciliationDelayAfterUpdate = (*v1.Duration)(unsafe.Pointer(in.ReconciliationDelayAfterUpdate))
+	out.ZoneMetricsInterval = (*v1.Duration)(unsafe.Pointer(in.ZoneMetricsInterval))
 	return nil
 }
 
@@ -315,6 +316,7 @@ func autoConvert_config_DNSEntryControllerConfig_To_v1alpha1_DNSEntryControllerC
 	out.MaxConcurrentLookups = (*int)(unsafe.Pointer(in.MaxConcurrentLookups))
 	out.DefaultCNAMELookupInterval = (*int64)(unsafe.Pointer(in.DefaultCNAMELookupInterval))
 	out.ReconciliationDelayAfterUpdate = (*v1.Duration)(unsafe.Pointer(in.ReconciliationDelayAfterUpdate))
+	out.ZoneMetricsInterval = (*v1.Duration)(unsafe.Pointer(in.ZoneMetricsInterval))
 	return nil
 }
 

--- a/pkg/dnsman2/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -173,6 +173,11 @@ func (in *DNSEntryControllerConfig) DeepCopyInto(out *DNSEntryControllerConfig) 
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.ZoneMetricsInterval != nil {
+		in, out := &in.ZoneMetricsInterval, &out.ZoneMetricsInterval
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/dnsman2/apis/config/zz_generated.deepcopy.go
+++ b/pkg/dnsman2/apis/config/zz_generated.deepcopy.go
@@ -173,6 +173,11 @@ func (in *DNSEntryControllerConfig) DeepCopyInto(out *DNSEntryControllerConfig) 
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.ZoneMetricsInterval != nil {
+		in, out := &in.ZoneMetricsInterval, &out.ZoneMetricsInterval
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/dnsman2/controller/controlplane/dnsentry/add.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/add.go
@@ -117,6 +117,12 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, controlPlaneCluster clust
 		log.Info("Periodic reconciliation enabled", "syncPeriod", r.Config.SyncPeriod.Duration)
 	}
 
+	if interval := ptr.Deref(r.Config.ZoneMetricsInterval, metav1.Duration{}).Duration; interval > 0 {
+		if err := mgr.Add(newZoneMetricsReporter(r.Client, log.WithName("zoneMetrics"), r.Namespace, r.Class, r.SecondaryClasses, interval)); err != nil {
+			return err
+		}
+	}
+
 	return bld.WithOptions(controller.Options{
 		MaxConcurrentReconciles: ptr.Deref(r.Config.ConcurrentSyncs, 10),
 		SkipNameValidation:      cfg.Controllers.SkipNameValidation,

--- a/pkg/dnsman2/controller/controlplane/dnsentry/zone_metrics.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/zone_metrics.go
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dnsentry
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/metrics"
+)
+
+// zoneMetricsReporter periodically lists all DNSEntry resources and updates the
+// per-zone DNS entry count gauge, grouped by status.state.
+type zoneMetricsReporter struct {
+	client           client.Client
+	log              logr.Logger
+	namespace        string
+	class            string
+	secondaryClasses []string
+	interval         time.Duration
+
+	previous map[metrics.EntryStateLabels]time.Time
+}
+
+func newZoneMetricsReporter(c client.Client, log logr.Logger, namespace, class string, secondaryClasses []string, interval time.Duration) *zoneMetricsReporter {
+	return &zoneMetricsReporter{
+		client:           c,
+		log:              log,
+		namespace:        namespace,
+		class:            class,
+		secondaryClasses: secondaryClasses,
+		interval:         interval,
+		previous:         map[metrics.EntryStateLabels]time.Time{},
+	}
+}
+
+// Start implements manager.Runnable.
+func (r *zoneMetricsReporter) Start(ctx context.Context) error {
+	r.log.Info("Starting zone metrics reporter", "interval", r.interval)
+	r.report(ctx)
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			r.report(ctx)
+		}
+	}
+}
+
+func (r *zoneMetricsReporter) report(ctx context.Context) {
+	entryList := &v1alpha1.DNSEntryList{}
+	if err := r.client.List(ctx, entryList, client.InNamespace(r.namespace)); err != nil {
+		r.log.Error(err, "failed to list DNSEntry resources for zone metrics")
+		return
+	}
+	counts := map[metrics.EntryStateLabels]int{}
+	for _, entry := range dns.FilterEntriesByClass(entryList.Items, r.class, r.secondaryClasses) {
+		counts[metrics.EntryStateLabels{
+			ProviderType: ptr.Deref(entry.Status.ProviderType, ""),
+			Zone:         ptr.Deref(entry.Status.Zone, ""),
+			State:        entry.Status.State,
+		}]++
+	}
+	r.previous = metrics.ReportEntryStates(counts, r.previous)
+}
+
+var _ manager.Runnable = &zoneMetricsReporter{}

--- a/pkg/dnsman2/dns/metrics/metrics.go
+++ b/pkg/dnsman2/dns/metrics/metrics.go
@@ -12,18 +12,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
-
-	"github.com/gardener/external-dns-management/pkg/dnsman2/dns"
 )
 
 // RegisterAll registers all metrics with the controller-runtime registry, which is served by the metrics server.
 func RegisterAll() {
 	ctrlmetrics.Registry.MustRegister(Requests)
 	ctrlmetrics.Registry.MustRegister(ZoneRequests)
-	ctrlmetrics.Registry.MustRegister(ZoneCacheDiscardings)
 	ctrlmetrics.Registry.MustRegister(Accounts)
 	ctrlmetrics.Registry.MustRegister(Entries)
-	ctrlmetrics.Registry.MustRegister(StaleEntries)
 	ctrlmetrics.Registry.MustRegister(LookupProcessorJobs)
 	ctrlmetrics.Registry.MustRegister(LookupProcessorSkips)
 	ctrlmetrics.Registry.MustRegister(LookupProcessorLookups)
@@ -52,15 +48,6 @@ var (
 		[]string{"providertype", "accounthash", "requesttype", "zone"},
 	)
 
-	// ZoneCacheDiscardings tracks the number of discarding of zone cache per provider type and zone.
-	ZoneCacheDiscardings = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "external_dns_management_zone_cache_discardings",
-			Help: "Discardings of zone cache per provider type and zone",
-		},
-		[]string{"providertype", "zone"},
-	)
-
 	// Accounts tracks the number of providers per account.
 	Accounts = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -70,22 +57,13 @@ var (
 		[]string{"providertype", "accounthash"},
 	)
 
-	// Entries tracks the total number of DNS entries per hosted zone.
+	// Entries tracks the number of DNS entries per hosted zone and reconciliation state.
 	Entries = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "external_dns_management_dns_entries",
-			Help: "Total number of dns entries per hosted zone",
+			Help: "Number of DNS entries per hosted zone, grouped by status state",
 		},
-		[]string{"providertype", "zone"},
-	)
-
-	// StaleEntries tracks the number of stale DNS entries per hosted zone.
-	StaleEntries = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "external_dns_management_dns_entries_stale",
-			Help: "Total number of stale dns entries per hosted zone",
-		},
-		[]string{"providertype", "zone"},
+		[]string{"providertype", "zone", "state"},
 	)
 
 	// LookupProcessorJobs tracks the number of jobs in the lookup processor.
@@ -192,7 +170,6 @@ func DeleteAccount(ptype, account string) {
 	for rtype := range requestTypes {
 		Requests.DeleteLabelValues(ptype, account, rtype)
 	}
-	Entries.DeleteLabelValues(ptype, account)
 }
 
 // ReportAccountProviders sets the number of providers for a given provider type and account.
@@ -209,44 +186,48 @@ func AddRequests(ptype, account, requestType string, no int, zone *string) {
 	}
 }
 
-// AddZoneCacheDiscarding increments the zone cache discarding metric for the given zone.
-func AddZoneCacheDiscarding(id dns.ZoneID) {
-	ZoneCacheDiscardings.WithLabelValues(id.ProviderType, id.ID).Add(float64(1))
+// EntryStateLabels identifies a unique combination of providertype, zone and entry state used by Entries.
+type EntryStateLabels struct {
+	ProviderType string
+	Zone         string
+	State        string
 }
 
-// ZoneProviderTypes tracks provider types for zones.
-type ZoneProviderTypes struct {
-	lock      sync.Mutex
-	providers map[dns.ZoneID]struct{}
-}
+// entryStateDeletionGracePeriod is the time a zero-valued label combination is kept
+// before it is actually deleted. Prometheus caches scraped series for a short time,
+// so deleting immediately would hide that the value dropped to zero.
+const entryStateDeletionGracePeriod = 5 * time.Minute
 
-// Add adds a zone to the set of known providers.
-func (this *ZoneProviderTypes) Add(zone dns.ZoneID) {
-	this.lock.Lock()
-	defer this.lock.Unlock()
-	this.providers[zone] = struct{}{}
-}
-
-// Remove removes a zone from the set of known providers.
-func (this *ZoneProviderTypes) Remove(zone dns.ZoneID) {
-	this.lock.Lock()
-	defer this.lock.Unlock()
-	delete(this.providers, zone)
-}
-
-var zoneProviders = &ZoneProviderTypes{providers: map[dns.ZoneID]struct{}{}}
-
-// ReportZoneEntries sets the number of entries and stale entries for a zone.
-func ReportZoneEntries(zoneid dns.ZoneID, amount int, stale int) {
-	Entries.WithLabelValues(zoneid.ProviderType, zoneid.ID).Set(float64(amount))
-	StaleEntries.WithLabelValues(zoneid.ProviderType, zoneid.ID).Set(float64(stale))
-	zoneProviders.Add(zoneid)
-}
-
-// DeleteZone removes metrics for a given zone.
-func DeleteZone(zoneid dns.ZoneID) {
-	zoneProviders.Remove(zoneid)
-	Entries.DeleteLabelValues(zoneid.ProviderType, zoneid.ID)
+// ReportEntryStates replaces the current values of the Entries gauge with the given counts.
+// Label combinations that were present in previous but are missing from counts are set to 0
+// and only deleted after they have stayed at 0 for at least entryStateDeletionGracePeriod.
+// The returned map must be passed back as previous on the next call.
+func ReportEntryStates(counts map[EntryStateLabels]int, previous map[EntryStateLabels]time.Time) map[EntryStateLabels]time.Time {
+	now := time.Now()
+	current := make(map[EntryStateLabels]time.Time, len(counts)+len(previous))
+	for k, v := range counts {
+		Entries.WithLabelValues(k.ProviderType, k.Zone, k.State).Set(float64(v))
+		current[k] = time.Time{} // not zero / not pending deletion
+	}
+	for k, zeroSince := range previous {
+		if _, ok := counts[k]; ok {
+			continue
+		}
+		if zeroSince.IsZero() {
+			// First time we see this combination missing: set to 0 and start the grace period.
+			Entries.WithLabelValues(k.ProviderType, k.Zone, k.State).Set(0)
+			current[k] = now
+			continue
+		}
+		if now.Sub(zeroSince) >= entryStateDeletionGracePeriod {
+			Entries.DeleteLabelValues(k.ProviderType, k.Zone, k.State)
+			continue
+		}
+		// Still within the grace period; keep the original timestamp and ensure value is 0.
+		Entries.WithLabelValues(k.ProviderType, k.Zone, k.State).Set(0)
+		current[k] = zeroSince
+	}
+	return current
 }
 
 // ReportLookupProcessorIncrSkipped increments the skipped lookups metric.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
  - Replace the unused `external_dns_management_dns_entries` / `external_dns_management_dns_entries_stale` gauges with a single `external_dns_management_dns_entries{providertype, zone, state}` gauge populated from `DNSEntry.status`.
  - Add a `zoneMetricsReporter` (`manager.Runnable`) in the DNSEntry control-plane controller that periodically lists DNSEntry resources, groups them by `(status.providerType, status.zone, status.state)`, and updates the gauge — removing label combinations that disappear between cycles.
  - New config field `controllers.dnsEntry.zoneMetricsInterval` (default `30s`; `0` disables).                                                                                                                                                                                                                        
  - Drop now-unused `external_dns_management_zone_cache_discardings` and the legacy `ZoneProviderTypes` / `ReportZoneEntries` / `AddZoneCacheDiscarding` / `DeleteZone` helpers from the metrics package.
  - Document the metrics actually exposed by the next-gen `dns-controller-manager`, with a clear list of legacy metrics intentionally not present.                                                                                                                                                                    
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
