### PR TITLE
[next-generation] use the default finalizer `dns.gardener.cloud/compound` instead of `gardendns-next-gen.dns.gardener.cloud/compound`

### DIFF
--- a/pkg/dnsman2/dns/class.go
+++ b/pkg/dnsman2/dns/class.go
@@ -62,6 +62,11 @@ func IsDefaultClass(class string) bool {
 	return NormalizeClass(class) == DefaultClass
 }
 
+// IsNextGenMigrationClass returns true if the provided class is the next-generation migration class.
+func IsNextGenMigrationClass(class string) bool {
+	return NormalizeClass(class) == NextGenMigrationClass
+}
+
 // EquivalentClass returns true if the annotation class are equivalent, i.e. equal after normalizing.
 func EquivalentClass(cls1, cls2 string) bool {
 	return NormalizeClass(cls1) == NormalizeClass(cls2)
@@ -69,7 +74,7 @@ func EquivalentClass(cls1, cls2 string) bool {
 
 // ClassFinalizerName returns the finalizer name for the provided class, which is either the default finalizer or the class name followed by the default finalizer.
 func ClassFinalizerName(class string) string {
-	if IsDefaultClass(class) {
+	if IsDefaultClass(class) || IsNextGenMigrationClass(class) {
 		return FinalizerCompound
 	}
 	return class + "." + FinalizerCompound
@@ -82,6 +87,12 @@ func HasSecondaryClassFinalizerNames(obj client.Object, secondaryClasses []strin
 			return true
 		}
 	}
+
+	// TODO(MartinWeindel) remove this cleanup code for the obsolete gardendns-next-gen finalizer after release v0.45.0
+	if slices.Contains(obj.GetFinalizers(), NextGenMigrationFinalizerCompound) {
+		return true
+	}
+
 	return false
 }
 
@@ -91,6 +102,10 @@ func MigrateSecondaryClassFinalizers(obj client.Object, class string, secondaryC
 	for _, secondaryClass := range secondaryClasses {
 		finalizers = slices.DeleteFunc(finalizers, func(f string) bool { return f == ClassFinalizerName(secondaryClass) })
 	}
+
+	// TODO(MartinWeindel) remove this cleanup code for the obsolete gardendns-next-gen finalizer after release v0.45.0
+	finalizers = slices.DeleteFunc(finalizers, func(f string) bool { return f == NextGenMigrationFinalizerCompound })
+
 	if !slices.Contains(finalizers, ClassFinalizerName(class)) {
 		finalizers = append(finalizers, ClassFinalizerName(class))
 	}

--- a/pkg/dnsman2/dns/class_test.go
+++ b/pkg/dnsman2/dns/class_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Class", func() {
 			},
 			Entry("empty class returns default finalizer", "", FinalizerCompound),
 			Entry("default class returns default finalizer", DefaultClass, FinalizerCompound),
-			Entry("next-generation migration class returns default finalizer", DefaultClass, FinalizerCompound),
+			Entry("next-generation migration class returns default finalizer", NextGenMigrationClass, FinalizerCompound),
 			Entry("custom class prefixes finalizer", "myclass", "myclass."+FinalizerCompound),
 			Entry("another custom class", "secondary", "secondary."+FinalizerCompound),
 		)

--- a/pkg/dnsman2/dns/class_test.go
+++ b/pkg/dnsman2/dns/class_test.go
@@ -21,8 +21,21 @@ var _ = Describe("Class", func() {
 			},
 			Entry("empty string", "", true),
 			Entry("default class name", DefaultClass, true),
+			Entry("next-gen migration class is not default", NextGenMigrationClass, false),
 			Entry("non-default class", "customclass", false),
 			Entry("similar but different", "gardendns2", false),
+		)
+	})
+
+	Describe("#IsNextGenMigrationClass", func() {
+		DescribeTable("should return true for next-gen migration class variants",
+			func(class string, expected bool) {
+				Expect(IsNextGenMigrationClass(class)).To(Equal(expected))
+			},
+			Entry("empty string", "", false),
+			Entry("default class name is not next-gen", DefaultClass, false),
+			Entry("next generation migration class name", NextGenMigrationClass, true),
+			Entry("non-default class", "customclass", false),
 		)
 	})
 
@@ -48,6 +61,7 @@ var _ = Describe("Class", func() {
 			},
 			Entry("empty class returns default finalizer", "", FinalizerCompound),
 			Entry("default class returns default finalizer", DefaultClass, FinalizerCompound),
+			Entry("next-generation migration class returns default finalizer", DefaultClass, FinalizerCompound),
 			Entry("custom class prefixes finalizer", "myclass", "myclass."+FinalizerCompound),
 			Entry("another custom class", "secondary", "secondary."+FinalizerCompound),
 		)
@@ -94,6 +108,7 @@ var _ = Describe("Class", func() {
 
 		It("should work with default class", func() {
 			obj := newEntry(ClassFinalizerName("secondary1"))
+			Expect(HasSecondaryClassFinalizerNames(obj, nil)).To(BeFalse())
 			MigrateSecondaryClassFinalizers(obj, DefaultClass, []string{"secondary1"})
 			Expect(obj.GetFinalizers()).To(ConsistOf(FinalizerCompound))
 		})
@@ -103,6 +118,21 @@ var _ = Describe("Class", func() {
 			obj := newEntry(original...)
 			MigrateSecondaryClassFinalizers(obj, "primary", []string{"secondary1"})
 			Expect(original).To(Equal([]string{ClassFinalizerName("secondary1")}))
+		})
+
+		It("should drop the gardendns-next-gen finalizer for next-gen migration class", func() {
+			original := []string{"gardendns-next-gen.dns.gardener.cloud/compound"}
+			obj := newEntry(original...)
+			Expect(HasSecondaryClassFinalizerNames(obj, nil)).To(BeTrue())
+			MigrateSecondaryClassFinalizers(obj, "gardendns-next-gen", nil)
+			Expect(obj.GetFinalizers()).To(Equal([]string{"dns.gardener.cloud/compound"}))
+		})
+
+		It("should drop the gardendns-next-gen finalizer when migrating to a custom class", func() {
+			original := []string{"gardendns-next-gen.dns.gardener.cloud/compound"}
+			obj := newEntry(original...)
+			MigrateSecondaryClassFinalizers(obj, "foo", nil)
+			Expect(obj.GetFinalizers()).To(Equal([]string{"foo.dns.gardener.cloud/compound"}))
 		})
 	})
 

--- a/pkg/dnsman2/dns/const.go
+++ b/pkg/dnsman2/dns/const.go
@@ -18,6 +18,8 @@ const (
 
 	// DefaultClass is the default DNS class used by the controller.
 	DefaultClass = "gardendns"
+	// NextGenMigrationClass is a special DNS class used during migrating from legacy to next-generation controller.
+	NextGenMigrationClass = "gardendns-next-gen"
 	// AnnotationClass is the annotation key for specifying the DNS class.
 	AnnotationClass = "dns.gardener.cloud/class"
 	// AnnotationTTL is the annotation key for specifying the TTL (Time To Live) for DNS records.
@@ -30,6 +32,8 @@ const (
 
 	// FinalizerCompound is the finalizer for provider resources ("compound" to be backwards-compatible).
 	FinalizerCompound = "dns.gardener.cloud/compound"
+	// NextGenMigrationFinalizerCompound is the finalizer used for provider resources during migration from legacy to next-generation controller.
+	NextGenMigrationFinalizerCompound = NextGenMigrationClass + "." + FinalizerCompound
 	// FinalizerReplication is the finalizer for provider resources (exact name needed for backward compatibility).
 	FinalizerReplication = "garden.dns.gardener.cloud/dnsprovider-replication"
 	// FinalizerSourceTemplate is the finalizer template to be filled with class and controller (exact name needed for backward compatibility).

--- a/pkg/dnsman2/dns/const.go
+++ b/pkg/dnsman2/dns/const.go
@@ -18,7 +18,7 @@ const (
 
 	// DefaultClass is the default DNS class used by the controller.
 	DefaultClass = "gardendns"
-	// NextGenMigrationClass is a special DNS class used during migrating from legacy to next-generation controller.
+	// NextGenMigrationClass is a special DNS class used during migration from legacy to next-generation controller.
 	NextGenMigrationClass = "gardendns-next-gen"
 	// AnnotationClass is the annotation key for specifying the DNS class.
 	AnnotationClass = "dns.gardener.cloud/class"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind task

**What this PR does / why we need it**:
This change makes the next-generation dns-controller-manager (when configured with Class=`gardendns-next-gen`) use the default finalizer `dns.gardener.cloud/compound` instead of `gardendns-next-gen.dns.gardener.cloud/compound`. It also adds one-time cleanup logic that strips the spurious `gardendns-next-gen.dns.gardener.cloud/compound` finalizer left over from earlier next-gen builds.
The change is required to have a clean back-migration path to the legacy controller. It will also simplify switching back to the class `gardendns` for the next-generation controller when the legacy controller is disabled.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Related to changes in #897

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
[next-generation] use the default finalizer `dns.gardener.cloud/compound` instead of `gardendns-next-gen.dns.gardener.cloud/compound`
```
