### PR TITLE
[next-generation] Reduce reconciliation load on `DNSEntry` controller

### DIFF
--- a/pkg/dnsman2/apis/config/v1alpha1/defaults.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/defaults.go
@@ -143,7 +143,7 @@ func SetDefaults_DNSEntryControllerConfig(obj *DNSEntryControllerConfig) {
 		obj.ConcurrentSyncs = ptr.To(5)
 	}
 	if obj.SyncPeriod == nil {
-		obj.SyncPeriod = &metav1.Duration{Duration: time.Hour}
+		obj.SyncPeriod = &metav1.Duration{Duration: 8 * time.Hour}
 	}
 	if obj.ReconciliationTimeout == nil {
 		obj.ReconciliationTimeout = &metav1.Duration{Duration: 2 * time.Minute}

--- a/pkg/dnsman2/apis/config/v1alpha1/defaults.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/defaults.go
@@ -143,6 +143,7 @@ func SetDefaults_DNSEntryControllerConfig(obj *DNSEntryControllerConfig) {
 		obj.ConcurrentSyncs = ptr.To(5)
 	}
 	if obj.SyncPeriod == nil {
+		// periodic sync is a safety net, not the primary trigger.
 		obj.SyncPeriod = &metav1.Duration{Duration: 8 * time.Hour}
 	}
 	if obj.ReconciliationTimeout == nil {

--- a/pkg/dnsman2/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/defaults_test.go
@@ -194,7 +194,7 @@ var _ = Describe("Defaults", func() {
 					SetDefaults_DNSEntryControllerConfig(obj)
 
 					Expect(obj.ConcurrentSyncs).To(PointTo(Equal(5)))
-					Expect(obj.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: time.Hour})))
+					Expect(obj.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 8 * time.Hour})))
 					Expect(obj.ReconciliationTimeout).To(PointTo(Equal(metav1.Duration{Duration: 2 * time.Minute})))
 					Expect(obj.ZoneMetricsInterval).To(PointTo(Equal(metav1.Duration{Duration: 30 * time.Second})))
 					Expect(obj.PropagationWaitTime).To(PointTo(Equal(metav1.Duration{Duration: 10 * time.Second})))

--- a/pkg/dnsman2/controller/controlplane/dnsentry/add.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/add.go
@@ -13,6 +13,7 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/go-logr/logr"
 	"github.com/jellydator/ttlcache/v3"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -88,17 +89,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, controlPlaneCluster clust
 		WatchesRawSource(source.Kind[client.Object](controlPlaneCluster.GetCache(),
 			&v1alpha1.DNSProvider{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, provider client.Object) []reconcile.Request {
-				requests, unchanged, err := r.entriesToReconcileOnProviderChanges(ctx, provider)
-				if err != nil {
-					log.Error(err, "unable to reconcile provider changes")
-					return nil
-				}
-				if unchanged {
-					log.Info("DNSProvider unchanged", "provider", client.ObjectKeyFromObject(provider))
-					return nil
-				}
-				log.Info("trigger reconciliation by DNSProvider change", "entries", len(requests), "provider", client.ObjectKeyFromObject(provider))
-				return requests
+				return r.entriesToReconcileOnProviderChanges(ctx, log, provider)
 			}),
 			dnsman2controller.DNSClassesPredicate(r.Class, r.SecondaryClasses),
 		))
@@ -151,28 +142,43 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, controlPlaneCluster clust
 		Complete(r)
 }
 
-func (r *Reconciler) entriesToReconcileOnProviderChanges(ctx context.Context, obj client.Object) ([]reconcile.Request, bool, error) {
-	var requests []reconcile.Request
+func (r *Reconciler) entriesToReconcileOnProviderChanges(ctx context.Context, log logr.Logger, obj client.Object) []reconcile.Request {
 	provider, ok := obj.(*v1alpha1.DNSProvider)
 	if !ok {
-		return nil, false, fmt.Errorf("unexpected object type: %T", obj)
+		log.Error(fmt.Errorf("unexpected object type: %T", obj), "unable to reconcile provider changes")
+		return nil
+	}
+	providerKey := client.ObjectKeyFromObject(provider)
+
+	// Gate: skip if provider hasn't caught up with its current spec.
+	if provider.Status.ObservedGeneration != provider.Generation {
+		log.V(1).Info("DNSProvider not yet reconciled, skipping entry fan-out",
+			"provider", providerKey,
+			"generation", provider.Generation,
+			"observedGeneration", provider.Status.ObservedGeneration)
+		return nil
 	}
 
 	var newLastUpdateTime time.Time
 	if provider.Status.LastUpdateTime != nil {
 		newLastUpdateTime = provider.Status.LastUpdateTime.Time
 	}
-	if item := r.lastProviderUpdate.Get(client.ObjectKeyFromObject(provider)); item != nil {
-		if item.Value().observedGeneration == provider.Generation && item.Value().lastUpdateTime.Equal(newLastUpdateTime) {
-			return nil, true, nil
+	// Cache: skip if we've already fanned out for this exact status snapshot.
+	if item := r.lastProviderUpdate.Get(providerKey); item != nil {
+		if item.Value().observedGeneration == provider.Status.ObservedGeneration &&
+			item.Value().lastUpdateTime.Equal(newLastUpdateTime) {
+			log.Info("DNSProvider unchanged", "provider", providerKey)
+			return nil
 		}
 	}
 	providerName := provider.Namespace + "/" + provider.Name
 
 	entryList := &v1alpha1.DNSEntryList{}
 	if err := r.Client.List(ctx, entryList, client.InNamespace(r.Namespace)); err != nil {
-		return nil, false, err
+		log.Error(err, "unable to reconcile provider changes", "provider", providerKey)
+		return nil
 	}
+	var requests []reconcile.Request
 	for _, entry := range entryList.Items {
 		entryProviderName := ptr.Deref(entry.Status.Provider, "")
 		add := false
@@ -196,7 +202,8 @@ func (r *Reconciler) entriesToReconcileOnProviderChanges(ctx context.Context, ob
 		providerSnapshot{observedGeneration: provider.Status.ObservedGeneration, lastUpdateTime: newLastUpdateTime},
 		0,
 	)
-	return requests, false, nil
+	log.Info("trigger reconciliation by DNSProvider change", "entries", len(requests), "provider", providerKey)
+	return requests
 }
 
 func (r *Reconciler) allEntriesToReconcile(ctx context.Context) []reconcile.Request {

--- a/pkg/dnsman2/controller/controlplane/dnsentry/add.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/add.go
@@ -149,13 +149,14 @@ func (r *Reconciler) entriesToReconcileOnProviderChanges(ctx context.Context, lo
 		return nil
 	}
 	providerKey := client.ObjectKeyFromObject(provider)
+	observedGeneration := provider.Status.ObservedGeneration
 
 	// Gate: skip if provider hasn't caught up with its current spec.
-	if provider.Status.ObservedGeneration != provider.Generation {
+	if observedGeneration != provider.Generation {
 		log.V(1).Info("DNSProvider not yet reconciled, skipping entry fan-out",
 			"provider", providerKey,
 			"generation", provider.Generation,
-			"observedGeneration", provider.Status.ObservedGeneration)
+			"observedGeneration", observedGeneration)
 		return nil
 	}
 
@@ -165,9 +166,9 @@ func (r *Reconciler) entriesToReconcileOnProviderChanges(ctx context.Context, lo
 	}
 	// Cache: skip if we've already fanned out for this exact status snapshot.
 	if item := r.lastProviderUpdate.Get(providerKey); item != nil {
-		if item.Value().observedGeneration == provider.Status.ObservedGeneration &&
+		if item.Value().observedGeneration == observedGeneration &&
 			item.Value().lastUpdateTime.Equal(newLastUpdateTime) {
-			log.Info("DNSProvider unchanged", "provider", providerKey)
+			log.V(1).Info("DNSProvider unchanged", "provider", providerKey)
 			return nil
 		}
 	}
@@ -198,8 +199,8 @@ func (r *Reconciler) entriesToReconcileOnProviderChanges(ctx context.Context, lo
 		}
 	}
 	r.lastProviderUpdate.Set(
-		client.ObjectKeyFromObject(provider),
-		providerSnapshot{observedGeneration: provider.Status.ObservedGeneration, lastUpdateTime: newLastUpdateTime},
+		providerKey,
+		providerSnapshot{observedGeneration: observedGeneration, lastUpdateTime: newLastUpdateTime},
 		0,
 	)
 	log.Info("trigger reconciliation by DNSProvider change", "entries", len(requests), "provider", providerKey)

--- a/pkg/dnsman2/controller/controlplane/dnsentry/add.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/add.go
@@ -96,7 +96,9 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, controlPlaneCluster clust
 		bld.WatchesRawSource(
 			source.Channel(ch,
 				handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, _ client.Object) []reconcile.Request {
-					return r.allEntriesToReconcile(ctx)
+					requests := r.allEntriesToReconcile(ctx)
+					log.Info("periodic reconciliation", "requests", len(requests))
+					return requests
 				}),
 			),
 		)

--- a/pkg/dnsman2/controller/controlplane/dnsentry/add.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/add.go
@@ -41,6 +41,8 @@ import (
 // ControllerName is the name of this controller.
 const ControllerName = "dnsentry"
 
+const defaultProviderUpdateCachePeriod = 7 * 24 * time.Hour
+
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager, controlPlaneCluster cluster.Cluster, cfg *config.DNSManagerConfiguration) error {
 	r.Config = cfg.Controllers.DNSEntry
@@ -67,6 +69,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, controlPlaneCluster clust
 	r.setCachePeriods(
 		ptr.Deref(r.Config.ReconciliationDelayAfterUpdate, metav1.Duration{Duration: defaultReconciliationDelayAfterUpdate}).Duration,
 		ptr.Deref(r.Config.DriftCheckPeriod, metav1.Duration{Duration: defaultDriftCheckPeriod}).Duration,
+		defaultProviderUpdateCachePeriod,
 	)
 	if err := mgr.Add(r.lookupProcessor); err != nil {
 		return err
@@ -85,7 +88,17 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, controlPlaneCluster clust
 		WatchesRawSource(source.Kind[client.Object](controlPlaneCluster.GetCache(),
 			&v1alpha1.DNSProvider{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, provider client.Object) []reconcile.Request {
-				return r.entriesToReconcileOnProviderChanges(ctx, provider)
+				requests, unchanged, err := r.entriesToReconcileOnProviderChanges(ctx, provider)
+				if err != nil {
+					log.Error(err, "unable to reconcile provider changes")
+					return nil
+				}
+				if unchanged {
+					log.Info("DNSProvider unchanged", "provider", client.ObjectKeyFromObject(provider))
+					return nil
+				}
+				log.Info("trigger reconciliation by DNSProvider change", "entries", len(requests), "provider", client.ObjectKeyFromObject(provider))
+				return requests
 			}),
 			dnsman2controller.DNSClassesPredicate(r.Class, r.SecondaryClasses),
 		))
@@ -97,7 +110,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, controlPlaneCluster clust
 			source.Channel(ch,
 				handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, _ client.Object) []reconcile.Request {
 					requests := r.allEntriesToReconcile(ctx)
-					log.Info("periodic reconciliation", "requests", len(requests))
+					log.Info("periodic reconciliation", "entries", len(requests))
 					return requests
 				}),
 			),
@@ -138,17 +151,27 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, controlPlaneCluster clust
 		Complete(r)
 }
 
-func (r *Reconciler) entriesToReconcileOnProviderChanges(ctx context.Context, obj client.Object) []reconcile.Request {
+func (r *Reconciler) entriesToReconcileOnProviderChanges(ctx context.Context, obj client.Object) ([]reconcile.Request, bool, error) {
 	var requests []reconcile.Request
 	provider, ok := obj.(*v1alpha1.DNSProvider)
 	if !ok {
-		return nil
+		return nil, false, fmt.Errorf("unexpected object type: %T", obj)
+	}
+
+	var newLastUpdateTime time.Time
+	if provider.Status.LastUpdateTime != nil {
+		newLastUpdateTime = provider.Status.LastUpdateTime.Time
+	}
+	if item := r.lastProviderUpdate.Get(client.ObjectKeyFromObject(provider)); item != nil {
+		if item.Value().observedGeneration == provider.Generation && item.Value().lastUpdateTime.Equal(newLastUpdateTime) {
+			return nil, true, nil
+		}
 	}
 	providerName := provider.Namespace + "/" + provider.Name
 
 	entryList := &v1alpha1.DNSEntryList{}
 	if err := r.Client.List(ctx, entryList, client.InNamespace(r.Namespace)); err != nil {
-		return nil
+		return nil, false, err
 	}
 	for _, entry := range entryList.Items {
 		entryProviderName := ptr.Deref(entry.Status.Provider, "")
@@ -168,7 +191,12 @@ func (r *Reconciler) entriesToReconcileOnProviderChanges(ctx context.Context, ob
 			})
 		}
 	}
-	return requests
+	r.lastProviderUpdate.Set(
+		client.ObjectKeyFromObject(provider),
+		providerSnapshot{observedGeneration: provider.Status.ObservedGeneration, lastUpdateTime: newLastUpdateTime},
+		0,
+	)
+	return requests, false, nil
 }
 
 func (r *Reconciler) allEntriesToReconcile(ctx context.Context) []reconcile.Request {
@@ -189,7 +217,7 @@ func (r *Reconciler) allEntriesToReconcile(ctx context.Context) []reconcile.Requ
 	return requests
 }
 
-func (r *Reconciler) setCachePeriods(reconciliationDelayAfterUpdate, driftCheckPeriod time.Duration) {
+func (r *Reconciler) setCachePeriods(reconciliationDelayAfterUpdate, driftCheckPeriod, providerUpdateCachePeriod time.Duration) {
 	r.reconciliationDelayAfterUpdate = reconciliationDelayAfterUpdate
 	r.lastUpdate = ttlcache.New[client.ObjectKey, struct{}](
 		ttlcache.WithTTL[client.ObjectKey, struct{}](reconciliationDelayAfterUpdate),
@@ -197,6 +225,9 @@ func (r *Reconciler) setCachePeriods(reconciliationDelayAfterUpdate, driftCheckP
 	r.lastDriftCheck = ttlcache.New[client.ObjectKey, struct{}](
 		ttlcache.WithTTL[client.ObjectKey, struct{}](driftCheckPeriod),
 		ttlcache.WithDisableTouchOnHit[client.ObjectKey, struct{}]())
+	r.lastProviderUpdate = ttlcache.New[client.ObjectKey, providerSnapshot](
+		ttlcache.WithTTL[client.ObjectKey, providerSnapshot](providerUpdateCachePeriod),
+		ttlcache.WithDisableTouchOnHit[client.ObjectKey, providerSnapshot]())
 }
 
 func domainMatches(dnsName string, domains v1alpha1.DNSSelectionStatus) bool {

--- a/pkg/dnsman2/controller/controlplane/dnsentry/add_test.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/add_test.go
@@ -2,6 +2,7 @@ package dnsentry
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/smithy-go/ptr"
 	. "github.com/onsi/ginkgo/v2"
@@ -23,6 +24,14 @@ var _ = Describe("Add", func() {
 			fakeClient             client.Client
 			reconciler             *Reconciler
 			key1, key2, key3, key4 client.ObjectKey
+
+			checkEntriesToReconcileOnProviderChanges = func(ctx context.Context, provider client.Object) []reconcile.Request {
+				GinkgoHelper()
+				requests, unchanged, err := reconciler.entriesToReconcileOnProviderChanges(ctx, provider)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(unchanged).To(BeFalse())
+				return requests
+			}
 		)
 
 		BeforeEach(func() {
@@ -32,6 +41,7 @@ var _ = Describe("Add", func() {
 				Namespace: "test",
 				state:     state.GetState(),
 			}
+			reconciler.setCachePeriods(1*time.Microsecond, defaultDriftCheckPeriod, defaultProviderUpdateCachePeriod)
 
 			Expect(fakeClient.Create(ctx, &v1alpha1.DNSEntry{
 				ObjectMeta: metav1.ObjectMeta{Name: "entry1", Namespace: "test"},
@@ -78,14 +88,26 @@ var _ = Describe("Add", func() {
 					Domains: v1alpha1.DNSSelectionStatus{
 						Included: []string{"example.com"},
 					},
+					LastUpdateTime: &metav1.Time{Time: time.Now()},
 				},
 			}
-			Expect(reconciler.entriesToReconcileOnProviderChanges(ctx, provider)).To(ConsistOf(
+			expectedRequests := []any{
 				reconcile.Request{NamespacedName: key1},
 				reconcile.Request{NamespacedName: key2},
 				reconcile.Request{NamespacedName: key3},
 				reconcile.Request{NamespacedName: key4}, // matches because it is already assigned to the provider
-			))
+			}
+			Expect(checkEntriesToReconcileOnProviderChanges(ctx, provider)).To(ConsistOf(expectedRequests...))
+
+			// second call should return empty list because unchanged
+			requests, unchanged, err := reconciler.entriesToReconcileOnProviderChanges(ctx, provider)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(requests).To(BeEmpty())
+			Expect(unchanged).To(BeTrue())
+
+			// after updating LastUpdateTime expected requests should be returned
+			provider.Status.LastUpdateTime.Time = provider.Status.LastUpdateTime.Add(1 * time.Microsecond)
+			Expect(checkEntriesToReconcileOnProviderChanges(ctx, provider)).To(ConsistOf(expectedRequests...))
 		})
 
 		It("should return empty list for not matching provider", func() {
@@ -98,7 +120,7 @@ var _ = Describe("Add", func() {
 					},
 				},
 			}
-			Expect(reconciler.entriesToReconcileOnProviderChanges(ctx, provider)).To(BeEmpty())
+			Expect(checkEntriesToReconcileOnProviderChanges(ctx, provider)).To(BeEmpty())
 		})
 
 		It("should return exact matching domain", func() {
@@ -112,7 +134,7 @@ var _ = Describe("Add", func() {
 					},
 				},
 			}
-			Expect(reconciler.entriesToReconcileOnProviderChanges(ctx, provider)).To(ConsistOf(
+			Expect(checkEntriesToReconcileOnProviderChanges(ctx, provider)).To(ConsistOf(
 				reconcile.Request{NamespacedName: key2},
 				reconcile.Request{NamespacedName: key3},
 			))
@@ -129,7 +151,7 @@ var _ = Describe("Add", func() {
 					},
 				},
 			}
-			Expect(reconciler.entriesToReconcileOnProviderChanges(ctx, provider)).To(ConsistOf(
+			Expect(checkEntriesToReconcileOnProviderChanges(ctx, provider)).To(ConsistOf(
 				reconcile.Request{NamespacedName: key2},
 			))
 		})
@@ -144,7 +166,7 @@ var _ = Describe("Add", func() {
 					},
 				},
 			}
-			Expect(reconciler.entriesToReconcileOnProviderChanges(ctx, provider)).To(ConsistOf(
+			Expect(checkEntriesToReconcileOnProviderChanges(ctx, provider)).To(ConsistOf(
 				reconcile.Request{NamespacedName: key3},
 			))
 		})
@@ -159,7 +181,7 @@ var _ = Describe("Add", func() {
 					},
 				},
 			}
-			Expect(reconciler.entriesToReconcileOnProviderChanges(ctx, provider)).To(BeEmpty())
+			Expect(checkEntriesToReconcileOnProviderChanges(ctx, provider)).To(BeEmpty())
 		})
 
 	})

--- a/pkg/dnsman2/controller/controlplane/dnsentry/add_test.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/add_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/aws/smithy-go/ptr"
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,10 +28,7 @@ var _ = Describe("Add", func() {
 
 			checkEntriesToReconcileOnProviderChanges = func(ctx context.Context, provider client.Object) []reconcile.Request {
 				GinkgoHelper()
-				requests, unchanged, err := reconciler.entriesToReconcileOnProviderChanges(ctx, provider)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(unchanged).To(BeFalse())
-				return requests
+				return reconciler.entriesToReconcileOnProviderChanges(ctx, logr.Discard(), provider)
 			}
 		)
 
@@ -100,10 +98,8 @@ var _ = Describe("Add", func() {
 			Expect(checkEntriesToReconcileOnProviderChanges(ctx, provider)).To(ConsistOf(expectedRequests...))
 
 			// second call should return empty list because unchanged
-			requests, unchanged, err := reconciler.entriesToReconcileOnProviderChanges(ctx, provider)
-			Expect(err).ToNot(HaveOccurred())
+			requests := reconciler.entriesToReconcileOnProviderChanges(ctx, logr.Discard(), provider)
 			Expect(requests).To(BeEmpty())
-			Expect(unchanged).To(BeTrue())
 
 			// after updating LastUpdateTime expected requests should be returned
 			provider.Status.LastUpdateTime.Time = provider.Status.LastUpdateTime.Add(1 * time.Microsecond)

--- a/pkg/dnsman2/controller/controlplane/dnsentry/add_test.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/add_test.go
@@ -106,6 +106,30 @@ var _ = Describe("Add", func() {
 			Expect(checkEntriesToReconcileOnProviderChanges(ctx, provider)).To(ConsistOf(expectedRequests...))
 		})
 
+		It("should skip fan-out if provider status has not caught up with spec", func() {
+			provider := &v1alpha1.DNSProvider{
+				ObjectMeta: metav1.ObjectMeta{Name: "provider1", Namespace: "test", Generation: 2},
+				Status: v1alpha1.DNSProviderStatus{
+					ObservedGeneration: 1,
+					State:              v1alpha1.StateReady,
+					Domains: v1alpha1.DNSSelectionStatus{
+						Included: []string{"example.com"},
+					},
+					LastUpdateTime: &metav1.Time{Time: time.Now()},
+				},
+			}
+			Expect(checkEntriesToReconcileOnProviderChanges(ctx, provider)).To(BeEmpty())
+
+			// once status catches up, the fan-out should happen
+			provider.Status.ObservedGeneration = 2
+			Expect(checkEntriesToReconcileOnProviderChanges(ctx, provider)).To(ConsistOf(
+				reconcile.Request{NamespacedName: key1},
+				reconcile.Request{NamespacedName: key2},
+				reconcile.Request{NamespacedName: key3},
+				reconcile.Request{NamespacedName: key4},
+			))
+		})
+
 		It("should return empty list for not matching provider", func() {
 			provider := &v1alpha1.DNSProvider{
 				ObjectMeta: metav1.ObjectMeta{Name: "other-provider", Namespace: "test"},

--- a/pkg/dnsman2/controller/controlplane/dnsentry/reconciler.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/reconciler.go
@@ -45,10 +45,16 @@ type Reconciler struct {
 	defaultCNAMELookupInterval     int64
 	reconciliationDelayAfterUpdate time.Duration
 
-	state           *state.State
-	lookupProcessor lookup.LookupProcessor
-	lastUpdate      *ttlcache.Cache[client.ObjectKey, struct{}]
-	lastDriftCheck  *ttlcache.Cache[client.ObjectKey, struct{}]
+	state              *state.State
+	lookupProcessor    lookup.LookupProcessor
+	lastUpdate         *ttlcache.Cache[client.ObjectKey, struct{}]
+	lastDriftCheck     *ttlcache.Cache[client.ObjectKey, struct{}]
+	lastProviderUpdate *ttlcache.Cache[client.ObjectKey, providerSnapshot]
+}
+
+type providerSnapshot struct {
+	observedGeneration int64
+	lastUpdateTime     time.Time
 }
 
 // Reconcile reconciles DNSEntry resources.

--- a/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_test.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_test.go
@@ -344,7 +344,7 @@ var _ = Describe("Reconcile", func() {
 			state:           state.GetState(),
 			lookupProcessor: lookup.NewLookupProcessor(log.WithName("lookup-processor"), lookup.NewNullTrigger(), 1, 250*time.Millisecond),
 		}
-		reconciler.setCachePeriods(1*time.Microsecond, defaultDriftCheckPeriod)
+		reconciler.setCachePeriods(1*time.Microsecond, defaultDriftCheckPeriod, defaultProviderUpdateCachePeriod)
 		state.GetState().SetDNSHandlerFactory(registry)
 
 		mlh = lookup.NewMockLookupHost(map[string]lookup.MockLookupHostResult{

--- a/pkg/dnsman2/dns/provider/account.go
+++ b/pkg/dnsman2/dns/provider/account.go
@@ -133,6 +133,19 @@ func (a *DNSAccount) GetZones(ctx context.Context) ([]DNSHostedZone, error) {
 	return zones, err
 }
 
+// GetCachedZone returns the cached hosted zone for the given zone ID, or nil if not found.
+func (a *DNSAccount) GetCachedZone(zoneID dns.ZoneID) DNSHostedZone {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	for _, zone := range a.cachedZones {
+		if zone.ZoneID() == zoneID {
+			return zone
+		}
+	}
+	return nil
+}
+
 // GetCustomQueryDNSFunc returns a custom query DNS function for the given zone.
 func (a *DNSAccount) GetCustomQueryDNSFunc(zone dns.ZoneInfo, factory utils.QueryDNSFactoryFunc) (CustomQueryDNSFunc, error) {
 	return a.handler.GetCustomQueryDNSFunc(zone, factory)
@@ -330,15 +343,13 @@ func (m *AccountMap) GetDNSCachesByZone(ctx context.Context, zoneID dns.ZoneID) 
 
 	var result []*utils.DNSCache
 	for _, account := range m.accounts {
-		for _, zone := range account.cachedZones {
-			if zone.ZoneID() == zoneID {
-				zoneInfo := dns.NewZoneInfo(zone.ZoneID(), zone.Domain(), zone.IsPrivate(), zone.Key())
-				cache, err := account.getZoneQueryCache(ctx, zoneInfo)
-				if err != nil {
-					return nil, fmt.Errorf("failed to get DNS cache for zone %s: %w", zoneID, err)
-				}
-				result = append(result, cache)
+		if zone := account.GetCachedZone(zoneID); zone != nil {
+			zoneInfo := dns.NewZoneInfo(zone.ZoneID(), zone.Domain(), zone.IsPrivate(), zone.Key())
+			cache, err := account.getZoneQueryCache(ctx, zoneInfo)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get DNS cache for zone %s: %w", zoneID, err)
 			}
+			result = append(result, cache)
 		}
 	}
 	if len(result) == 0 {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Three related tuning changes to the next generation dnsentry controller that reduce unnecessary reconciliation work:

  1. Provider update cache — Introduce a TTL cache (lastProviderUpdate, 7-day TTL) that tracks each DNSProvider's Status.LastUpdateTime. When a provider watch event fires with an unchanged timestamp, the map function short-circuits — skipping the full DNSEntry list and avoiding mass fan-out reconciliation.
  2. Longer sync period — Default DNSEntry sync period bumped from 1 hour → 8 hours. Real changes still flow through watches; periodic sync is a safety net, not the primary trigger.
  3. Trigger logging — Add log.Info entries when periodic reconciliation runs and when a DNSProvider change (actually) triggers entry reconciliation, making load spikes traceable in logs.

Additionally, a data race has been fixed on field `account.cachedZones`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
[next-generation] Reduce reconciliation load on `DNSEntry` controller
```
