### PR TITLE
[next-generation] Reintroduce value `all` as alias for wildcard value `*` of the `dns.gardener.cloud/dnsnames` annotation

### DIFF
--- a/pkg/dnsman2/controller/source/common/dnsspecinput.go
+++ b/pkg/dnsman2/controller/source/common/dnsspecinput.go
@@ -27,6 +27,13 @@ import (
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/utils"
 )
 
+const (
+	// DNSNamesWildcard is the annotation value for 'dns.gardener.cloud/dnsnames' to add all hosts.
+	DNSNamesWildcard = "*"
+	// DNSNamesAll is an annotation value for 'dns.gardener.cloud/dnsnames' to add all hosts (alias of value "*").
+	DNSNamesAll = "all"
+)
+
 // DNSSpecInput specifies names, targets, and policies for DNS records.
 type DNSSpecInput struct {
 	Names                     *utils.UniqueStrings
@@ -51,8 +58,8 @@ func GetDNSSpecInputForService(log logr.Logger, state state.AnnotationState, gvk
 	if names == nil {
 		return nil, nil // no DNS names specified means no need to create DNS entries
 	}
-	if names.Contains("*") {
-		return nil, fmt.Errorf("domain name annotation value '*' is not allowed for service objects")
+	if HasDNSNamesWildcard(names) {
+		return nil, fmt.Errorf("domain name annotation value %q or %q is not allowed for service objects", DNSNamesWildcard, DNSNamesAll)
 	}
 
 	ipStack := annotations[dns.AnnotationIPStack]
@@ -124,7 +131,7 @@ func getDNSNamesForIngress(log logr.Logger, ingress *networkingv1.Ingress, annot
 		return nil, nil
 	}
 
-	all := annotatedNames.Contains("*")
+	all := HasDNSNamesWildcard(annotatedNames)
 	dnsNames := utils.NewUniqueStrings()
 	for _, rule := range ingress.Spec.Rules {
 		host := rule.Host
@@ -133,7 +140,7 @@ func getDNSNamesForIngress(log logr.Logger, ingress *networkingv1.Ingress, annot
 		}
 	}
 
-	annotatedNames.Remove("*")
+	RemoveDNSNamesWildcard(annotatedNames)
 	diff := annotatedNames.Difference(dnsNames)
 	if len(diff) > 0 {
 		return nil, fmt.Errorf("annotated dns names %s not declared by ingress", strings.Join(diff, ", "))
@@ -287,4 +294,15 @@ func BuildResourceReference(gvk schema.GroupVersionKind, obj metav1.Object) v1al
 //   - host: example.com,          h: *.gardener.cloud     -> false (unrelated domain)
 func MatchesWildcardSingleSubdomain(host, h string) bool {
 	return strings.HasPrefix(h, "*.") && strings.HasSuffix(host, h[1:]) && !strings.Contains(host[:len(host)-len(h)+1], ".")
+}
+
+// HasDNSNamesWildcard checks whether the given set of DNS names contains a wildcard entry (either "*" or "all").
+func HasDNSNamesWildcard(names *utils.UniqueStrings) bool {
+	return names.Contains(DNSNamesWildcard) || names.Contains(DNSNamesAll)
+}
+
+// RemoveDNSNamesWildcard removes wildcard entries (both "*" and "all") from the given set of DNS names.
+func RemoveDNSNamesWildcard(names *utils.UniqueStrings) {
+	names.Remove(DNSNamesWildcard)
+	names.Remove(DNSNamesAll)
 }

--- a/pkg/dnsman2/controller/source/common/dnsspecinput_test.go
+++ b/pkg/dnsman2/controller/source/common/dnsspecinput_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gardener/external-dns-management/pkg/dnsman2/controller/source/common"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/state"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/utils"
 )
 
 var _ = Describe("DNSSpecInput", func() {
@@ -60,6 +61,13 @@ var _ = Describe("DNSSpecInput", func() {
 
 		It("should handle the wildcard dns name annotation", func() {
 			ingress.Annotations[dns.AnnotationDNSNames] = "*"
+			input, err := common.GetDNSSpecInputForIngress(log, annotationState, gkv, ingress)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(input.Names.ToSlice()).To(ConsistOf([]string{"example.com", "gardener.cloud", "wikipedia.org"}))
+		})
+
+		It("should handle the wildcard dns name annotation (alias value 'all')", func() {
+			ingress.Annotations[dns.AnnotationDNSNames] = "all"
 			input, err := common.GetDNSSpecInputForIngress(log, annotationState, gkv, ingress)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(input.Names.ToSlice()).To(ConsistOf([]string{"example.com", "gardener.cloud", "wikipedia.org"}))
@@ -276,6 +284,46 @@ var _ = Describe("DNSSpecInput", func() {
 
 		It("should match with a deeper base domain", func() {
 			Expect(common.MatchesWildcardSingleSubdomain("foo.api.gardener.cloud", "*.api.gardener.cloud")).To(BeTrue())
+		})
+	})
+
+	Describe("#HasDNSNamesWildcard", func() {
+		It("should return true when the set contains '*'", func() {
+			names := utils.NewUniqueStrings()
+			names.Add("*")
+			Expect(common.HasDNSNamesWildcard(names)).To(BeTrue())
+		})
+
+		It("should return true when the set contains 'all'", func() {
+			names := utils.NewUniqueStrings()
+			names.Add("all")
+			Expect(common.HasDNSNamesWildcard(names)).To(BeTrue())
+		})
+
+		It("should return false when neither '*' nor 'all' is in the set", func() {
+			names := utils.NewUniqueStrings()
+			names.Add("example.com")
+			Expect(common.HasDNSNamesWildcard(names)).To(BeFalse())
+		})
+
+		It("should return false for an empty set", func() {
+			Expect(common.HasDNSNamesWildcard(utils.NewUniqueStrings())).To(BeFalse())
+		})
+	})
+
+	Describe("#RemoveDNSNamesWildcard", func() {
+		It("should remove both '*' and 'all' entries", func() {
+			names := utils.NewUniqueStrings()
+			names.AddAll([]string{"*", "all", "example.com"})
+			common.RemoveDNSNamesWildcard(names)
+			Expect(names.ToSlice()).To(ConsistOf("example.com"))
+		})
+
+		It("should be a no-op when neither wildcard is present", func() {
+			names := utils.NewUniqueStrings()
+			names.AddAll([]string{"example.com", "gardener.cloud"})
+			common.RemoveDNSNamesWildcard(names)
+			Expect(names.ToSlice()).To(ConsistOf("example.com", "gardener.cloud"))
 		})
 	})
 })

--- a/pkg/dnsman2/controller/source/gatewayapi/common.go
+++ b/pkg/dnsman2/controller/source/gatewayapi/common.go
@@ -138,7 +138,7 @@ func getDNSNames[T client.Object](ctx context.Context, r *common.SourceReconcile
 	if err != nil {
 		return nil, err
 	}
-	all := annotatedNames.Contains("*")
+	all := common.HasDNSNamesWildcard(annotatedNames)
 	dnsNames := utils.NewUniqueStrings()
 	for _, host := range hosts {
 		if all || annotatedNames.Contains(host) {
@@ -146,7 +146,7 @@ func getDNSNames[T client.Object](ctx context.Context, r *common.SourceReconcile
 		}
 	}
 
-	annotatedNames.Remove("*")
+	common.RemoveDNSNamesWildcard(annotatedNames)
 	diff := annotatedNames.Difference(dnsNames)
 	if len(diff) > 0 {
 		return nil, fmt.Errorf("annotated dns names %s not declared by gateway.spec.listeners[].hostname", strings.Join(diff, ", "))

--- a/pkg/dnsman2/controller/source/gatewayapi/common_test.go
+++ b/pkg/dnsman2/controller/source/gatewayapi/common_test.go
@@ -280,6 +280,13 @@ var _ = Describe("Common", func() {
 			Expect(names.ToSlice()).To(Equal([]string{"example.com", "wikipedia.org"}))
 		})
 
+		It("should get all DNS names with a wildcard annotation (alias value 'all')", func() {
+			gateway.Annotations["dns.gardener.cloud/dnsnames"] = "all"
+			names, err := getDNSNames(context.Background(), reconciler, gateway, gateway.Annotations)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(names.ToSlice()).To(Equal([]string{"example.com", "wikipedia.org"}))
+		})
+
 		It("should return an error if an annotated DNS name is not declared by the Gateway's listeners", func() {
 			gateway.Annotations["dns.gardener.cloud/dnsnames"] = "notlistened.to"
 			_, err := getDNSNames(context.Background(), reconciler, gateway, gateway.Annotations)

--- a/pkg/dnsman2/controller/source/gatewayapi/v1/actuator_test.go
+++ b/pkg/dnsman2/controller/source/gatewayapi/v1/actuator_test.go
@@ -193,6 +193,17 @@ var _ = Describe("Actuator", func() {
 			Expect(dnsEntries.Items).To(HaveLen(3))
 		})
 
+		It("should handle the wildcard DNS names annotation (alias value 'all')", func() {
+			gateway.Annotations["dns.gardener.cloud/dnsnames"] = "all"
+			Expect(fakeClientSrc.Create(ctx, gateway)).To(Succeed())
+
+			err := doReconcile(ctx, reconciler, gateway)
+			Expect(err).NotTo(HaveOccurred())
+
+			dnsEntries := getDNSEntries(ctx, fakeClientCtrl, reconciler)
+			Expect(dnsEntries.Items).To(HaveLen(3))
+		})
+
 		It("should create nothing without the DNS names annotation", func() {
 			delete(gateway.Annotations, "dns.gardener.cloud/dnsnames")
 			Expect(fakeClientSrc.Create(ctx, gateway)).To(Succeed())

--- a/pkg/dnsman2/controller/source/gatewayapi/v1beta1/actuator_test.go
+++ b/pkg/dnsman2/controller/source/gatewayapi/v1beta1/actuator_test.go
@@ -210,6 +210,17 @@ var _ = Describe("Actuator", func() {
 			Expect(dnsEntries.Items).To(HaveLen(3))
 		})
 
+		It("should handle the wildcard DNS names annotation (alias value 'all')", func() {
+			gateway.Annotations["dns.gardener.cloud/dnsnames"] = "all"
+			Expect(fakeClientSrc.Create(ctx, gateway)).To(Succeed())
+
+			err := doReconcile(ctx, reconciler, gateway)
+			Expect(err).NotTo(HaveOccurred())
+
+			dnsEntries := getDNSEntries(ctx, fakeClientCtrl, reconciler)
+			Expect(dnsEntries.Items).To(HaveLen(3))
+		})
+
 		It("should create nothing without the DNS names annotation", func() {
 			delete(gateway.Annotations, "dns.gardener.cloud/dnsnames")
 			Expect(fakeClientSrc.Create(ctx, gateway)).To(Succeed())

--- a/pkg/dnsman2/controller/source/ingress/actuator_test.go
+++ b/pkg/dnsman2/controller/source/ingress/actuator_test.go
@@ -127,6 +127,18 @@ var _ = Describe("Actuator", func() {
 
 		})
 
+		It("should handle the wildcard DNS names annotation (alias value 'all')", func() {
+			ingress.Annotations["dns.gardener.cloud/dnsnames"] = "all"
+			Expect(fakeClientSrc.Create(ctx, ingress)).To(Succeed())
+
+			err := doReconcile(ctx, reconciler, ingress)
+			Expect(err).NotTo(HaveOccurred())
+
+			dnsEntries := getDNSEntries(ctx, fakeClientCtrl, reconciler)
+			Expect(dnsEntries.Items).To(HaveLen(3))
+
+		})
+
 		It("should create nothing without the DNS names annotation", func() {
 			delete(ingress.Annotations, "dns.gardener.cloud/dnsnames")
 			Expect(fakeClientSrc.Create(ctx, ingress)).To(Succeed())

--- a/pkg/dnsman2/controller/source/istio/common.go
+++ b/pkg/dnsman2/controller/source/istio/common.go
@@ -85,7 +85,7 @@ func getDNSNames[T client.Object](ctx context.Context, r *common.SourceReconcile
 		return nil, err
 	}
 
-	all := annotatedNames.Contains("*")
+	all := common.HasDNSNamesWildcard(annotatedNames)
 	dnsNames := utils.NewUniqueStrings()
 	for _, host := range hosts {
 		if all || annotatedNames.Contains(host) {
@@ -93,7 +93,7 @@ func getDNSNames[T client.Object](ctx context.Context, r *common.SourceReconcile
 		}
 	}
 
-	annotatedNames.Remove("*")
+	common.RemoveDNSNamesWildcard(annotatedNames)
 	diff := annotatedNames.Difference(dnsNames)
 	if len(diff) > 0 {
 		return nil, fmt.Errorf("annotated dns names %s not declared by gateway.spec.servers[].hosts[]", strings.Join(diff, ", "))

--- a/pkg/dnsman2/controller/source/service/actuator_test.go
+++ b/pkg/dnsman2/controller/source/service/actuator_test.go
@@ -287,7 +287,13 @@ var _ = Describe("Actuator", func() {
 
 		It("should fail if dnsnames are set to '*'", func() {
 			svc.Annotations[dns.AnnotationDNSNames] = "*"
-			test(nil, "domain name annotation value '*' is not allowed for service objects")
+			test(nil, "domain name annotation value \"*\" or \"all\" is not allowed for service objects")
+			testutils.AssertEvents(fakeRecorder.Events, "Warning Invalid ")
+		})
+
+		It("should fail if dnsnames are set to '*' (alias value 'all')", func() {
+			svc.Annotations[dns.AnnotationDNSNames] = "all"
+			test(nil, "domain name annotation value \"*\" or \"all\" is not allowed for service objects")
 			testutils.AssertEvents(fakeRecorder.Events, "Warning Invalid ")
 		})
 

--- a/pkg/dnsman2/controller/source/service/actuator_test.go
+++ b/pkg/dnsman2/controller/source/service/actuator_test.go
@@ -291,7 +291,7 @@ var _ = Describe("Actuator", func() {
 			testutils.AssertEvents(fakeRecorder.Events, "Warning Invalid ")
 		})
 
-		It("should fail if dnsnames are set to '*' (alias value 'all')", func() {
+		It("should fail if dnsnames are set to 'all'", func() {
 			svc.Annotations[dns.AnnotationDNSNames] = "all"
 			test(nil, "domain name annotation value \"*\" or \"all\" is not allowed for service objects")
 			testutils.AssertEvents(fakeRecorder.Events, "Warning Invalid ")


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Reintroduce `all` as alias for wildcard `*` in `dns.gardener.cloud/dnsnames` annotation for the next-generation controller.

 ## What

  Adds support for the value "all" as an alias for "*" in the `dns.gardener.cloud/dnsnames` annotation handled by the next-generation (dnsman2) source controllers. This restores the dnsman1 behavior for users migrating to the new controller.

##  Why

  The legacy controller accepted `all` as a synonym for the `*` wildcard. The new dnsman2 controller (next-generation) previously only accepted `*`, which is a silent breaking change for users with existing manifests. This PR restores compatibility.

##  Changes

###  Production code
  - pkg/dnsman2/controller/source/common/dnsspecinput.go
    - New constants DNSNamesWildcard = "*" and DNSNamesAll = "all".
    - New helpers HasDNSNamesWildcard(*UniqueStrings) bool and RemoveDNSNamesWildcard(*UniqueStrings) centralize alias handling.
    - GetDNSSpecInputForService now rejects both "*" and "all" with an updated error message.
    - getDNSNamesForIngress uses the new helpers.
  - pkg/dnsman2/controller/source/gatewayapi/common.go — uses the new helpers in getDNSNames.
  - pkg/dnsman2/controller/source/istio/common.go — uses the new helpers in getDNSNames.
  
###  Tests
  - dnsspecinput_test.go — adds the "all" alias case for GetDNSSpecInputForIngress plus dedicated unit tests for HasDNSNamesWildcard and RemoveDNSNamesWildcard (covers */all/neither/empty for the predicate, and removal/no-op cases).
  - ingress/actuator_test.go, gatewayapi/v1/actuator_test.go, gatewayapi/v1beta1/actuator_test.go — add a reconcile-level test for the "all" alias.
  - service/actuator_test.go — updates the "*" rejection assertion to the new error string and adds a parallel rejection test for "all".
  
##  Affected sources

  Ingress, Gateway API v1, Gateway API v1beta1, Istio (v1/v1beta1/v1alpha3 via shared common), and Service (rejection only).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
[next-generation] Reintroduce value `all` as alias for wildcard value `*` of the `dns.gardener.cloud/dnsnames` annotation
```
