### PR TITLE
[dnsman-nextgen] Start lookup processor

### DIFF
--- a/pkg/dnsman2/controller/controlplane/dnsentry/add.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/add.go
@@ -64,6 +64,9 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, controlPlaneCluster clust
 		15*time.Second,
 	)
 	r.defaultCNAMELookupInterval = ptr.Deref(r.Config.DefaultCNAMELookupInterval, 600)
+	if err := mgr.Add(r.lookupProcessor); err != nil {
+		return err
+	}
 	r.setReconciliationDelayAfterUpdate(ptr.Deref(r.Config.ReconciliationDelayAfterUpdate, metav1.Duration{Duration: defaultReconciliationDelayAfterUpdate}).Duration)
 	bld := builder.
 		ControllerManagedBy(mgr).

--- a/pkg/dnsman2/controller/controlplane/dnsentry/lookup/processor.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/lookup/processor.go
@@ -17,17 +17,18 @@ import (
 	"go.uber.org/atomic"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 // LookupProcessor is an interface that defines methods for processing periodic DNS lookups for DNS entry targets.
 type LookupProcessor interface {
+	manager.Runnable
+
 	// Upsert inserts or updates a lookup job for the given object name.
 	Upsert(ctx context.Context, name client.ObjectKey, results LookupAllResults, interval time.Duration)
 	// Delete removes the lookup job for the given object name.
 	Delete(name client.ObjectKey)
 
-	// Run starts the lookup processor, which periodically checks for jobs to run.
-	Run(ctx context.Context)
 	// IsRunning returns true if the processor is running.
 	IsRunning() bool
 }
@@ -197,7 +198,7 @@ func (p *lookupProcessor) Delete(name client.ObjectKey) {
 	p.metrics.ReportCurrentJobCount(len(p.queue))
 }
 
-func (p *lookupProcessor) Run(ctx context.Context) {
+func (p *lookupProcessor) Start(ctx context.Context) error {
 	p.running.Store(true)
 	defer p.running.Store(false)
 	p.log.Info("starting lookup processor", "slots", p.concurrentJobs)
@@ -206,7 +207,7 @@ func (p *lookupProcessor) Run(ctx context.Context) {
 	for {
 		if err := sleep(ctx, nextCheck); err != nil {
 			p.log.Info("lookup processor stopped", "error", ctx.Err())
-			return
+			return nil
 		}
 		nextCheckTime, skipped := p.runJob(ctx)
 		if skipped != nil {

--- a/pkg/dnsman2/controller/controlplane/dnsentry/lookup/processor_test.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/lookup/processor_test.go
@@ -96,6 +96,12 @@ var _ = ginkgov2.Describe("Lookup processor", func() {
 			time.Sleep(10 * quantum)
 			Expect(processor.running.Load()).To(BeFalse())
 		}
+
+		startProcessor = func() {
+			go func() {
+				_ = processor.Start(ctx)
+			}()
+		}
 	)
 
 	ginkgov2.BeforeEach(func() {
@@ -189,7 +195,7 @@ var _ = ginkgov2.Describe("Lookup processor", func() {
 	})
 
 	ginkgov2.It("performs multiple lookup jobs regularly", func() {
-		go processor.Run(ctx)
+		startProcessor()
 		processor.Upsert(ctx, nameE1, LookupAllHostnamesIPs(ctx, "host1"), 1*quantum)
 		processor.Upsert(ctx, nameE2, LookupAllHostnamesIPs(ctx, "host2"), 2*quantum)
 		processor.Upsert(ctx, nameE3, LookupAllHostnamesIPs(ctx, "host3a", "host3b", "host3c"), 3*quantum)
@@ -218,7 +224,7 @@ var _ = ginkgov2.Describe("Lookup processor", func() {
 
 	ginkgov2.It("performs multiple lookup jobs but skips on overload", func() {
 		mlh.delay = 19 * quantum / 10
-		go processor.Run(ctx)
+		startProcessor()
 		processor.Upsert(ctx, nameE1, LookupAllHostnamesIPs(ctx, "host1"), 1*quantum)
 		processor.Upsert(ctx, nameE3, LookupAllHostnamesIPs(ctx, "host3a", "host3b", "host3c"), 1*quantum)
 		time.Sleep(processor.checkPeriod)
@@ -240,7 +246,7 @@ var _ = ginkgov2.Describe("Lookup processor", func() {
 
 	ginkgov2.It("performs multiple lookup jobs and enqueues keys on lookup changes", func() {
 		changedIP := net.ParseIP("1.1.1.42")
-		go processor.Run(ctx)
+		startProcessor()
 		processor.Upsert(ctx, nameE1, LookupAllHostnamesIPs(ctx, "host1"), 1*quantum)
 		processor.Upsert(ctx, nameE2, LookupAllHostnamesIPs(ctx, "host2"), 1*quantum)
 		processor.Upsert(ctx, nameE3, LookupAllHostnamesIPs(ctx, "host3a", "host3b", "host3c"), 1*quantum)

--- a/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_reconcile.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_reconcile.go
@@ -38,13 +38,14 @@ type entryReconciliation struct {
 }
 
 type newTargetsData struct {
-	providerKey   client.ObjectKey
-	providerType  string
-	zoneID        dns.ZoneID
-	dnsSet        *dns.DNSSet
-	targets       dns.Targets
-	routingPolicy *dns.RoutingPolicy
-	warnings      []string
+	providerKey    client.ObjectKey
+	providerType   string
+	zoneID         dns.ZoneID
+	dnsSet         *dns.DNSSet
+	targets        dns.Targets
+	routingPolicy  *dns.RoutingPolicy
+	warnings       []string
+	lookupInterval *int64
 }
 
 type zonedRequests = map[dns.ZoneID]map[dns.DNSSetName]*provider.ChangeRequests
@@ -245,6 +246,7 @@ func (r *entryReconciliation) updateStatusWithProvider(targetsData *newTargetsDa
 		} else {
 			status.TTL = nil
 		}
+		status.CNameLookupInterval = targetsData.lookupInterval
 
 		status.ObservedGeneration = r.Entry.Generation
 		status.State = v1alpha1.StateReady
@@ -346,13 +348,14 @@ func (r *entryReconciliation) calcNewTargets(providerData *providerselector.NewP
 		newTargets = nil
 	}
 	return &newTargetsData{
-		providerKey:   providerData.ProviderKey,
-		providerType:  providerData.Provider.Spec.Type,
-		zoneID:        newZoneID,
-		dnsSet:        newDNSSet,
-		targets:       newTargets,
-		routingPolicy: rp,
-		warnings:      result.Warnings,
+		providerKey:    providerData.ProviderKey,
+		providerType:   providerData.Provider.Spec.Type,
+		zoneID:         newZoneID,
+		dnsSet:         newDNSSet,
+		targets:        newTargets,
+		routingPolicy:  rp,
+		warnings:       result.Warnings,
+		lookupInterval: result.LookupInterval,
 	}, nil
 }
 

--- a/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_test.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_test.go
@@ -359,7 +359,9 @@ var _ = Describe("Reconcile", func() {
 			ctxCancel()
 			Eventually(reconciler.lookupProcessor.IsRunning).WithPolling(1 * time.Millisecond).WithTimeout(500 * time.Millisecond).Should(BeFalse())
 		}
-		go reconciler.lookupProcessor.Run(lookupCtx)
+		go func() {
+			_ = reconciler.lookupProcessor.Start(lookupCtx)
+		}()
 
 		Expect(fakeClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test"}})).To(Succeed())
 

--- a/pkg/dnsman2/controller/controlplane/dnsentry/targets/targets.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/targets/targets.go
@@ -27,9 +27,10 @@ const maxCNAMETargets = 25
 
 // TargetsResult holds the result of extracting targets from a DNSEntrySpec.
 type TargetsResult struct {
-	EntryKey client.ObjectKey
-	Targets  dns.Targets
-	Warnings []string
+	EntryKey       client.ObjectKey
+	Targets        dns.Targets
+	Warnings       []string
+	LookupInterval *int64
 }
 
 // AddTarget adds a target to the TargetsResult, avoiding duplicates and adding a warning if duplicate.
@@ -143,7 +144,6 @@ func (p *TargetsProducer) FromSpec(key client.ObjectKey, spec *v1alpha1.DNSEntry
 		if err != nil {
 			return
 		}
-		// TODO(MartinWeindel) update lookup processor, retrieve addresses for CNAME targets
 	} else {
 		err = p.deleteLookupJob(key)
 		if err != nil {
@@ -195,6 +195,7 @@ func (p *TargetsProducer) upsertLookupJob(ctx context.Context, key client.Object
 		resolvedTargets = append(resolvedTargets, dns.NewTarget(dns.TypeAAAA, ip, ttl))
 	}
 	result.Targets = resolvedTargets
+	result.LookupInterval = &lookupInterval
 	return nil
 }
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
For the next-generation dns-controller-manager, the lookup processor needs to be started by the controller-runtime manager.
It was only started in the tests.
Additionally, the status field `cnameLookupInterval` was not set.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
