### PR TITLE
[alicloud-dns] Allow `CNAME` record type for Alicloud weighted routing policy.

### DIFF
--- a/docs/alicloud-dns/README.md
+++ b/docs/alicloud-dns/README.md
@@ -8,7 +8,7 @@ You need to provide an access key (access key ID and secret access key) for Alib
 authenticate to Alibaba Cloud DNS.
 
 For details see [AccessKey Client](https://github.com/aliyun/alibaba-cloud-sdk-go/blob/master/docs/2-Client-EN.md#accesskey-client).
-Currently the `regionId` is fixed to `cn-shanghai`. 
+Currently, the `regionId` is fixed to `cn-shanghai`. 
 
 ## Using the Access Key
 
@@ -50,7 +50,7 @@ If multiple targets are specified in the same `DNSEntry`, this is equivalent to 
 
 Every record set needs a `SetIdentifier` which must be a string containing only letters, digits, and '-'.
 
-The weighted routing policy is only supported for the `A` and `AAAA` record types.
+The weighted routing policy is only supported for the `A`, `AAAA`, and `CNAME` record types.
 
 All entries of the same domain name must have the same record type and TTL. Allowed values for weights are integer values between 1 and 100.
 
@@ -61,8 +61,8 @@ apiVersion: dns.gardener.cloud/v1alpha1
 kind: DNSEntry
 metadata:
   annotations:
-  # If you are delegating the DNS management to Gardener Shoot DNS Service, uncomment the following line
-  #dns.gardener.cloud/class: garden
+    # If you are delegating the DNS management to Gardener Shoot DNS Service, uncomment the following line
+    #dns.gardener.cloud/class: garden
   name: alidns-weighted
   namespace: default
 spec:

--- a/pkg/controller/provider/alicloud/handler.go
+++ b/pkg/controller/provider/alicloud/handler.go
@@ -112,7 +112,7 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, _ provider.ZoneCache
 		r := (*Record)(record)
 		if id := r.GetSetIdentifier(); id != "" {
 			switch r.GetType() {
-			case dns.RS_A, dns.RS_AAAA:
+			case dns.RS_A, dns.RS_AAAA, dns.RS_CNAME:
 				// ok
 			default:
 				// ignore

--- a/pkg/controller/provider/alicloud/routingpolicy.go
+++ b/pkg/controller/provider/alicloud/routingpolicy.go
@@ -40,10 +40,10 @@ func checkRoutingPolicyForDNSSet(set *dns.DNSSet) error {
 	}
 	for t := range set.Sets {
 		switch t {
-		case dns.RS_A, dns.RS_AAAA:
+		case dns.RS_A, dns.RS_AAAA, dns.RS_CNAME:
 			// ok
 		default:
-			return fmt.Errorf("weighted routing policy only supported for A and AAAA records")
+			return fmt.Errorf("weighted routing policy only supported for A, AAAA, and CNAME records")
 		}
 	}
 	return nil

--- a/pkg/dnsman2/dns/provider/handler/alicloud/access.go
+++ b/pkg/dnsman2/dns/provider/handler/alicloud/access.go
@@ -289,7 +289,7 @@ func (a *access) GetRecordList(_ context.Context, dnsName, rtype string, zone pr
 	for i, r := range rl {
 		if r.GetSetIdentifier() != "" {
 			switch r.GetType() {
-			case string(dns.TypeA), string(dns.TypeAAAA):
+			case string(dns.TypeA), string(dns.TypeAAAA), string(dns.TypeCNAME):
 				r := r.(*Record)
 				if r.Weight != nil {
 					routingPoliciesPerRecord[i] = dns.NewRoutingPolicy(dns.RoutingPolicyWeighted, "weight", strconv.FormatInt(int64(*r.Weight), 10))

--- a/pkg/dnsman2/dns/provider/handler/alicloud/routingpolicy.go
+++ b/pkg/dnsman2/dns/provider/handler/alicloud/routingpolicy.go
@@ -39,10 +39,10 @@ func checkRoutingPolicyForDNSSet(name dns.DNSSetName, rs *dns.RecordSet) error {
 		return fmt.Errorf("unsupported routing policy")
 	}
 	switch rs.Type {
-	case dns.TypeA, dns.TypeAAAA:
+	case dns.TypeA, dns.TypeAAAA, dns.TypeCNAME:
 		// ok
 	default:
-		return fmt.Errorf("weighted routing policy only supported for A and AAAA records")
+		return fmt.Errorf("weighted routing policy only supported for A, AAAA, and CNAME records")
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
On the initial implementation of routing policy for the `alicloud-dns` provider, only the record types `A` and `AAAA` were allowed, as the Alicloud documentation mentioned only them.
In the meantime, Alicloud has added support for the record type `CNAME`, see [Alicloud documentation - Weighted DNS resolution](https://www.alibabacloud.com/help/en/dns/pvtz-intelligent-analysis-of-sub-weight). The provider handlers are extended to allow this type for both legacy and next-generation controllers.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Follow-up of #461

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
[alicloud-dns] Allow `CNAME` record type for weighted routing policy additionally to record types `A` and `AAAA`.
```
