### PR TITLE
[next-generation] Fix DNSEntry cleanup when all targets/text are removed from the spec.

### DIFF
--- a/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_reconcile.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_reconcile.go
@@ -359,7 +359,7 @@ func (r *entryReconciliation) checkProviderNotReady(data *providerselector.NewPr
 func (r *entryReconciliation) calcNewTargets(providerData *providerselector.NewProviderData, recordsToCheck records.FullRecordKeySet) (*newTargetsData, *common.ReconcileResult) {
 	producer := targets.NewTargetsProducer(r.Ctx, providerData.DefaultTTL, r.defaultCNAMELookupInterval, r.lookupProcessor)
 
-	result, err := producer.FromSpec(client.ObjectKeyFromObject(r.Entry), &r.Entry.Spec, r.Entry.Annotations[dns.AnnotationIPStack])
+	result, err := producer.FromSpec(client.ObjectKeyFromObject(r.Entry), &r.Entry.Spec, r.Entry.Annotations[dns.AnnotationIPStack], len(r.Entry.Status.Targets) > 0)
 	if err != nil {
 		return nil, common.InvalidReconcileResult(err.Error())
 	}

--- a/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_test.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_test.go
@@ -426,6 +426,43 @@ var _ = Describe("Reconcile", func() {
 		Expect(apierrors.IsNotFound(fakeClient.Get(ctx, client.ObjectKeyFromObject(entryA), entryA))).To(BeTrue(), "Entry should be not found")
 	})
 
+	It("should clean up status targets when spec targets are removed", func() {
+		createProvider("p1", []string{"example.com"}, nil, v1alpha1.StateReady, mockConfig1)
+		Expect(fakeClient.Create(ctx, entryA)).To(Succeed())
+
+		checkEntryStatus(entryA, "test/p1", zoneID1, "Ready", defaultTTL, "1.2.3.4")
+		expectRecordSets(zoneID1, "test.sub.example.com", recordSetA)
+
+		entryA.Spec.Targets = nil
+		Expect(fakeClient.Update(ctx, entryA)).To(Succeed())
+		checkEntryStatus(entryA, "test/p1", zoneID1, "Ready", 0)
+		expectRecordSets(zoneID1, "test.sub.example.com")
+	})
+
+	It("should clean up status targets when spec text is removed from TXT entry", func() {
+		createProvider("p1", []string{"example.com"}, nil, v1alpha1.StateReady, mockConfig1)
+		Expect(fakeClient.Create(ctx, entryB)).To(Succeed())
+
+		checkEntryStatus(entryB, "test/p1", zoneID1, "Ready", defaultTTL, "\"This is a text!\"", "\"blabla\"")
+		expectRecordSets(zoneID1, "txt.sub.example.com", recordSetB)
+
+		entryB.Spec.Text = nil
+		Expect(fakeClient.Update(ctx, entryB)).To(Succeed())
+		checkEntryStatus(entryB, "test/p1", zoneID1, "Ready", 0)
+		expectRecordSets(zoneID1, "txt.sub.example.com")
+	})
+
+	It("should reject a new entry with neither targets nor text", func() {
+		createProvider("p1", []string{"example.com"}, nil, v1alpha1.StateReady, mockConfig1)
+		entryA.Spec.Targets = nil
+		Expect(fakeClient.Create(ctx, entryA)).To(Succeed())
+
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(entryA)})
+		Expect(err).ToNot(HaveOccurred())
+		checkEntryStateAndMessage(entryA, "Invalid", ContainSubstring("no target or text specified"))
+		expectRecordSets(zoneID1, "test.sub.example.com")
+	})
+
 	It("should create/update/delete TXT record", func() {
 		createProvider("p1", []string{"example.com"}, nil, v1alpha1.StateReady, mockConfig1)
 		Expect(fakeClient.Create(ctx, entryB)).To(Succeed())

--- a/pkg/dnsman2/controller/controlplane/dnsentry/targets/targets.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/targets/targets.go
@@ -81,7 +81,7 @@ func NewTargetsProducer(ctx context.Context, defaultTTL, defaultCNAMELookupInter
 
 // FromSpec extracts dns.Targets from a DNSEntrySpec.
 // It validates the spec and returns warnings for duplicate targets or empty text.
-func (p *TargetsProducer) FromSpec(key client.ObjectKey, spec *v1alpha1.DNSEntrySpec, ipstack string) (result *TargetsResult, err error) {
+func (p *TargetsProducer) FromSpec(key client.ObjectKey, spec *v1alpha1.DNSEntrySpec, ipstack string, hasOldTargets bool) (result *TargetsResult, err error) {
 	if err = dns.ValidateDomainName(spec.DNSName); err != nil {
 		return
 	}
@@ -129,11 +129,6 @@ func (p *TargetsProducer) FromSpec(key client.ObjectKey, spec *v1alpha1.DNSEntry
 		return
 	}
 
-	if !result.HasTargets() {
-		err = fmt.Errorf("no target or text specified")
-		return
-	}
-
 	resolveTargetsToAddresses, err := checkCNAMETargets(spec, result.Targets)
 	if err != nil {
 		return
@@ -149,6 +144,12 @@ func (p *TargetsProducer) FromSpec(key client.ObjectKey, spec *v1alpha1.DNSEntry
 		if err != nil {
 			return
 		}
+	}
+
+	// if entry has existing targets, don't fail to allow cleanup
+	if !result.HasTargets() && !hasOldTargets {
+		err = fmt.Errorf("no target or text specified")
+		return
 	}
 
 	return

--- a/pkg/dnsman2/controller/controlplane/dnsentry/targets/targets_test.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/targets/targets_test.go
@@ -46,7 +46,7 @@ var _ = Describe("SpecToTargets", func() {
 	It("returns targets for valid A record", func() {
 		spec.Targets = []string{ipv4Address}
 
-		result, err := producer.FromSpec(key, spec, "")
+		result, err := producer.FromSpec(key, spec, "", false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result.HasWarnings()).To(BeFalse())
 		Expect(result.Targets).To(HaveLen(1))
@@ -59,7 +59,7 @@ var _ = Describe("SpecToTargets", func() {
 		spec.Targets = []string{ipv6Address}
 		spec.TTL = ptr.To[int64](120)
 
-		result, err := producer.FromSpec(key, spec, "")
+		result, err := producer.FromSpec(key, spec, "", false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result.HasWarnings()).To(BeFalse())
 		Expect(result.Targets).To(HaveLen(1))
@@ -71,7 +71,7 @@ var _ = Describe("SpecToTargets", func() {
 	It("returns targets for valid A and AAAA records", func() {
 		spec.Targets = []string{ipv4Address, ipv4Address2, ipv6Address}
 
-		result, err := producer.FromSpec(key, spec, "")
+		result, err := producer.FromSpec(key, spec, "", false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result.HasWarnings()).To(BeFalse())
 		Expect(result.Targets).To(HaveLen(3))
@@ -86,7 +86,7 @@ var _ = Describe("SpecToTargets", func() {
 	It("returns targets for valid CNAME record", func() {
 		spec.Targets = []string{"*.example.com"}
 
-		result, err := producer.FromSpec(key, spec, "")
+		result, err := producer.FromSpec(key, spec, "", false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result.HasWarnings()).To(BeFalse())
 		Expect(result.Targets).To(HaveLen(1))
@@ -97,7 +97,7 @@ var _ = Describe("SpecToTargets", func() {
 	It("returns targets for valid TXT record", func() {
 		spec.Text = []string{"example.com", ipv4Address}
 
-		result, err := producer.FromSpec(key, spec, "")
+		result, err := producer.FromSpec(key, spec, "", false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result.HasWarnings()).To(BeFalse())
 		Expect(result.Targets).To(HaveLen(2))
@@ -110,7 +110,7 @@ var _ = Describe("SpecToTargets", func() {
 	It("returns warning for duplicate targets", func() {
 		spec.Targets = []string{ipv4Address, ipv4Address}
 
-		result, err := producer.FromSpec(key, spec, "")
+		result, err := producer.FromSpec(key, spec, "", false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result.Warnings).To(HaveLen(1))
 		Expect(result.Targets).To(HaveLen(1))
@@ -119,14 +119,14 @@ var _ = Describe("SpecToTargets", func() {
 	It("returns error for empty target", func() {
 		spec.Targets = []string{""}
 
-		_, err := producer.FromSpec(key, spec, "")
+		_, err := producer.FromSpec(key, spec, "", false)
 		Expect(err).To(MatchError(ContainSubstring("must not be empty")))
 	})
 
 	It("returns warning for empty text", func() {
 		spec.Text = []string{""}
 
-		result, err := producer.FromSpec(key, spec, "")
+		result, err := producer.FromSpec(key, spec, "", false)
 		Expect(err).To(MatchError(ContainSubstring("only empty text")))
 		Expect(result.Warnings).To(HaveLen(1))
 	})
@@ -135,26 +135,32 @@ var _ = Describe("SpecToTargets", func() {
 		spec.Targets = []string{ipv4Address}
 		spec.Text = []string{"foo"}
 
-		_, err := producer.FromSpec(key, spec, "")
+		_, err := producer.FromSpec(key, spec, "", false)
 		Expect(err).To(MatchError(ContainSubstring("only text or targets possible")))
 	})
 
 	It("returns error if no targets or text are set", func() {
-		_, err := producer.FromSpec(key, spec, "")
+		_, err := producer.FromSpec(key, spec, "", false)
 		Expect(err).To(MatchError(ContainSubstring("no target or text specified")))
+	})
+
+	It("returns empty targets without error if no targets or text are set but entry has existing targets", func() {
+		result, err := producer.FromSpec(key, spec, "", true)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.Targets).To(BeEmpty())
 	})
 
 	It("returns error if there are too many CNAME targets", func() {
 		for i := range 26 {
 			spec.Targets = append(spec.Targets, fmt.Sprintf("cname%d.example.com", i))
 		}
-		_, err := producer.FromSpec(key, spec, "")
+		_, err := producer.FromSpec(key, spec, "", false)
 		Expect(err).To(MatchError(ContainSubstring("too many CNAME targets (26), maximum is 25")))
 	})
 
 	It("returns error if there are CNAME target is mixed with IP addresses", func() {
 		spec.Targets = []string{"foo.example.com", ipv4Address}
-		_, err := producer.FromSpec(key, spec, "")
+		_, err := producer.FromSpec(key, spec, "", false)
 		Expect(err).To(MatchError(ContainSubstring("cannot mix CNAME and other record types in targets")))
 	})
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Previously, removing `Spec.Targets` or `Spec.Text` from an existing `DNSEntry` caused the reconciler to reject the spec as invalid (`no target or text specified`), leaving orphaned records in the zone and the deletion of the `DNSEntry` was stuck. Now, when an entry already has targets in `Status.Targets`, the producer accepts an empty spec and emits empty targets, allowing the reconciler to delete the published records and clear the status.

  ## Changes
  
  - `targets.FromSpec` accepts a new `hasOldTargets` flag; the "no target or text specified" error is suppressed when set, enabling cleanup of orphaned records.
  - `entryReconciliation.calcNewTargets` passes `len(Status.Targets) > 0` so the relaxation only kicks in for entries that previously published records — brand-new empty entries are still rejected as `Invalid`.

  ## Test plan

  - [x] Unit test in `targets_test.go` for the new `hasOldTargets=true` branch
  - [x] Integration test: A-record entry with targets removed → records deleted, status cleared
  - [x] Integration test: TXT entry with text removed → records deleted, status cleared
  - [x] Integration test: brand-new entry with neither targets nor text is rejected as `Invalid`
  
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
[next-generation] Fix DNSEntry cleanup when all targets/text are removed from the spec.
```
