### PR TITLE
[next-generation] Fix condition in handleEmptyProviderState to recognise controller restart

### DIFF
--- a/pkg/dnsman2/controller/controlplane/dnsprovider/reconciler_delete.go
+++ b/pkg/dnsman2/controller/controlplane/dnsprovider/reconciler_delete.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -52,7 +51,7 @@ func (r *Reconciler) delete(ctx context.Context, log logr.Logger, provider *v1al
 			return res, err
 		}
 		return res, r.updateStatus(ctx, provider, func(status *v1alpha1.DNSProviderStatus) error {
-			status.Message = ptr.To(fmt.Sprintf("cannot delete provider, %d DNSEntries still assigned to it", len(entries.Items)))
+			status.Message = new(fmt.Sprintf("cannot delete provider, %d DNSEntries still assigned to it", len(entries.Items)))
 			return nil
 		})
 	}
@@ -65,7 +64,8 @@ func (r *Reconciler) delete(ctx context.Context, log logr.Logger, provider *v1al
 }
 
 func (r *Reconciler) handleEmptyProviderState(ctx context.Context, log logr.Logger, provider *v1alpha1.DNSProvider) (reconcile.Result, error) {
-	if r.state.GetProviderState(client.ObjectKeyFromObject(provider)) == nil {
+	providerState := r.state.GetProviderState(client.ObjectKeyFromObject(provider))
+	if providerState == nil || providerState.GetAccount() == nil {
 		// after controller restart, reconcile to recreate provider state
 		res, err := r.reconcile(ctx, log, provider)
 		if !res.IsZero() || err != nil {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
This is a bugfix for the next generation dns-controller-manager.
The bug: when a DNSProvider is deleted while still owning DNSEntries, after a controller restart the deletion path called handleEmptyProviderState, but the guard r.state.GetProviderState(...) == nil only triggered re-reconciliation when no state existed. This worked in an alpha version, but not anymore after some refactoring. After a restart, GetOrCreateProviderState may have already created a ProviderState without a DNSAccount, so the existing guard skipped re-reconciliation and the provider got stuck.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
[next-generation] Fix condition in handleEmptyProviderState to recognise controller restart correctly.
```
