### PR TITLE
[next-generation] Improve resilience of DNSEntry reconciler when a managed entry collides with a foreign record at the same name

### DIFF
--- a/docs/api-reference/config.md
+++ b/docs/api-reference/config.md
@@ -419,6 +419,18 @@ integer
 <p>ZoneMetricsInterval is the interval for refreshing the per-zone DNS entry count metrics.<br />A value of 0 disables the periodic update. Default value is 30 seconds	.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>driftCheckPeriod</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#duration-v1-meta">Duration</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DriftCheckPeriod is the minimum interval between two record-type drift recovery attempts for the same DNSEntry.<br />When an entry is in Error or Stale state, the reconciler additionally queries the alternative address record types<br />(A, AAAA, CNAME) at the same name to detect a foreign record blocking the entry. This bounds the resulting query<br />amplification: too short causes repeated full-spectrum queries during persistent error states, too long slows<br />recovery once the conflict is resolved.</p>
+</td>
+</tr>
 
 </tbody>
 </table>

--- a/docs/api-reference/config.md
+++ b/docs/api-reference/config.md
@@ -416,7 +416,7 @@ integer
 </td>
 <td>
 <em>(Optional)</em>
-<p>ZoneMetricsInterval is the interval for refreshing the per-zone DNS entry count metrics.<br />A value of 0 disables the periodic update. Default value is 30 seconds	.</p>
+<p>ZoneMetricsInterval is the interval for refreshing the per-zone DNS entry count metrics.<br />A value of 0 disables the periodic update. Default value is 30 seconds.</p>
 </td>
 </tr>
 <tr>
@@ -428,7 +428,7 @@ integer
 </td>
 <td>
 <em>(Optional)</em>
-<p>DriftCheckPeriod is the minimum interval between two record-type drift recovery attempts for the same DNSEntry.<br />When an entry is in Error or Stale state, the reconciler additionally queries the alternative address record types<br />(A, AAAA, CNAME) at the same name to detect a foreign record blocking the entry. This bounds the resulting query<br />amplification: too short causes repeated full-spectrum queries during persistent error states, too long slows<br />recovery once the conflict is resolved.</p>
+<p>DriftCheckPeriod is the minimum interval between two record-type drift recovery attempts for the same DNSEntry.<br />When an entry is in Error or Stale state, the reconciler additionally queries the alternative address record types<br />(A, AAAA, CNAME) at the same name to detect a foreign record blocking the entry. This bounds the resulting query<br />amplification: too short causes repeated full-spectrum queries during persistent error states, too long slows<br />recovery once the conflict is resolved. Default value is 12 hours.</p>
 </td>
 </tr>
 

--- a/pkg/dnsman2/apis/config/types.go
+++ b/pkg/dnsman2/apis/config/types.go
@@ -164,6 +164,12 @@ type DNSEntryControllerConfig struct {
 	// ZoneMetricsInterval is the interval for refreshing the per-zone DNS entry count metrics.
 	// A value of 0 disables the periodic update. Default value is 30 seconds.
 	ZoneMetricsInterval *metav1.Duration
+	// DriftCheckPeriod is the minimum interval between two record-type drift recovery attempts for the same DNSEntry.
+	// When an entry is in Error or Stale state, the reconciler additionally queries the alternative address record types
+	// (A, AAAA, CNAME) at the same name to detect a foreign record blocking the entry. This bounds the resulting query
+	// amplification: too short causes repeated full-spectrum queries during persistent error states, too long slows
+	// recovery once the conflict is resolved.
+	DriftCheckPeriod *metav1.Duration
 }
 
 // DNSAnnotationControllerConfig is the configuration for the DNSAnnotation controller.

--- a/pkg/dnsman2/apis/config/types.go
+++ b/pkg/dnsman2/apis/config/types.go
@@ -168,7 +168,7 @@ type DNSEntryControllerConfig struct {
 	// When an entry is in Error or Stale state, the reconciler additionally queries the alternative address record types
 	// (A, AAAA, CNAME) at the same name to detect a foreign record blocking the entry. This bounds the resulting query
 	// amplification: too short causes repeated full-spectrum queries during persistent error states, too long slows
-	// recovery once the conflict is resolved.
+	// recovery once the conflict is resolved. Default value is 12 hours.
 	DriftCheckPeriod *metav1.Duration
 }
 

--- a/pkg/dnsman2/apis/config/v1alpha1/defaults.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/defaults.go
@@ -154,6 +154,9 @@ func SetDefaults_DNSEntryControllerConfig(obj *DNSEntryControllerConfig) {
 	if obj.PropagationWaitTime == nil {
 		obj.PropagationWaitTime = &metav1.Duration{Duration: 10 * time.Second}
 	}
+	if obj.DriftCheckPeriod == nil {
+		obj.DriftCheckPeriod = &metav1.Duration{Duration: 12 * time.Hour}
+	}
 }
 
 // SetDefaults_SourceControllerConfig sets defaults for the SourceControllerConfig object.

--- a/pkg/dnsman2/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/defaults_test.go
@@ -198,6 +198,7 @@ var _ = Describe("Defaults", func() {
 					Expect(obj.ReconciliationTimeout).To(PointTo(Equal(metav1.Duration{Duration: 2 * time.Minute})))
 					Expect(obj.ZoneMetricsInterval).To(PointTo(Equal(metav1.Duration{Duration: 30 * time.Second})))
 					Expect(obj.PropagationWaitTime).To(PointTo(Equal(metav1.Duration{Duration: 10 * time.Second})))
+					Expect(obj.DriftCheckPeriod).To(PointTo(Equal(metav1.Duration{Duration: 12 * time.Hour})))
 				})
 
 				It("should not overwrite existing values", func() {
@@ -207,6 +208,7 @@ var _ = Describe("Defaults", func() {
 						ReconciliationTimeout: &metav1.Duration{Duration: 30 * time.Second},
 						ZoneMetricsInterval:   &metav1.Duration{Duration: 0},
 						PropagationWaitTime:   &metav1.Duration{Duration: 5 * time.Second},
+						DriftCheckPeriod:      &metav1.Duration{Duration: 6 * time.Hour},
 					}
 
 					SetDefaults_DNSEntryControllerConfig(obj)
@@ -216,6 +218,7 @@ var _ = Describe("Defaults", func() {
 					Expect(obj.ReconciliationTimeout).To(PointTo(Equal(metav1.Duration{Duration: 30 * time.Second})))
 					Expect(obj.ZoneMetricsInterval).To(PointTo(Equal(metav1.Duration{Duration: 0})))
 					Expect(obj.PropagationWaitTime).To(PointTo(Equal(metav1.Duration{Duration: 5 * time.Second})))
+					Expect(obj.DriftCheckPeriod).To(PointTo(Equal(metav1.Duration{Duration: 6 * time.Hour})))
 				})
 			})
 			Describe("Source controller", func() {

--- a/pkg/dnsman2/apis/config/v1alpha1/types.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/types.go
@@ -192,14 +192,14 @@ type DNSEntryControllerConfig struct {
 	// +optional
 	ReconciliationDelayAfterUpdate *metav1.Duration `json:"reconciliationDelayAfterUpdate,omitempty"`
 	// ZoneMetricsInterval is the interval for refreshing the per-zone DNS entry count metrics.
-	// A value of 0 disables the periodic update. Default value is 30 seconds	.
+	// A value of 0 disables the periodic update. Default value is 30 seconds.
 	// +optional
 	ZoneMetricsInterval *metav1.Duration `json:"zoneMetricsInterval,omitempty"`
 	// DriftCheckPeriod is the minimum interval between two record-type drift recovery attempts for the same DNSEntry.
 	// When an entry is in Error or Stale state, the reconciler additionally queries the alternative address record types
 	// (A, AAAA, CNAME) at the same name to detect a foreign record blocking the entry. This bounds the resulting query
 	// amplification: too short causes repeated full-spectrum queries during persistent error states, too long slows
-	// recovery once the conflict is resolved.
+	// recovery once the conflict is resolved. Default value is 12 hours.
 	// +optional
 	DriftCheckPeriod *metav1.Duration `json:"driftCheckPeriod,omitempty"`
 }

--- a/pkg/dnsman2/apis/config/v1alpha1/types.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/types.go
@@ -195,6 +195,13 @@ type DNSEntryControllerConfig struct {
 	// A value of 0 disables the periodic update. Default value is 30 seconds	.
 	// +optional
 	ZoneMetricsInterval *metav1.Duration `json:"zoneMetricsInterval,omitempty"`
+	// DriftCheckPeriod is the minimum interval between two record-type drift recovery attempts for the same DNSEntry.
+	// When an entry is in Error or Stale state, the reconciler additionally queries the alternative address record types
+	// (A, AAAA, CNAME) at the same name to detect a foreign record blocking the entry. This bounds the resulting query
+	// amplification: too short causes repeated full-spectrum queries during persistent error states, too long slows
+	// recovery once the conflict is resolved.
+	// +optional
+	DriftCheckPeriod *metav1.Duration `json:"driftCheckPeriod,omitempty"`
 }
 
 // DNSAnnotationControllerConfig is the configuration for the DNSAnnotation controller.

--- a/pkg/dnsman2/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/zz_generated.conversion.go
@@ -302,6 +302,7 @@ func autoConvert_v1alpha1_DNSEntryControllerConfig_To_config_DNSEntryControllerC
 	out.PropagationWaitTime = (*v1.Duration)(unsafe.Pointer(in.PropagationWaitTime))
 	out.ReconciliationDelayAfterUpdate = (*v1.Duration)(unsafe.Pointer(in.ReconciliationDelayAfterUpdate))
 	out.ZoneMetricsInterval = (*v1.Duration)(unsafe.Pointer(in.ZoneMetricsInterval))
+	out.DriftCheckPeriod = (*v1.Duration)(unsafe.Pointer(in.DriftCheckPeriod))
 	return nil
 }
 
@@ -319,6 +320,7 @@ func autoConvert_config_DNSEntryControllerConfig_To_v1alpha1_DNSEntryControllerC
 	out.PropagationWaitTime = (*v1.Duration)(unsafe.Pointer(in.PropagationWaitTime))
 	out.ReconciliationDelayAfterUpdate = (*v1.Duration)(unsafe.Pointer(in.ReconciliationDelayAfterUpdate))
 	out.ZoneMetricsInterval = (*v1.Duration)(unsafe.Pointer(in.ZoneMetricsInterval))
+	out.DriftCheckPeriod = (*v1.Duration)(unsafe.Pointer(in.DriftCheckPeriod))
 	return nil
 }
 

--- a/pkg/dnsman2/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -183,6 +183,11 @@ func (in *DNSEntryControllerConfig) DeepCopyInto(out *DNSEntryControllerConfig) 
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.DriftCheckPeriod != nil {
+		in, out := &in.DriftCheckPeriod, &out.DriftCheckPeriod
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/dnsman2/apis/config/zz_generated.deepcopy.go
+++ b/pkg/dnsman2/apis/config/zz_generated.deepcopy.go
@@ -183,6 +183,11 @@ func (in *DNSEntryControllerConfig) DeepCopyInto(out *DNSEntryControllerConfig) 
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.DriftCheckPeriod != nil {
+		in, out := &in.DriftCheckPeriod, &out.DriftCheckPeriod
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/dnsman2/controller/controlplane/dnsentry/add.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/add.go
@@ -71,7 +71,6 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, controlPlaneCluster clust
 	if err := mgr.Add(r.lookupProcessor); err != nil {
 		return err
 	}
-	r.setReconciliationDelayAfterUpdate(ptr.Deref(r.Config.ReconciliationDelayAfterUpdate, metav1.Duration{Duration: defaultReconciliationDelayAfterUpdate}).Duration)
 	bld := builder.
 		ControllerManagedBy(mgr).
 		Named(ControllerName).

--- a/pkg/dnsman2/controller/controlplane/dnsentry/add.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/add.go
@@ -64,6 +64,10 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, controlPlaneCluster clust
 		15*time.Second,
 	)
 	r.defaultCNAMELookupInterval = ptr.Deref(r.Config.DefaultCNAMELookupInterval, 600)
+	r.setCachePeriods(
+		ptr.Deref(r.Config.ReconciliationDelayAfterUpdate, metav1.Duration{Duration: defaultReconciliationDelayAfterUpdate}).Duration,
+		ptr.Deref(r.Config.DriftCheckPeriod, metav1.Duration{Duration: defaultDriftCheckPeriod}).Duration,
+	)
 	if err := mgr.Add(r.lookupProcessor); err != nil {
 		return err
 	}
@@ -184,10 +188,13 @@ func (r *Reconciler) allEntriesToReconcile(ctx context.Context) []reconcile.Requ
 	return requests
 }
 
-func (r *Reconciler) setReconciliationDelayAfterUpdate(reconciliationDelayAfterUpdate time.Duration) {
+func (r *Reconciler) setCachePeriods(reconciliationDelayAfterUpdate, driftCheckPeriod time.Duration) {
 	r.reconciliationDelayAfterUpdate = reconciliationDelayAfterUpdate
 	r.lastUpdate = ttlcache.New[client.ObjectKey, struct{}](
 		ttlcache.WithTTL[client.ObjectKey, struct{}](reconciliationDelayAfterUpdate),
+		ttlcache.WithDisableTouchOnHit[client.ObjectKey, struct{}]())
+	r.lastDriftCheck = ttlcache.New[client.ObjectKey, struct{}](
+		ttlcache.WithTTL[client.ObjectKey, struct{}](driftCheckPeriod),
 		ttlcache.WithDisableTouchOnHit[client.ObjectKey, struct{}]())
 }
 

--- a/pkg/dnsman2/controller/controlplane/dnsentry/reconciler.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/reconciler.go
@@ -28,7 +28,10 @@ import (
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/state"
 )
 
-const defaultReconciliationDelayAfterUpdate = 5 * time.Second
+const (
+	defaultReconciliationDelayAfterUpdate = 5 * time.Second
+	defaultDriftCheckPeriod               = 12 * time.Hour
+)
 
 // Reconciler is a reconciler for DNSEntry resources on the control plane.
 type Reconciler struct {
@@ -45,6 +48,7 @@ type Reconciler struct {
 	state           *state.State
 	lookupProcessor lookup.LookupProcessor
 	lastUpdate      *ttlcache.Cache[client.ObjectKey, struct{}]
+	lastDriftCheck  *ttlcache.Cache[client.ObjectKey, struct{}]
 }
 
 // Reconcile reconciles DNSEntry resources.
@@ -86,6 +90,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		state:                      r.state,
 		defaultCNAMELookupInterval: r.defaultCNAMELookupInterval,
 		lastUpdate:                 r.lastUpdate,
+		lastDriftCheck:             r.lastDriftCheck,
 	}
 	res := er.reconcile()
 	if res.Err != nil {

--- a/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_reconcile.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_reconcile.go
@@ -36,6 +36,7 @@ type entryReconciliation struct {
 	lookupProcessor            lookup.LookupProcessor
 	defaultCNAMELookupInterval int64
 	lastUpdate                 *ttlcache.Cache[client.ObjectKey, struct{}]
+	lastDriftCheck             *ttlcache.Cache[client.ObjectKey, struct{}]
 }
 
 type newTargetsData struct {
@@ -119,6 +120,11 @@ func (r *entryReconciliation) doReconcile() common.ReconcileResult {
 		return *res
 	}
 
+	if r.shouldTryRecordTypeDriftRecovery() {
+		r.insertPossibleAlternativeKeys(recordsToCheck)
+		r.markDriftCheckAttempted()
+	}
+
 	actualRecords, res := r.dnsRecordManager().QueryRecords(r.Ctx, recordsToCheck)
 	if res != nil {
 		return *res
@@ -137,6 +143,21 @@ func (r *entryReconciliation) doReconcile() common.ReconcileResult {
 	}
 
 	return r.updateStatusWithProvider(targetsData)
+}
+
+// shouldTryRecordTypeDriftRecovery reports whether the entry is in a state that warrants checking for record-type drift
+// and whether the per-entry cooldown for the previous attempt has elapsed. It is a pure predicate; callers must invoke
+// markDriftCheckAttempted to consume the budget.
+func (r *entryReconciliation) shouldTryRecordTypeDriftRecovery() bool {
+	if r.Entry.Status.State != v1alpha1.StateError && r.Entry.Status.State != v1alpha1.StateStale {
+		return false
+	}
+	return !r.lastDriftCheck.Has(client.ObjectKeyFromObject(r.Entry))
+}
+
+// markDriftCheckAttempted records that a drift recovery attempt was made for the current entry, starting the cooldown.
+func (r *entryReconciliation) markDriftCheckAttempted() {
+	r.lastDriftCheck.Set(client.ObjectKeyFromObject(r.Entry), struct{}{}, ttlcache.DefaultTTL)
 }
 
 func (r *entryReconciliation) migrateDNSClass() *common.ReconcileResult {
@@ -381,6 +402,19 @@ func (r *entryReconciliation) mapTargets(targets dns.Targets, providerType strin
 		return targets, nil
 	}
 	return makeTargetsUnique(mapper.MapTargets(targets)), nil
+}
+
+func (r *entryReconciliation) insertPossibleAlternativeKeys(recordsToCheck records.FullRecordKeySet) {
+	for _, key := range recordsToCheck.UnsortedList() {
+		if key.RecordType == dns.TypeA || key.RecordType == dns.TypeAAAA || key.RecordType == dns.TypeCNAME {
+			for _, recordType := range []dns.RecordType{dns.TypeA, dns.TypeAAAA, dns.TypeCNAME} {
+				recordsToCheck.Insert(records.FullRecordSetKey{
+					FullDNSSetName: key.FullDNSSetName,
+					RecordType:     recordType,
+				})
+			}
+		}
+	}
 }
 
 // clearDNSCaches clears the DNS caches for the zones that are being updated

--- a/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_test.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_test.go
@@ -913,7 +913,7 @@ var _ = Describe("Reconcile", func() {
 				Expect(err).ToNot(HaveOccurred(), "failed to inject foreign record")
 				// The reconciler caches DNS query results per zone; the rogue record we just inserted
 				// is invisible to the next reconcile unless we drop the cache for this zone.
-				Expect(state.GetState().ClearDNSCaches(ctx, zoneID)).To(Succeed())
+				Expect(state.GetState().ClearDNSCaches(ctx, log, zoneID)).To(Succeed())
 			}
 
 			forceEntryError = func(entry *v1alpha1.DNSEntry) {

--- a/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_test.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_test.go
@@ -34,6 +34,11 @@ import (
 // TODO(MartinWeindel) add tests for dynamic changes of CNAME to A lookups
 // TODO(MartinWeindel) add tests for alias targets
 
+type noopMetrics struct{}
+
+func (noopMetrics) AddGenericRequests(_ dnsprovider.MetricsRequestType, _ int)        {}
+func (noopMetrics) AddZoneRequests(_ string, _ dnsprovider.MetricsRequestType, _ int) {}
+
 var _ = Describe("Reconcile", func() {
 	var (
 		ctx                   = context.Background()
@@ -339,7 +344,7 @@ var _ = Describe("Reconcile", func() {
 			state:           state.GetState(),
 			lookupProcessor: lookup.NewLookupProcessor(log.WithName("lookup-processor"), lookup.NewNullTrigger(), 1, 250*time.Millisecond),
 		}
-		reconciler.setReconciliationDelayAfterUpdate(1 * time.Microsecond)
+		reconciler.setCachePeriods(1*time.Microsecond, defaultDriftCheckPeriod)
 		state.GetState().SetDNSHandlerFactory(registry)
 
 		mlh = lookup.NewMockLookupHost(map[string]lookup.MockLookupHostResult{
@@ -894,6 +899,107 @@ var _ = Describe("Reconcile", func() {
 
 			reconciler.MigrationMode = true
 			checkEntryStatus(entryA, "test/p1", zoneID1, "Ready", defaultTTL, "1.2.3.4")
+		})
+	})
+
+	Context("record-type drift recovery", func() {
+		var (
+			injectForeignRecord = func(zoneID dns.ZoneID, dnsName string, rs dns.RecordSet) {
+				GinkgoHelper()
+				mock := local.GetInMemoryMockByZoneID(zoneID)
+				Expect(mock).NotTo(BeNil(), "in-memory mock for zone %s not found", zoneID)
+				err := mock.Apply(zoneID, dns.DNSSetName{DNSName: dnsName}, rs.Type,
+					&dnsprovider.ChangeRequestUpdate{New: &rs}, noopMetrics{})
+				Expect(err).ToNot(HaveOccurred(), "failed to inject foreign record")
+				// The reconciler caches DNS query results per zone; the rogue record we just inserted
+				// is invisible to the next reconcile unless we drop the cache for this zone.
+				Expect(state.GetState().ClearDNSCaches(ctx, zoneID)).To(Succeed())
+			}
+
+			forceEntryError = func(entry *v1alpha1.DNSEntry) {
+				GinkgoHelper()
+				key := client.ObjectKeyFromObject(entry)
+				Expect(fakeClient.Get(ctx, key, entry)).To(Succeed())
+				entry.Status.State = v1alpha1.StateError
+				Expect(fakeClient.Status().Update(ctx, entry)).To(Succeed())
+			}
+		)
+
+		BeforeEach(func() {
+			createProvider("p1", []string{"example.com"}, nil, v1alpha1.StateReady, mockConfig1)
+		})
+
+		It("recovers an A entry when a foreign CNAME shadows the same name", func() {
+			Expect(fakeClient.Create(ctx, entryA)).To(Succeed())
+			checkEntryStatus(entryA, "test/p1", zoneID1, "Ready", defaultTTL, "1.2.3.4")
+			expectRecordSets(zoneID1, "test.sub.example.com", recordSetA)
+
+			injectForeignRecord(zoneID1, "test.sub.example.com", dns.RecordSet{
+				Type:    dns.TypeCNAME,
+				TTL:     defaultTTL,
+				Records: []*dns.Record{{Value: "rogue.example.org."}},
+			})
+			forceEntryError(entryA)
+
+			checkEntryStatus(entryA, "test/p1", zoneID1, "Ready", defaultTTL, "1.2.3.4")
+			expectRecordSets(zoneID1, "test.sub.example.com", recordSetA)
+		})
+
+		It("recovers an A entry when a foreign AAAA exists at the same name", func() {
+			Expect(fakeClient.Create(ctx, entryA)).To(Succeed())
+			checkEntryStatus(entryA, "test/p1", zoneID1, "Ready", defaultTTL, "1.2.3.4")
+
+			injectForeignRecord(zoneID1, "test.sub.example.com", dns.RecordSet{
+				Type:    dns.TypeAAAA,
+				TTL:     defaultTTL,
+				Records: []*dns.Record{{Value: "::dead:beef"}},
+			})
+			forceEntryError(entryA)
+
+			checkEntryStatus(entryA, "test/p1", zoneID1, "Ready", defaultTTL, "1.2.3.4")
+			expectRecordSets(zoneID1, "test.sub.example.com", recordSetA)
+		})
+
+		It("recovers a CNAME entry when a foreign A exists at the same name", func() {
+			Expect(fakeClient.Create(ctx, entryC)).To(Succeed())
+			checkEntryStatus(entryC, "test/p1", zoneID1, "Ready", 120, "www.somewhere.com")
+
+			expectedCNAME := dns.RecordSet{
+				Type:    dns.TypeCNAME,
+				TTL:     120,
+				Records: []*dns.Record{{Value: "www.somewhere.com"}},
+			}
+			expectRecordSets(zoneID1, "cname.sub.example.com", expectedCNAME)
+
+			injectForeignRecord(zoneID1, "cname.sub.example.com", dns.RecordSet{
+				Type:    dns.TypeA,
+				TTL:     defaultTTL,
+				Records: []*dns.Record{{Value: "9.9.9.9"}},
+			})
+			forceEntryError(entryC)
+
+			checkEntryStatus(entryC, "test/p1", zoneID1, "Ready", 120, "www.somewhere.com")
+			expectRecordSets(zoneID1, "cname.sub.example.com", expectedCNAME)
+		})
+
+		It("does not expand alternative keys for a TXT entry, leaving foreign A records untouched", func() {
+			Expect(fakeClient.Create(ctx, entryB)).To(Succeed())
+			checkEntryStatus(entryB, "test/p1", zoneID1, "Ready", defaultTTL, "\"This is a text!\"", "\"blabla\"")
+			expectRecordSets(zoneID1, "txt.sub.example.com", recordSetB)
+
+			foreignA := dns.RecordSet{
+				Type:    dns.TypeA,
+				TTL:     defaultTTL,
+				Records: []*dns.Record{{Value: "9.9.9.9"}},
+			}
+			injectForeignRecord(zoneID1, "txt.sub.example.com", foreignA)
+			forceEntryError(entryB)
+
+			// Reconcile and expect the foreign A to remain in place (TXT keys do not trigger expansion).
+			_, err := reconcileEntry(client.ObjectKeyFromObject(entryB))
+			Expect(err).ToNot(HaveOccurred())
+
+			expectRecordSetsInternal(zoneID1, dns.DNSSetName{DNSName: "txt.sub.example.com"}, 1, 2, recordSetB, foreignA)
 		})
 	})
 

--- a/pkg/dnsman2/dns/provider/handler/aws/execution.go
+++ b/pkg/dnsman2/dns/provider/handler/aws/execution.go
@@ -95,6 +95,7 @@ func (ex *execution) submitChanges(ctx context.Context, metrics provider.Metrics
 		return nil
 	}
 
+	var failedErr error
 	failed := 0
 	throttlingErrCount := 0
 	limitedChanges := limitChangeSet(ex.changes, ex.batchSize)
@@ -139,13 +140,14 @@ func (ex *execution) submitChanges(ctx context.Context, metrics provider.Metrics
 		if len(failedChanges) > 0 {
 			failed += len(failedChanges)
 			ex.log.Error(err, fmt.Sprintf("%d records failed", len(failedChanges)), "zoneID", ex.zoneID)
+			failedErr = errors.Join(failedErr, err)
 		}
 		if len(succeededChanges) > 0 {
 			ex.log.Info(fmt.Sprintf("%d records were successfully updated", len(succeededChanges)), "zoneID", ex.zoneID)
 		}
 	}
 	if failed > 0 {
-		err := fmt.Errorf("%d changes failed", failed)
+		err := fmt.Errorf("%d changes failed: %w", failed, failedErr)
 		if throttlingErrCount == len(limitedChanges) {
 			err = dnserrors.NewThrottlingError(err)
 		}

--- a/pkg/dnsman2/dns/utils/dnsquery.go
+++ b/pkg/dnsman2/dns/utils/dnsquery.go
@@ -44,16 +44,22 @@ type QueryDNS interface {
 type standardQueryDNS struct {
 	nameservers NameserversProvider
 	timeout     time.Duration
+	// dnsQueryFn allows tests to override the actual DNS exchange.
+	dnsQueryFn func(ctx context.Context, fqdn string, rtype uint16) (*miekgdns.Msg, error)
 }
 
 // NewStandardQueryDNS creates a new StandardQueryDNS.
 func NewStandardQueryDNS(nameservers NameserversProvider) QueryDNS {
-	return &standardQueryDNS{nameservers: nameservers, timeout: 10 * time.Second}
+	q := &standardQueryDNS{nameservers: nameservers, timeout: 10 * time.Second}
+	q.dnsQueryFn = q.dnsQuery
+	return q
 }
 
 // NewStandardQueryDNSWithTimeout creates a new StandardQueryDNS with a custom DNS timeout.
 func NewStandardQueryDNSWithTimeout(nameservers NameserversProvider, timeout time.Duration) QueryDNS {
-	return &standardQueryDNS{nameservers: nameservers, timeout: timeout}
+	q := &standardQueryDNS{nameservers: nameservers, timeout: timeout}
+	q.dnsQueryFn = q.dnsQuery
+	return q
 }
 
 func (q *standardQueryDNS) Query(ctx context.Context, setName dns.DNSSetName, rstype dns.RecordType) QueryDNSResult {
@@ -78,7 +84,7 @@ func (q *standardQueryDNS) Query(ctx context.Context, setName dns.DNSSetName, rs
 		return QueryDNSResult{Err: fmt.Errorf("unsupported record type %s", rstype)}
 	}
 
-	msg, err := q.dnsQuery(ctx, ToFQDN(setName.DNSName), rtype)
+	msg, err := q.dnsQueryFn(ctx, ToFQDN(setName.DNSName), rtype)
 	if err != nil {
 		return QueryDNSResult{Err: err}
 	}
@@ -100,12 +106,21 @@ func (q *standardQueryDNS) Query(ctx context.Context, setName dns.DNSSetName, rs
 		case dns.TypeA:
 			r, ok := rr.(*miekgdns.A)
 			if !ok {
+				if isCNAMEAnswer(rr) {
+					// CNAME present means the name is an alias; A records (if any) belong to the alias target,
+					// not to the queried name. Return an empty record set so the caller can detect the type mismatch.
+					return QueryDNSResult{RecordSet: dns.NewRecordSet(rstype, 0, nil)}
+				}
 				return QueryDNSResult{Err: fmt.Errorf("unexpected record type %T (A)", rr)}
 			}
 			addRecord(r.A.String(), r.Hdr.Ttl)
 		case dns.TypeAAAA:
 			r, ok := rr.(*miekgdns.AAAA)
 			if !ok {
+				if isCNAMEAnswer(rr) {
+					// See comment above for TypeA.
+					return QueryDNSResult{RecordSet: dns.NewRecordSet(rstype, 0, nil)}
+				}
 				return QueryDNSResult{Err: fmt.Errorf("unexpected record type %T (AAAA)", rr)}
 			}
 			addRecord(r.AAAA.String(), r.Hdr.Ttl)
@@ -189,4 +204,13 @@ func (q *standardQueryDNS) sendDNSQuery(ctx context.Context, m *miekgdns.Msg, ns
 	}
 
 	return in, err
+}
+
+// isCNAMEAnswer returns true if the given DNS answer is a CNAME record that should be ignored for A/AAAA queries.
+func isCNAMEAnswer(rr miekgdns.RR) bool {
+	// When you query A or AAAA for a name that's actually a CNAME, recursive resolvers commonly return
+	// the CNAME chain plus the resolved A — but if the chain doesn't resolve or the server short-circuits,
+	// you get back just the CNAME RR with the queried type
+	_, ok := rr.(*miekgdns.CNAME)
+	return ok
 }

--- a/pkg/dnsman2/dns/utils/dnsquery.go
+++ b/pkg/dnsman2/dns/utils/dnsquery.go
@@ -44,8 +44,7 @@ type QueryDNS interface {
 type standardQueryDNS struct {
 	nameservers NameserversProvider
 	timeout     time.Duration
-	// dnsQueryFn allows tests to override the actual DNS exchange.
-	dnsQueryFn func(ctx context.Context, fqdn string, rtype uint16) (*miekgdns.Msg, error)
+	dnsQueryFn  func(ctx context.Context, fqdn string, rtype uint16) (*miekgdns.Msg, error)
 }
 
 // NewStandardQueryDNS creates a new StandardQueryDNS.
@@ -118,7 +117,8 @@ func (q *standardQueryDNS) Query(ctx context.Context, setName dns.DNSSetName, rs
 			r, ok := rr.(*miekgdns.AAAA)
 			if !ok {
 				if isCNAMEAnswer(rr) {
-					// See comment above for TypeA.
+					// CNAME present means the name is an alias; AAAA records (if any) belong to the alias target,
+					// not to the queried name. Return an empty record set so the caller can detect the type mismatch.
 					return QueryDNSResult{RecordSet: dns.NewRecordSet(rstype, 0, nil)}
 				}
 				return QueryDNSResult{Err: fmt.Errorf("unexpected record type %T (AAAA)", rr)}

--- a/pkg/dnsman2/dns/utils/dnsquery_test.go
+++ b/pkg/dnsman2/dns/utils/dnsquery_test.go
@@ -2,17 +2,18 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package utils_test
+package utils
 
 import (
 	"context"
 	"net"
 
+	miekgdns "github.com/miekg/dns"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
 
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns"
-	. "github.com/gardener/external-dns-management/pkg/dnsman2/dns/utils"
 )
 
 var _ = Describe("ToFQDN", func() {
@@ -108,4 +109,140 @@ var _ = Describe("QueryDNS", func() {
 		Expect(result.Err).To(HaveOccurred())
 		Expect(result.Err.Error()).To(ContainSubstring("set identifier is not supported for DNS queries"))
 	})
+})
+
+var _ = Describe("QueryDNS with mocked DNS responses", func() {
+	var (
+		ctx     context.Context
+		setName = dns.DNSSetName{DNSName: "example.com"}
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	// makeQueryDNS builds a standardQueryDNS whose dnsQueryFn returns the supplied answer set.
+	makeQueryDNS := func(answer []miekgdns.RR, rcode int) QueryDNS {
+		q := &standardQueryDNS{
+			nameservers: mockNameserversProvider{nameservers: []string{"unused"}},
+		}
+		q.dnsQueryFn = func(_ context.Context, _ string, _ uint16) (*miekgdns.Msg, error) {
+			msg := new(miekgdns.Msg)
+			msg.Rcode = rcode
+			msg.Answer = answer
+			return msg, nil
+		}
+		return q
+	}
+
+	cnameRR := func(name, target string, ttl uint32) *miekgdns.CNAME {
+		return &miekgdns.CNAME{
+			Hdr:    miekgdns.RR_Header{Name: name, Rrtype: miekgdns.TypeCNAME, Class: miekgdns.ClassINET, Ttl: ttl},
+			Target: target,
+		}
+	}
+	aRR := func(name, ip string, ttl uint32) *miekgdns.A {
+		return &miekgdns.A{
+			Hdr: miekgdns.RR_Header{Name: name, Rrtype: miekgdns.TypeA, Class: miekgdns.ClassINET, Ttl: ttl},
+			A:   net.ParseIP(ip).To4(),
+		}
+	}
+	aaaaRR := func(name, ip string, ttl uint32) *miekgdns.AAAA {
+		return &miekgdns.AAAA{
+			Hdr:  miekgdns.RR_Header{Name: name, Rrtype: miekgdns.TypeAAAA, Class: miekgdns.ClassINET, Ttl: ttl},
+			AAAA: net.ParseIP(ip),
+		}
+	}
+	mxRR := func(name string, ttl uint32) *miekgdns.MX {
+		return &miekgdns.MX{
+			Hdr:        miekgdns.RR_Header{Name: name, Rrtype: miekgdns.TypeMX, Class: miekgdns.ClassINET, Ttl: ttl},
+			Preference: 10,
+			Mx:         "mail.example.com.",
+		}
+	}
+
+	DescribeTable("record-type / answer combinations",
+		func(rstype dns.RecordType, answer []miekgdns.RR, rcode int, errMatcher types.GomegaMatcher, recordsMatcher types.GomegaMatcher) {
+			q := makeQueryDNS(answer, rcode)
+			result := q.Query(ctx, setName, rstype)
+			Expect(result.Err).To(errMatcher)
+			if result.Err == nil && result.RecordSet != nil {
+				Expect(result.RecordSet.Records).To(recordsMatcher)
+			} else if result.Err == nil {
+				Expect(result.RecordSet).To(BeNil())
+			}
+		},
+		Entry("A query with only CNAME RR returns no records and no error",
+			dns.TypeA,
+			[]miekgdns.RR{cnameRR("example.com.", "alias.example.net.", 60)},
+			miekgdns.RcodeSuccess,
+			Not(HaveOccurred()),
+			BeEmpty(),
+		),
+		Entry("AAAA query with only CNAME RR returns no records and no error",
+			dns.TypeAAAA,
+			[]miekgdns.RR{cnameRR("example.com.", "alias.example.net.", 60)},
+			miekgdns.RcodeSuccess,
+			Not(HaveOccurred()),
+			BeEmpty(),
+		),
+		Entry("A query with mixed CNAME + A RRs discards A records",
+			dns.TypeA,
+			[]miekgdns.RR{
+				cnameRR("example.com.", "alias.example.net.", 60),
+				aRR("alias.example.net.", "1.2.3.4", 60),
+			},
+			miekgdns.RcodeSuccess,
+			Not(HaveOccurred()),
+			BeEmpty(),
+		),
+		Entry("AAAA query with mixed CNAME + AAAA RRs discards AAAA records",
+			dns.TypeAAAA,
+			[]miekgdns.RR{
+				cnameRR("example.com.", "alias.example.net.", 60),
+				aaaaRR("alias.example.net.", "2001:db8::1", 60),
+			},
+			miekgdns.RcodeSuccess,
+			Not(HaveOccurred()),
+			BeEmpty(),
+		),
+		Entry("A query with truly unexpected RR type errors",
+			dns.TypeA,
+			[]miekgdns.RR{mxRR("example.com.", 60)},
+			miekgdns.RcodeSuccess,
+			MatchError(ContainSubstring("unexpected record type")),
+			nil,
+		),
+		Entry("AAAA query with truly unexpected RR type errors",
+			dns.TypeAAAA,
+			[]miekgdns.RR{mxRR("example.com.", 60)},
+			miekgdns.RcodeSuccess,
+			MatchError(ContainSubstring("unexpected record type")),
+			nil,
+		),
+		Entry("CNAME query receiving A record errors (inverse mismatch)",
+			dns.TypeCNAME,
+			[]miekgdns.RR{aRR("example.com.", "1.2.3.4", 60)},
+			miekgdns.RcodeSuccess,
+			MatchError(ContainSubstring("unexpected record type")),
+			nil,
+		),
+		Entry("NXDOMAIN returns nil record set without error",
+			dns.TypeA,
+			nil,
+			miekgdns.RcodeNameError,
+			Not(HaveOccurred()),
+			nil,
+		),
+		Entry("A query with only A RRs returns those records",
+			dns.TypeA,
+			[]miekgdns.RR{
+				aRR("example.com.", "1.2.3.4", 60),
+				aRR("example.com.", "5.6.7.8", 120),
+			},
+			miekgdns.RcodeSuccess,
+			Not(HaveOccurred()),
+			ConsistOf(&dns.Record{Value: "1.2.3.4"}, &dns.Record{Value: "5.6.7.8"}),
+		),
+	)
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

- Record-type drift recovery: when a `DNSEntry` is in `Error` or `Stale` state, the reconciler now also queries the alternative address record types (`A`, `AAAA`, `CNAME`) at the same name during the next reconciliation. If a foreign record of a different type is shadowing the entry, it can now be detected and overwritten instead of leaving the entry stuck. To bound query amplification, each entry is rechecked at most once per DriftCheckPeriod (default 12h, configurable via `DNSEntryControllerConfig.driftCheckPeriod`).
 - DNS query — ignore `CNAME`-only answers for `A`/`AAAA`: a `CNAME`-only response to an `A`/`AAAA` query is now treated as an empty record set rather than a type-cast error, so the reconciler can recognize the type mismatch and trigger recovery instead of failing.
 - AWS handler — propagate batch errors: submitChanges now wraps the underlying per-batch errors (errors.Join + %w) instead of reporting an opaque "N changes failed" message, preserving the throttling classification through the chain.
 
*Test plan*                                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                            
  - New table-driven tests in pkg/dnsman2/dns/utils/dnsquery_test.go cover `CNAME` shadowing for `A`/`AAAA` queries, mixed answers, NXDOMAIN, and inverse mismatches.
  - New context record-type drift recovery in reconciler_test.go covers:
    - `A` entry recovers when a foreign `CNAME` shadows the same name
    - `A` entry recovers when a foreign `AAAA` exists at the same name
    - `CNAME` entry recovers when a foreign `A` exists at the same name
    - `TXT` entry leaves a co-located foreign `A` record untouched (no expansion)                                                                                                                                                                                                                                                               
  - Defaults test asserts `DriftCheckPeriod` defaults to `12h` and is not overwritten when set.    


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
