### PR TITLE
[next-generation] Introduce `propagationWaitTime` for dnsentry controller

### DIFF
--- a/docs/api-reference/config.md
+++ b/docs/api-reference/config.md
@@ -385,6 +385,18 @@ integer
 </tr>
 <tr>
 <td>
+<code>propagationWaitTime</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#duration-v1-meta">Duration</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PropagationWaitTime is the duration to wait after a DNSEntry object has been updated before its old/new domain names are allowed to be reconciled again.<br />This avoids potential phantom reads from authoritative DNS servers. Default value is 10 seconds.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>reconciliationDelayAfterUpdate</code></br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#duration-v1-meta">Duration</a>

--- a/pkg/dnsman2/apis/config/types.go
+++ b/pkg/dnsman2/apis/config/types.go
@@ -156,6 +156,9 @@ type DNSEntryControllerConfig struct {
 	MaxConcurrentLookups *int
 	// DefaultCNAMELookupInterval is the default interval for CNAME lookups in seconds.
 	DefaultCNAMELookupInterval *int64
+	// PropagationWaitTime is the duration to wait after a DNSEntry object has been updated before its old/new domain names are allowed to be reconciled again.
+	// This avoids potential phantom reads from authoritative DNS servers. Default value is 10 seconds.
+	PropagationWaitTime *metav1.Duration
 	// ReconciliationDelayAfterUpdate is the duration to wait after a DNSEntry object has been updated before its reconciliation is performed.
 	ReconciliationDelayAfterUpdate *metav1.Duration
 	// ZoneMetricsInterval is the interval for refreshing the per-zone DNS entry count metrics.

--- a/pkg/dnsman2/apis/config/v1alpha1/defaults.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/defaults.go
@@ -151,6 +151,9 @@ func SetDefaults_DNSEntryControllerConfig(obj *DNSEntryControllerConfig) {
 	if obj.ZoneMetricsInterval == nil {
 		obj.ZoneMetricsInterval = &metav1.Duration{Duration: 30 * time.Second}
 	}
+	if obj.PropagationWaitTime == nil {
+		obj.PropagationWaitTime = &metav1.Duration{Duration: 10 * time.Second}
+	}
 }
 
 // SetDefaults_SourceControllerConfig sets defaults for the SourceControllerConfig object.

--- a/pkg/dnsman2/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/defaults_test.go
@@ -197,6 +197,7 @@ var _ = Describe("Defaults", func() {
 					Expect(obj.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Hour})))
 					Expect(obj.ReconciliationTimeout).To(PointTo(Equal(metav1.Duration{Duration: 2 * time.Minute})))
 					Expect(obj.ZoneMetricsInterval).To(PointTo(Equal(metav1.Duration{Duration: 30 * time.Second})))
+					Expect(obj.PropagationWaitTime).To(PointTo(Equal(metav1.Duration{Duration: 10 * time.Second})))
 				})
 
 				It("should not overwrite existing values", func() {
@@ -205,6 +206,7 @@ var _ = Describe("Defaults", func() {
 						SyncPeriod:            &metav1.Duration{Duration: 0 * time.Second},
 						ReconciliationTimeout: &metav1.Duration{Duration: 30 * time.Second},
 						ZoneMetricsInterval:   &metav1.Duration{Duration: 0},
+						PropagationWaitTime:   &metav1.Duration{Duration: 5 * time.Second},
 					}
 
 					SetDefaults_DNSEntryControllerConfig(obj)
@@ -213,6 +215,7 @@ var _ = Describe("Defaults", func() {
 					Expect(obj.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 0})))
 					Expect(obj.ReconciliationTimeout).To(PointTo(Equal(metav1.Duration{Duration: 30 * time.Second})))
 					Expect(obj.ZoneMetricsInterval).To(PointTo(Equal(metav1.Duration{Duration: 0})))
+					Expect(obj.PropagationWaitTime).To(PointTo(Equal(metav1.Duration{Duration: 5 * time.Second})))
 				})
 			})
 			Describe("Source controller", func() {

--- a/pkg/dnsman2/apis/config/v1alpha1/types.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/types.go
@@ -184,6 +184,10 @@ type DNSEntryControllerConfig struct {
 	// DefaultCNAMELookupInterval is the default interval for CNAME lookups in seconds.
 	// +optional
 	DefaultCNAMELookupInterval *int64 `json:"defaultCNAMELookupInterval,omitempty"`
+	// PropagationWaitTime is the duration to wait after a DNSEntry object has been updated before its old/new domain names are allowed to be reconciled again.
+	// This avoids potential phantom reads from authoritative DNS servers. Default value is 10 seconds.
+	// +optional
+	PropagationWaitTime *metav1.Duration `json:"propagationWaitTime,omitempty"`
 	// ReconciliationDelayAfterUpdate is the duration to wait after a DNSEntry object has been updated before its reconciliation is performed.
 	// +optional
 	ReconciliationDelayAfterUpdate *metav1.Duration `json:"reconciliationDelayAfterUpdate,omitempty"`

--- a/pkg/dnsman2/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/zz_generated.conversion.go
@@ -299,6 +299,7 @@ func autoConvert_v1alpha1_DNSEntryControllerConfig_To_config_DNSEntryControllerC
 	out.ReconciliationTimeout = (*v1.Duration)(unsafe.Pointer(in.ReconciliationTimeout))
 	out.MaxConcurrentLookups = (*int)(unsafe.Pointer(in.MaxConcurrentLookups))
 	out.DefaultCNAMELookupInterval = (*int64)(unsafe.Pointer(in.DefaultCNAMELookupInterval))
+	out.PropagationWaitTime = (*v1.Duration)(unsafe.Pointer(in.PropagationWaitTime))
 	out.ReconciliationDelayAfterUpdate = (*v1.Duration)(unsafe.Pointer(in.ReconciliationDelayAfterUpdate))
 	out.ZoneMetricsInterval = (*v1.Duration)(unsafe.Pointer(in.ZoneMetricsInterval))
 	return nil
@@ -315,6 +316,7 @@ func autoConvert_config_DNSEntryControllerConfig_To_v1alpha1_DNSEntryControllerC
 	out.ReconciliationTimeout = (*v1.Duration)(unsafe.Pointer(in.ReconciliationTimeout))
 	out.MaxConcurrentLookups = (*int)(unsafe.Pointer(in.MaxConcurrentLookups))
 	out.DefaultCNAMELookupInterval = (*int64)(unsafe.Pointer(in.DefaultCNAMELookupInterval))
+	out.PropagationWaitTime = (*v1.Duration)(unsafe.Pointer(in.PropagationWaitTime))
 	out.ReconciliationDelayAfterUpdate = (*v1.Duration)(unsafe.Pointer(in.ReconciliationDelayAfterUpdate))
 	out.ZoneMetricsInterval = (*v1.Duration)(unsafe.Pointer(in.ZoneMetricsInterval))
 	return nil

--- a/pkg/dnsman2/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -168,6 +168,11 @@ func (in *DNSEntryControllerConfig) DeepCopyInto(out *DNSEntryControllerConfig) 
 		*out = new(int64)
 		**out = **in
 	}
+	if in.PropagationWaitTime != nil {
+		in, out := &in.PropagationWaitTime, &out.PropagationWaitTime
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.ReconciliationDelayAfterUpdate != nil {
 		in, out := &in.ReconciliationDelayAfterUpdate, &out.ReconciliationDelayAfterUpdate
 		*out = new(v1.Duration)

--- a/pkg/dnsman2/apis/config/zz_generated.deepcopy.go
+++ b/pkg/dnsman2/apis/config/zz_generated.deepcopy.go
@@ -168,6 +168,11 @@ func (in *DNSEntryControllerConfig) DeepCopyInto(out *DNSEntryControllerConfig) 
 		*out = new(int64)
 		**out = **in
 	}
+	if in.PropagationWaitTime != nil {
+		in, out := &in.PropagationWaitTime, &out.PropagationWaitTime
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.ReconciliationDelayAfterUpdate != nil {
 		in, out := &in.ReconciliationDelayAfterUpdate, &out.ReconciliationDelayAfterUpdate
 		*out = new(v1.Duration)

--- a/pkg/dnsman2/controller/controlplane/dnsentry/reconciler.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/reconciler.go
@@ -81,6 +81,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		},
 		namespace:                  r.Namespace,
 		migrationMode:              r.MigrationMode,
+		propagationWaitTime:        ptr.Deref(r.Config.PropagationWaitTime, metav1.Duration{}).Duration,
 		lookupProcessor:            r.lookupProcessor,
 		state:                      r.state,
 		defaultCNAMELookupInterval: r.defaultCNAMELookupInterval,

--- a/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_reconcile.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_reconcile.go
@@ -32,6 +32,7 @@ type entryReconciliation struct {
 	namespace                  string
 	migrationMode              bool
 	state                      *state.State
+	propagationWaitTime        time.Duration
 	lookupProcessor            lookup.LookupProcessor
 	defaultCNAMELookupInterval int64
 	lastUpdate                 *ttlcache.Cache[client.ObjectKey, struct{}]
@@ -81,11 +82,17 @@ func (r *entryReconciliation) doReconcile() common.ReconcileResult {
 		return *res
 	}
 
-	unlockFunc, res := r.lockDNSNames()
+	names, res := r.acquireDNSNameLock()
 	if res != nil {
 		return *res
 	}
-	defer unlockFunc()
+	// If a DNS change is applied, reservation is set to propagationWaitTime so
+	// the deferred release keeps the names reserved for that duration; other
+	// reconciles for the same names will requeue until the reservation expires.
+	var reservation time.Duration
+	defer func() {
+		r.state.GetDNSNameLocking().UnlockWithExpiry(reservation, names...)
+	}()
 
 	if err := validateDNSEntry(r.Entry); err != nil {
 		return *common.InvalidReconcileResult(fmt.Sprintf("validation failed: %s", err))
@@ -125,6 +132,9 @@ func (r *entryReconciliation) doReconcile() common.ReconcileResult {
 	if res := r.dnsRecordManager().ApplyChangeRequests(newProviderData, zonedRequests); res != nil {
 		return *res
 	}
+	if len(zonedRequests) > 0 {
+		reservation = r.propagationWaitTime
+	}
 
 	return r.updateStatusWithProvider(targetsData)
 }
@@ -157,18 +167,21 @@ func (r *entryReconciliation) needsToMigrateDNSClassOrFinalizers() bool {
 	return dns.HasSecondaryClassFinalizerNames(r.Entry, r.SecondaryClasses)
 }
 
-func (r *entryReconciliation) lockDNSNames() (func(), *common.ReconcileResult) {
+func (r *entryReconciliation) acquireDNSNameLock() ([]string, *common.ReconcileResult) {
 	names := getDNSNames(r.Entry.Spec.DNSName, r.Entry.Status.DNSName)
 	locking := r.state.GetDNSNameLocking()
-	if !locking.Lock(names...) {
-		// already locked by another entry, requeue
+	ok, retryAfter := locking.Lock(names...)
+	if !ok {
+		// already locked by another entry or reserved during DNS propagation, requeue
+		jitter := time.Duration(rand.Intn(500)) * time.Millisecond
+		if retryAfter <= 0 {
+			retryAfter = 3 * time.Second
+		}
 		return nil, &common.ReconcileResult{
-			Result: reconcile.Result{RequeueAfter: 3*time.Second + time.Duration(rand.Intn(500))*time.Millisecond},
+			Result: reconcile.Result{RequeueAfter: retryAfter + jitter},
 		}
 	}
-	return func() {
-		locking.Unlock(names...)
-	}, nil
+	return names, nil
 }
 
 func validateDNSEntry(entry *v1alpha1.DNSEntry) error {
@@ -379,7 +392,7 @@ func (r *entryReconciliation) clearDNSCaches(zonedRequests zonedRequests) {
 				keys = append(keys, utils.RecordSetKey{Name: name, RecordType: recordType})
 			}
 		}
-		if err := r.state.ClearDNSCaches(r.Ctx, zoneID, keys...); err != nil {
+		if err := r.state.ClearDNSCaches(r.Ctx, r.Log, zoneID, keys...); err != nil {
 			r.Log.Error(err, "failed to clear DNS caches for zone", "zoneID", zoneID.ID)
 		}
 	}

--- a/pkg/dnsman2/controller/controlplane/dnsentry/records/dnsrecordmanager.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/records/dnsrecordmanager.go
@@ -82,7 +82,7 @@ func (m *DNSRecordManager) QueryRecords(ctx context.Context, keys FullRecordKeyS
 			if key.ZoneID != zoneID {
 				continue
 			}
-			targets, policy, err := queryHandler.Query(m.Ctx, key.Name, key.RecordType)
+			targets, policy, err := queryHandler.Query(m.Ctx, m.Log, key.Name, key.RecordType)
 			if err != nil {
 				m.Log.Error(err, "failed to query DNS records", "name", key.Name, "type", key.RecordType, "zoneID", zoneID.ID)
 				return nil, common.ErrorReconcileResult(fmt.Sprintf("failed to query DNS records for %s, type %s in zone %s: %s", key.Name, key.RecordType, zoneID.ID, err), true)

--- a/pkg/dnsman2/dns/provider/account.go
+++ b/pkg/dnsman2/dns/provider/account.go
@@ -44,6 +44,8 @@ type DNSAccountConfig struct {
 	GlobalConfig *config.DNSManagerConfiguration
 }
 
+const defaultDNSCacheTTL = 5 * time.Second
+
 // DNSAccount represents a DNS account.
 type DNSAccount struct {
 	*utils.RateLimiter
@@ -154,14 +156,18 @@ func (a *DNSAccount) getZoneQueryCache(ctx context.Context, zone dns.ZoneInfo) (
 		if err != nil {
 			return nil, fmt.Errorf("failed to get custom query DNS function for zone %s: %w", zone.ZoneID(), err)
 		}
+		ttl := defaultDNSCacheTTL
+		if a.config.GlobalConfig != nil && a.config.GlobalConfig.Controllers.DNSEntry.PropagationWaitTime != nil {
+			ttl = max(a.config.GlobalConfig.Controllers.DNSEntry.PropagationWaitTime.Duration, defaultDNSCacheTTL)
+		}
 		if queryFunc != nil {
-			cache = utils.NewDNSCache(&handlerZoneQueryDNS{queryFunc: queryFunc, zone: zone}, 30*time.Second) // TODO set default TTL
+			cache = utils.NewDNSCache(&handlerZoneQueryDNS{queryFunc: queryFunc, zone: zone}, ttl)
 		} else {
 			dnsQuery, err := factory()
 			if err != nil {
 				return nil, err
 			}
-			cache = utils.NewDNSCache(dnsQuery, 30*time.Second) // TODO set default TTL
+			cache = utils.NewDNSCache(dnsQuery, ttl)
 		}
 		a.dnsCaches[zone.ZoneID()] = cache
 	}

--- a/pkg/dnsman2/dns/state/dnsnamelocking.go
+++ b/pkg/dnsman2/dns/state/dnsnamelocking.go
@@ -5,46 +5,94 @@
 package state
 
 import (
-	"slices"
 	"sync"
+	"time"
 
-	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/clock"
 )
 
 type dnsNameLocking struct {
-	lock        sync.Mutex
-	lockedNames sets.Set[string]
+	clock clock.Clock
+	lock  sync.Mutex
+	// lockedNames maps a DNS name to its lock expiry. A zero time means the name is
+	// actively held by an in-progress reconciliation; a non-zero time means the name
+	// is reserved until that instant (e.g. for DNS propagation) but no goroutine is
+	// currently holding it.
+	lockedNames map[string]time.Time
 }
 
-// newDNSNameLocking creates a new instance of dnsNameLocking.
-func newDNSNameLocking() *dnsNameLocking {
+// newDNSNameLocking creates a new instance of dnsNameLocking using the given clock.
+func newDNSNameLocking(c clock.Clock) *dnsNameLocking {
 	return &dnsNameLocking{
-		lockedNames: sets.New[string](),
+		clock:       c,
+		lockedNames: map[string]time.Time{},
 	}
 }
 
-// Lock locks the given DNS names. It returns true if all names were successfully locked,
-// If true, they must be unlocked later using Unlock.
-func (d *dnsNameLocking) Lock(names ...string) bool {
+// Lock attempts to lock the given DNS names for an in-progress reconciliation.
+// On success it returns (true, 0) and the caller must release the names later
+// via Unlock or UnlockWithExpiry.
+// On contention it returns (false, retryAfter) where retryAfter is the time
+// until the latest blocking reservation is expected to expire (or 0 if blocked
+// by another in-progress holder).
+func (d *dnsNameLocking) Lock(names ...string) (bool, time.Duration) {
 	d.lock.Lock()
 	defer d.lock.Unlock()
 
-	if slices.ContainsFunc(names, d.lockedNames.Has) {
-		return false // name is already locked
+	now := d.clock.Now()
+	var retryAfter time.Duration
+	for _, name := range names {
+		exp, ok := d.lockedNames[name]
+		if !ok {
+			continue
+		}
+		if exp.IsZero() {
+			// in-progress holder; no known release time
+			return false, 0
+		}
+		if exp.After(now) {
+			if remaining := exp.Sub(now); remaining > retryAfter {
+				retryAfter = remaining
+			}
+			continue
+		}
+		// expired reservation, treat as free
+	}
+	if retryAfter > 0 {
+		return false, retryAfter
 	}
 
 	for _, name := range names {
-		d.lockedNames.Insert(name)
+		d.lockedNames[name] = time.Time{}
 	}
-	return true // Successfully locked all names
+	return true, 0
 }
 
-// Unlock unlocks the given DNS names.
+// Unlock releases the given DNS names immediately.
 func (d *dnsNameLocking) Unlock(names ...string) {
 	d.lock.Lock()
 	defer d.lock.Unlock()
 
 	for _, name := range names {
-		d.lockedNames.Delete(name)
+		delete(d.lockedNames, name)
+	}
+}
+
+// UnlockWithExpiry releases the given DNS names but keeps them reserved for
+// the given duration so that subsequent Lock attempts on the same names fail
+// (and requeue) until the reservation expires. Use this after a successful
+// DNS change to gate other reconciliations until the change has propagated.
+// A non-positive duration behaves like Unlock.
+func (d *dnsNameLocking) UnlockWithExpiry(reservation time.Duration, names ...string) {
+	if reservation <= 0 {
+		d.Unlock(names...)
+		return
+	}
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	expiry := d.clock.Now().Add(reservation)
+	for _, name := range names {
+		d.lockedNames[name] = expiry
 	}
 }

--- a/pkg/dnsman2/dns/state/dnsnamelocking_test.go
+++ b/pkg/dnsman2/dns/state/dnsnamelocking_test.go
@@ -1,0 +1,260 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package state
+
+import (
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/clock"
+	"k8s.io/utils/clock/testing"
+)
+
+var _ = Describe("dnsNameLocking", func() {
+	var (
+		fakeClock *testing.FakeClock
+		locking   *dnsNameLocking
+	)
+
+	BeforeEach(func() {
+		fakeClock = testing.NewFakeClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+		locking = newDNSNameLocking(fakeClock)
+	})
+
+	Describe("Lock", func() {
+		It("locks free names and returns (true, 0)", func() {
+			ok, retry := locking.Lock("a.example.com", "b.example.com")
+			Expect(ok).To(BeTrue())
+			Expect(retry).To(Equal(time.Duration(0)))
+		})
+
+		It("returns (false, 0) when blocked by an in-progress holder", func() {
+			ok, _ := locking.Lock("a.example.com")
+			Expect(ok).To(BeTrue())
+
+			ok2, retry := locking.Lock("a.example.com")
+			Expect(ok2).To(BeFalse())
+			Expect(retry).To(Equal(time.Duration(0)))
+		})
+
+		It("fails if any one of multiple names is held in-progress", func() {
+			ok, _ := locking.Lock("a.example.com")
+			Expect(ok).To(BeTrue())
+
+			ok2, retry := locking.Lock("b.example.com", "a.example.com", "c.example.com")
+			Expect(ok2).To(BeFalse())
+			Expect(retry).To(Equal(time.Duration(0)))
+
+			// none of the unrelated names should have been claimed by the failed call
+			ok3, _ := locking.Lock("b.example.com")
+			Expect(ok3).To(BeTrue())
+			ok4, _ := locking.Lock("c.example.com")
+			Expect(ok4).To(BeTrue())
+		})
+
+		It("returns retryAfter equal to the remaining reservation", func() {
+			ok, _ := locking.Lock("a.example.com")
+			Expect(ok).To(BeTrue())
+			locking.UnlockWithExpiry(200*time.Millisecond, "a.example.com")
+
+			ok2, retry := locking.Lock("a.example.com")
+			Expect(ok2).To(BeFalse())
+			Expect(retry).To(Equal(200 * time.Millisecond))
+
+			fakeClock.Step(50 * time.Millisecond)
+			ok3, retry2 := locking.Lock("a.example.com")
+			Expect(ok3).To(BeFalse())
+			Expect(retry2).To(Equal(150 * time.Millisecond))
+		})
+
+		It("returns the largest retryAfter across multiple reserved names", func() {
+			ok, _ := locking.Lock("a.example.com", "b.example.com")
+			Expect(ok).To(BeTrue())
+			locking.UnlockWithExpiry(50*time.Millisecond, "a.example.com")
+			locking.UnlockWithExpiry(300*time.Millisecond, "b.example.com")
+
+			ok2, retry := locking.Lock("a.example.com", "b.example.com")
+			Expect(ok2).To(BeFalse())
+			Expect(retry).To(Equal(300 * time.Millisecond))
+		})
+
+		It("succeeds once all reservations have expired", func() {
+			ok, _ := locking.Lock("a.example.com")
+			Expect(ok).To(BeTrue())
+			locking.UnlockWithExpiry(100*time.Millisecond, "a.example.com")
+
+			ok2, _ := locking.Lock("a.example.com")
+			Expect(ok2).To(BeFalse())
+
+			fakeClock.Step(100 * time.Millisecond)
+			ok3, retry := locking.Lock("a.example.com")
+			Expect(ok3).To(BeTrue())
+			Expect(retry).To(Equal(time.Duration(0)))
+		})
+
+		It("supports re-locking after Unlock", func() {
+			ok, _ := locking.Lock("a.example.com")
+			Expect(ok).To(BeTrue())
+			locking.Unlock("a.example.com")
+
+			ok2, retry := locking.Lock("a.example.com")
+			Expect(ok2).To(BeTrue())
+			Expect(retry).To(Equal(time.Duration(0)))
+		})
+
+		It("treats a no-name call as a no-op success", func() {
+			ok, retry := locking.Lock()
+			Expect(ok).To(BeTrue())
+			Expect(retry).To(Equal(time.Duration(0)))
+		})
+
+		It("prefers the in-progress signal (retry=0) when the request is blocked by both an in-progress holder and a reservation", func() {
+			// reserve "a" with a long expiry, hold "b" in-progress
+			ok, _ := locking.Lock("a.example.com")
+			Expect(ok).To(BeTrue())
+			locking.UnlockWithExpiry(time.Hour, "a.example.com")
+
+			ok2, _ := locking.Lock("b.example.com")
+			Expect(ok2).To(BeTrue())
+
+			// blocked by both: in-progress holder wins -> retry=0
+			ok3, retry := locking.Lock("a.example.com", "b.example.com")
+			Expect(ok3).To(BeFalse())
+			Expect(retry).To(Equal(time.Duration(0)))
+		})
+
+		It("does not claim any names when contended", func() {
+			ok, _ := locking.Lock("held.example.com")
+			Expect(ok).To(BeTrue())
+
+			ok2, _ := locking.Lock("free.example.com", "held.example.com")
+			Expect(ok2).To(BeFalse())
+
+			// "free" must still be acquirable by someone else
+			ok3, _ := locking.Lock("free.example.com")
+			Expect(ok3).To(BeTrue())
+		})
+	})
+
+	Describe("Unlock", func() {
+		It("clears in-progress holds", func() {
+			ok, _ := locking.Lock("a.example.com", "b.example.com")
+			Expect(ok).To(BeTrue())
+			locking.Unlock("a.example.com", "b.example.com")
+
+			ok2, _ := locking.Lock("a.example.com", "b.example.com")
+			Expect(ok2).To(BeTrue())
+		})
+
+		It("is a no-op for unknown names", func() {
+			Expect(func() { locking.Unlock("never-locked.example.com") }).NotTo(Panic())
+		})
+
+		It("does not affect names other than those passed", func() {
+			ok, _ := locking.Lock("a.example.com", "b.example.com")
+			Expect(ok).To(BeTrue())
+			locking.Unlock("a.example.com")
+
+			ok2, retry := locking.Lock("b.example.com")
+			Expect(ok2).To(BeFalse())
+			Expect(retry).To(Equal(time.Duration(0)))
+		})
+
+		It("clears an active reservation", func() {
+			locking.UnlockWithExpiry(time.Hour, "a.example.com")
+
+			ok, _ := locking.Lock("a.example.com")
+			Expect(ok).To(BeFalse())
+
+			locking.Unlock("a.example.com")
+			ok2, _ := locking.Lock("a.example.com")
+			Expect(ok2).To(BeTrue())
+		})
+	})
+
+	Describe("UnlockWithExpiry", func() {
+		It("falls back to immediate Unlock for non-positive durations", func() {
+			ok, _ := locking.Lock("a.example.com")
+			Expect(ok).To(BeTrue())
+			locking.UnlockWithExpiry(0, "a.example.com")
+
+			ok2, _ := locking.Lock("a.example.com")
+			Expect(ok2).To(BeTrue())
+
+			locking.UnlockWithExpiry(-5*time.Second, "a.example.com")
+			ok3, _ := locking.Lock("a.example.com")
+			Expect(ok3).To(BeTrue())
+		})
+
+		It("blocks subsequent locks until the reservation expires", func() {
+			ok, _ := locking.Lock("a.example.com")
+			Expect(ok).To(BeTrue())
+			locking.UnlockWithExpiry(50*time.Millisecond, "a.example.com")
+
+			ok2, retry := locking.Lock("a.example.com")
+			Expect(ok2).To(BeFalse())
+			Expect(retry).To(Equal(50 * time.Millisecond))
+
+			fakeClock.Step(50 * time.Millisecond)
+			ok3, _ := locking.Lock("a.example.com")
+			Expect(ok3).To(BeTrue())
+		})
+
+		It("can be called on names that were not previously held", func() {
+			locking.UnlockWithExpiry(100*time.Millisecond, "fresh.example.com")
+
+			ok, retry := locking.Lock("fresh.example.com")
+			Expect(ok).To(BeFalse())
+			Expect(retry).To(Equal(100 * time.Millisecond))
+		})
+
+		It("overwrites a prior reservation with the new expiry", func() {
+			locking.UnlockWithExpiry(time.Second, "a.example.com")
+			locking.UnlockWithExpiry(10*time.Millisecond, "a.example.com")
+
+			_, retry := locking.Lock("a.example.com")
+			Expect(retry).To(Equal(10 * time.Millisecond))
+		})
+	})
+
+	Describe("concurrency", func() {
+		It("permits exactly one in-progress holder of the same name at any instant", func() {
+			// Use a real clock so multiple goroutines see real time advancing.
+			real := newDNSNameLocking(clock.RealClock{})
+
+			const goroutines = 50
+			var wg sync.WaitGroup
+			var mu sync.Mutex
+			var inFlight, maxInFlight int
+
+			wg.Add(goroutines)
+			for range goroutines {
+				go func() {
+					defer wg.Done()
+					if ok, _ := real.Lock("contested.example.com"); ok {
+						mu.Lock()
+						inFlight++
+						if inFlight > maxInFlight {
+							maxInFlight = inFlight
+						}
+						mu.Unlock()
+						time.Sleep(100 * time.Microsecond)
+						mu.Lock()
+						inFlight--
+						mu.Unlock()
+						real.Unlock("contested.example.com")
+					}
+				}()
+			}
+			wg.Wait()
+
+			Expect(maxInFlight).To(Equal(1))
+			ok, _ := real.Lock("contested.example.com")
+			Expect(ok).To(BeTrue())
+		})
+	})
+})

--- a/pkg/dnsman2/dns/state/state.go
+++ b/pkg/dnsman2/dns/state/state.go
@@ -74,7 +74,7 @@ func newProviderMap() providerMap {
 // DNSQueryHandler defines an interface for querying DNS records.
 type DNSQueryHandler interface {
 	// Query performs either a DNS query to the authoritative nameservers or uses the provider API.
-	Query(ctx context.Context, setName dns.DNSSetName, rstype dns.RecordType) (dns.Targets, *dns.RoutingPolicy, error)
+	Query(ctx context.Context, log logr.Logger, setName dns.DNSSetName, rstype dns.RecordType) (dns.Targets, *dns.RoutingPolicy, error)
 }
 
 // GetOrCreateProviderState returns the ProviderState for the given DNSProvider, creating it if necessary.
@@ -137,13 +137,13 @@ func (s *State) FindAccountForZone(ctx context.Context, zoneID dns.ZoneID) (*pro
 }
 
 // ClearDNSCaches clears the DNS caches for the given zone ID and optional record set keys.
-func (s *State) ClearDNSCaches(ctx context.Context, zoneID dns.ZoneID, keys ...utils.RecordSetKey) error {
+func (s *State) ClearDNSCaches(ctx context.Context, log logr.Logger, zoneID dns.ZoneID, keys ...utils.RecordSetKey) error {
 	caches, err := s.accounts.GetDNSCachesByZone(ctx, zoneID)
 	if err != nil {
 		return err
 	}
 	for _, cache := range caches {
-		cache.ClearKeys(keys...)
+		cache.ClearKeys(log, keys...)
 	}
 	return nil
 }
@@ -187,10 +187,10 @@ func newDNSCachesQueryHandler(dnscaches []*utils.DNSCache) DNSQueryHandler {
 	return &dnsCachesQueryHandler{dnscaches: dnscaches}
 }
 
-func (h *dnsCachesQueryHandler) Query(ctx context.Context, setName dns.DNSSetName, rstype dns.RecordType) (dns.Targets, *dns.RoutingPolicy, error) {
+func (h *dnsCachesQueryHandler) Query(ctx context.Context, log logr.Logger, setName dns.DNSSetName, rstype dns.RecordType) (dns.Targets, *dns.RoutingPolicy, error) {
 	var errs []error
 	for _, cache := range h.dnscaches {
-		rs, err := cache.Get(ctx, setName, rstype)
+		rs, err := cache.Get(ctx, log, setName, rstype)
 		if err != nil {
 			errs = append(errs, err)
 			continue

--- a/pkg/dnsman2/dns/state/state.go
+++ b/pkg/dnsman2/dns/state/state.go
@@ -39,7 +39,7 @@ func GetState() *State {
 	state = &State{
 		providers:         newProviderMap(),
 		accounts:          provider.NewAccountMap(),
-		dnsNameLocking:    newDNSNameLocking(),
+		dnsNameLocking:    newDNSNameLocking(clock.RealClock{}),
 		annotationState:   newAnnotationState(),
 		quotaReservations: newQuotaReservationsMap(clock.RealClock{}, quotaReservationDuration),
 	}

--- a/pkg/dnsman2/dns/utils/dnscache.go
+++ b/pkg/dnsman2/dns/utils/dnscache.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/jellydator/ttlcache/v3"
 
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns"
@@ -17,6 +18,7 @@ import (
 type DNSCache struct {
 	dnsQuery QueryDNS
 	cache    *ttlcache.Cache[RecordSetKey, QueryDNSResult]
+	ttl      time.Duration
 }
 
 // RecordSetKey represents a key for a DNS record set, including name and record type.
@@ -25,30 +27,36 @@ type RecordSetKey struct {
 	RecordType dns.RecordType
 }
 
-const negativeTTL = 15 * time.Second
+func (k RecordSetKey) String() string {
+	return k.Name.String() + "/" + string(k.RecordType)
+}
 
 // NewDNSCache creates a new DNSCache.
-func NewDNSCache(dnsQuery QueryDNS, defaultTTL time.Duration) *DNSCache {
+func NewDNSCache(dnsQuery QueryDNS, ttl time.Duration) *DNSCache {
 	return &DNSCache{
 		dnsQuery: dnsQuery,
 		cache: ttlcache.New[RecordSetKey, QueryDNSResult](
-			ttlcache.WithTTL[RecordSetKey, QueryDNSResult](defaultTTL),
+			ttlcache.WithTTL[RecordSetKey, QueryDNSResult](ttl),
 			ttlcache.WithDisableTouchOnHit[RecordSetKey, QueryDNSResult](),
 		),
+		ttl: ttl,
 	}
 }
 
 // Get returns the DNS records for the given DNS name and record type.
-func (c *DNSCache) Get(ctx context.Context, setName dns.DNSSetName, rstype dns.RecordType) (*dns.RecordSet, error) {
+func (c *DNSCache) Get(ctx context.Context, log logr.Logger, setName dns.DNSSetName, rstype dns.RecordType) (*dns.RecordSet, error) {
 	key := RecordSetKey{Name: setName, RecordType: rstype}
 	item := c.cache.Get(key)
 	if item != nil {
+		log.V(2).Info("found in cache", "key", key)
 		return item.Value().RecordSet, item.Value().Err
 	}
 	result := c.dnsQuery.Query(ctx, setName, rstype)
 	if result.Err != nil || result.RecordSet == nil || len(result.RecordSet.Records) == 0 {
-		c.cache.Set(key, result, negativeTTL)
+		log.V(2).Info("caching negative result", "key", key, "ttl", c.ttl)
+		c.cache.Set(key, result, c.ttl)
 	} else {
+		log.V(2).Info("caching query result", "key", key, "ttl", c.ttl)
 		c.cache.Set(key, result, time.Duration(result.RecordSet.TTL)*time.Second)
 	}
 	return result.RecordSet, result.Err
@@ -60,10 +68,11 @@ func (c *DNSCache) Clear() {
 }
 
 // ClearKeys removes specific keys from the cache.
-func (c *DNSCache) ClearKeys(keys ...RecordSetKey) {
+func (c *DNSCache) ClearKeys(log logr.Logger, keys ...RecordSetKey) {
 	c.cache.DeleteExpired()
 	for _, key := range keys {
 		c.cache.Delete(key)
+		log.V(2).Info("clearing from cache", "key", key)
 	}
 }
 

--- a/pkg/dnsman2/dns/utils/dnscache_test.go
+++ b/pkg/dnsman2/dns/utils/dnscache_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/jellydator/ttlcache/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -49,7 +50,7 @@ var _ = Describe("DNSCache", func() {
 	Describe("Get", func() {
 		It("should query DNS and cache the result if not present", func() {
 			for i := range 7 {
-				rs, err := dnsCache.Get(ctx, dns.DNSSetName{DNSName: "example.com"}, dns.TypeA)
+				rs, err := dnsCache.Get(ctx, logr.Discard(), dns.DNSSetName{DNSName: "example.com"}, dns.TypeA)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(rs).NotTo(BeNil())
 				Expect(rs.TTL).To(Equal(int64(1)))


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind flake

**What this PR does / why we need it**:
## Introduce `propagationWaitTime` for DNSEntry reconciliation
  
  Adds a new `propagationWaitTime` configuration option (default: 10s) to `DNSEntryControllerConfig` that prevents phantom reads from authoritative DNS servers after a DNSEntries is deleted and immediately recreated with same spec.

  ### What changed  

  - **TTL-based DNS name locking**: `dnsNameLocking` is extended from a simple in-progress mutex to a TTL-based lock. After a successful DNS change, the affected names remain reserved for `propagationWaitTime`. Any concurrent reconcile for the same name receives a precise `RequeueAfter` based on the remaining reservation rather.
  - **DNS cache TTL**: The per-zone DNS query cache TTL is set to `max(propagationWaitTime, 5s)` instead of the previous hard-coded 30s, ensuring cached results stay valid at least through the propagation window.
  - **Trace logging**: `DNSCache.Get` and `ClearKeys` now accept a `logr.Logger` and emit `V(2)` cache hit/miss/clear events. The `DNSQueryHandler.Query` interface is updated accordingly.
  - **Tests**: Full unit test coverage for `dnsNameLocking` using a fake clock (20 specs). 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
[next-generation] Adds a new `propagationWaitTime` configuration option (default: 10s) to `DNSEntryControllerConfig` that prevents phantom reads from authoritative DNS servers after a DNSEntries is deleted and immediately recreated with same spec.
```
