### PR TITLE
[next-generation] Prevent self-retrigger: finalizer robustness and status-patch elision for `DNSEntry`

### DIFF
--- a/pkg/dnsman2/controller/controlplane/dnsentry/common/common_suite_test.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/common/common_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package common_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCommon(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "DNSEntry Common Suite")
+}

--- a/pkg/dnsman2/controller/controlplane/dnsentry/common/statusupdater.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/common/statusupdater.go
@@ -10,7 +10,9 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns"
@@ -27,7 +29,13 @@ func (u *EntryStatusUpdater) UpdateStatus(modifier func(status *v1alpha1.DNSEntr
 		return *res
 	}
 
-	if len(u.Entry.Status.Targets) == 0 {
+	// Keep the finalizer only if we have provisioned DNS state (Status.Targets) and the entry is not
+	// fully ignored via annotation. This ties finalizer lifetime to what we actually own on the
+	// DNS provider side, rather than to Spec — an entry that never successfully reconciled has
+	// nothing to clean up. Fully-ignored entries drop the finalizer here as well, mirroring the
+	// handling in reconciler_reconcile.go's ignoredByAnnotation.
+	_, ignoreFully := dns.IgnoreFullByAnnotation(u.Entry)
+	if len(u.Entry.Status.Targets) == 0 || ignoreFully {
 		if res := u.RemoveFinalizer(); res != nil {
 			return *res
 		}
@@ -47,33 +55,71 @@ func (u *EntryStatusUpdater) updateStatus(modifier func(status *v1alpha1.DNSEntr
 	}
 	if !reflect.DeepEqual(oldStatus, &u.Entry.Status) {
 		u.Entry.Status.LastUpdateTime = &metav1.Time{Time: u.Clock.Now()}
-	}
 
-	u.Log.Info("updating status", "state", u.Entry.Status.State, "message", u.Entry.Status.Message)
-	if err := u.Client.Status().Patch(u.Ctx, u.Entry, patch); err != nil {
-		u.Log.Error(err, "failed to update status")
-		return &ReconcileResult{Err: err}
+		u.Log.Info("updating status", "state", u.Entry.Status.State, "message", u.Entry.Status.Message)
+		if err := u.Client.Status().Patch(u.Ctx, u.Entry, patch); err != nil {
+			u.Log.Error(err, "failed to update status")
+			return &ReconcileResult{Err: err}
+		}
 	}
 	return u.dropReconcileAnnotation()
 }
 
 // AddFinalizer adds the DNS finalizer to the DNSEntry resource.
+// The retry loop fetches a fresh copy to avoid overwriting concurrent status/annotation mutations
+// on u.Entry. On success u.Entry.Finalizers is synced from the fresh copy so callers see the
+// up-to-date finalizer list.
 func (u *EntryStatusUpdater) AddFinalizer() *ReconcileResult {
 	if u.Entry.DeletionTimestamp != nil {
 		return nil
 	}
-	if err := controllerutils.AddFinalizers(u.Ctx, u.Client, u.Entry, u.finalizerName()); err != nil {
+	if controllerutil.ContainsFinalizer(u.Entry, u.finalizerName()) {
+		return nil
+	}
+	var fresh *v1alpha1.DNSEntry
+	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		fresh = &v1alpha1.DNSEntry{}
+		if err := u.Client.Get(u.Ctx, client.ObjectKeyFromObject(u.Entry), fresh); err != nil {
+			return err
+		}
+		if fresh.DeletionTimestamp != nil || controllerutil.ContainsFinalizer(fresh, u.finalizerName()) {
+			return nil
+		}
+		return controllerutils.AddFinalizers(u.Ctx, u.Client, fresh, u.finalizerName())
+	}); err != nil {
 		u.Log.Error(err, "failed to add finalizer")
 		return &ReconcileResult{Err: err}
+	}
+	if fresh != nil {
+		u.Entry.Finalizers = fresh.Finalizers
 	}
 	return nil
 }
 
 // RemoveFinalizer removes the DNS finalizer from the DNSEntry resource.
+// The retry loop fetches a fresh copy to avoid overwriting concurrent status/annotation mutations
+// on u.Entry. On success u.Entry.Finalizers is synced from the fresh copy so callers see the
+// up-to-date finalizer list.
 func (u *EntryStatusUpdater) RemoveFinalizer() *ReconcileResult {
-	if err := controllerutils.RemoveFinalizers(u.Ctx, u.Client, u.Entry, u.finalizerName()); err != nil {
+	if !controllerutil.ContainsFinalizer(u.Entry, u.finalizerName()) {
+		return nil
+	}
+	var fresh *v1alpha1.DNSEntry
+	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		fresh = &v1alpha1.DNSEntry{}
+		if err := u.Client.Get(u.Ctx, client.ObjectKeyFromObject(u.Entry), fresh); err != nil {
+			return client.IgnoreNotFound(err)
+		}
+		if !controllerutil.ContainsFinalizer(fresh, u.finalizerName()) {
+			return nil
+		}
+		return client.IgnoreNotFound(controllerutils.RemoveFinalizers(u.Ctx, u.Client, fresh, u.finalizerName()))
+	}); err != nil {
 		u.Log.Error(err, "failed to remove finalizer")
 		return &ReconcileResult{Err: err}
+	}
+	if fresh != nil {
+		u.Entry.Finalizers = fresh.Finalizers
 	}
 	return nil
 }

--- a/pkg/dnsman2/controller/controlplane/dnsentry/common/statusupdater_test.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/common/statusupdater_test.go
@@ -1,0 +1,233 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package common_test
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/clock/testing"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	dnsmanclient "github.com/gardener/external-dns-management/pkg/dnsman2/client"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/controller/controlplane/dnsentry/common"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns"
+)
+
+var _ = Describe("EntryStatusUpdater", func() {
+	const (
+		entryNamespace = "test"
+		entryName      = "entry-1"
+	)
+	var (
+		ctx       = context.Background()
+		entryKey  = client.ObjectKey{Namespace: entryNamespace, Name: entryName}
+		finalizer = dns.ClassFinalizerName(dns.DefaultClass)
+
+		newEntry = func() *v1alpha1.DNSEntry {
+			return &v1alpha1.DNSEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       entryName,
+					Namespace:  entryNamespace,
+					Generation: 1,
+				},
+				Spec: v1alpha1.DNSEntrySpec{
+					DNSName: "foo.example.com",
+					Targets: []string{"1.2.3.4"},
+				},
+			}
+		}
+		newCtx = func(c client.Client, entry *v1alpha1.DNSEntry) *common.EntryContext {
+			return &common.EntryContext{
+				Client: c,
+				Clock:  &testing.FakeClock{},
+				Ctx:    ctx,
+				Log:    logr.Discard(),
+				Class:  dns.DefaultClass,
+				Entry:  entry,
+			}
+		}
+		buildClient = func(obj *v1alpha1.DNSEntry, funcs interceptor.Funcs) client.Client {
+			return fakeclient.NewClientBuilder().
+				WithScheme(dnsmanclient.ClusterScheme).
+				WithStatusSubresource(&v1alpha1.DNSEntry{}).
+				WithObjects(obj).
+				WithInterceptorFuncs(funcs).
+				Build()
+		}
+		countingStatusPatch = func(counter *int32) interceptor.Funcs {
+			return interceptor.Funcs{
+				SubResourcePatch: func(ctx context.Context, cl client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+					if subResourceName == "status" {
+						atomic.AddInt32(counter, 1)
+					}
+					return cl.Status().Patch(ctx, obj, patch, opts...)
+				},
+			}
+		}
+		countingPatch = func(counter *int32) interceptor.Funcs {
+			return interceptor.Funcs{
+				Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					atomic.AddInt32(counter, 1)
+					return cl.Patch(ctx, obj, patch, opts...)
+				},
+			}
+		}
+	)
+
+	Describe("UpdateStatus status-patch elision", func() {
+		It("does not patch the status subresource when the modifier does not change it", func() {
+			entry := newEntry()
+			entry.Status.State = v1alpha1.StateReady
+			entry.Status.Targets = []string{"1.2.3.4"}
+
+			var statusPatches int32
+			c := buildClient(entry.DeepCopy(), countingStatusPatch(&statusPatches))
+
+			live := &v1alpha1.DNSEntry{}
+			Expect(c.Get(ctx, entryKey, live)).To(Succeed())
+
+			ec := newCtx(c, live)
+			// Modifier is a no-op: values are already what the modifier would set.
+			result := ec.StatusUpdater().UpdateStatus(func(status *v1alpha1.DNSEntryStatus) error {
+				status.State = v1alpha1.StateReady
+				status.Targets = []string{"1.2.3.4"}
+				return nil
+			})
+			Expect(result.Err).ToNot(HaveOccurred())
+			Expect(atomic.LoadInt32(&statusPatches)).To(BeZero(),
+				"status subresource must not be patched when the modifier makes no change")
+		})
+
+		It("patches once on change and elides the second call with identical modifier output", func() {
+			entry := newEntry()
+
+			var statusPatches int32
+			c := buildClient(entry.DeepCopy(), countingStatusPatch(&statusPatches))
+
+			modifier := func(status *v1alpha1.DNSEntryStatus) error {
+				status.State = v1alpha1.StateReady
+				status.Message = ptr.To("dns entry active")
+				status.Targets = []string{"1.2.3.4"}
+				return nil
+			}
+
+			for _, tag := range []string{"first", "second"} {
+				live := &v1alpha1.DNSEntry{}
+				Expect(c.Get(ctx, entryKey, live)).To(Succeed())
+				result := newCtx(c, live).StatusUpdater().UpdateStatus(modifier)
+				Expect(result.Err).ToNot(HaveOccurred(), "%s call", tag)
+				Expect(atomic.LoadInt32(&statusPatches)).To(Equal(int32(1)),
+					"%s call: expected exactly one status patch across both calls", tag)
+			}
+		})
+	})
+
+	Describe("AddFinalizer / RemoveFinalizer retry-on-conflict", func() {
+		It("retries when the finalizer PATCH returns Conflict and eventually succeeds", func() {
+			var patchAttempts int32
+			c := buildClient(newEntry(), interceptor.Funcs{
+				Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					if atomic.AddInt32(&patchAttempts, 1) == 1 {
+						// Emulate an optimistic-lock failure on the first attempt.
+						return apierrors.NewConflict(
+							schema.GroupResource{Group: v1alpha1.SchemeGroupVersion.Group, Resource: "dnsentries"},
+							obj.GetName(),
+							apierrors.NewBadRequest("resource version mismatch"),
+						)
+					}
+					return cl.Patch(ctx, obj, patch, opts...)
+				},
+			})
+
+			// Use an in-memory entry whose ResourceVersion mismatches the store,
+			// exercising the Get-refresh in the retry loop.
+			stale := newEntry()
+			stale.ResourceVersion = "999"
+
+			res := newCtx(c, stale).StatusUpdater().AddFinalizer()
+			Expect(res).To(BeNil(), "AddFinalizer should succeed after retry")
+			Expect(atomic.LoadInt32(&patchAttempts)).To(BeNumerically(">=", 2),
+				"expected at least one retry after the injected Conflict")
+
+			live := &v1alpha1.DNSEntry{}
+			Expect(c.Get(ctx, entryKey, live)).To(Succeed())
+			Expect(live.Finalizers).To(ContainElement(finalizer))
+
+			// u.Entry.Finalizers must be synced from the fresh copy so callers see the up-to-date state.
+			Expect(stale.Finalizers).To(ContainElement(finalizer),
+				"AddFinalizer must sync u.Entry.Finalizers from the freshly fetched copy")
+		})
+
+		DescribeTable("skips PATCH when the desired finalizer state already holds",
+			func(withFinalizer bool, op func(*common.EntryStatusUpdater) *common.ReconcileResult) {
+				entry := newEntry()
+				if withFinalizer {
+					entry.Finalizers = []string{finalizer}
+				}
+				var patchAttempts int32
+				c := buildClient(entry.DeepCopy(), countingPatch(&patchAttempts))
+
+				res := op(newCtx(c, entry.DeepCopy()).StatusUpdater())
+				Expect(res).To(BeNil())
+				Expect(atomic.LoadInt32(&patchAttempts)).To(BeZero(),
+					"no PATCH expected when finalizer state is already the target")
+			},
+			Entry("AddFinalizer, finalizer already present", true,
+				func(u *common.EntryStatusUpdater) *common.ReconcileResult { return u.AddFinalizer() }),
+			Entry("RemoveFinalizer, finalizer already absent", false,
+				func(u *common.EntryStatusUpdater) *common.ReconcileResult { return u.RemoveFinalizer() }),
+		)
+	})
+
+	DescribeTable("UpdateStatus finalizer semantics",
+		func(hasStatusTargets, ignoreFully, initialFinalizer, expectFinalizer bool) {
+			entry := newEntry()
+			if hasStatusTargets {
+				entry.Status.State = v1alpha1.StateReady
+				entry.Status.Targets = []string{"1.2.3.4"}
+			}
+			if ignoreFully {
+				entry.Annotations = map[string]string{dns.AnnotationIgnore: dns.AnnotationIgnoreValueFull}
+			}
+			if initialFinalizer {
+				entry.Finalizers = []string{finalizer}
+			}
+
+			c := buildClient(entry.DeepCopy(), interceptor.Funcs{})
+
+			live := &v1alpha1.DNSEntry{}
+			Expect(c.Get(ctx, entryKey, live)).To(Succeed())
+
+			// Modifier is a no-op — the finalizer decision must come from Status/annotations alone.
+			result := newCtx(c, live).StatusUpdater().UpdateStatus(func(_ *v1alpha1.DNSEntryStatus) error { return nil })
+			Expect(result.Err).ToNot(HaveOccurred())
+
+			after := &v1alpha1.DNSEntry{}
+			Expect(c.Get(ctx, entryKey, after)).To(Succeed())
+			if expectFinalizer {
+				Expect(after.Finalizers).To(ContainElement(finalizer))
+			} else {
+				Expect(after.Finalizers).ToNot(ContainElement(finalizer))
+			}
+		},
+		Entry("Status.Targets set, not ignored, finalizer set → keeps finalizer",
+			true, false, true, true),
+		Entry("Status.Targets empty → removes finalizer",
+			false, false, true, false),
+		Entry("Status.Targets set, fully ignored → removes finalizer",
+			true, true, true, false),
+	)
+})

--- a/pkg/dnsman2/controller/controlplane/dnsentry/providerselector/providerselector.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/providerselector/providerselector.go
@@ -79,11 +79,7 @@ func (s *providerSelector) calcNewProvider() (*NewProviderData, *common.Reconcil
 	if res != nil {
 		return nil, res
 	}
-	if len(s.Entry.Spec.Targets) != 0 || len(s.Entry.Spec.Text) != 0 {
-		if res := s.StatusUpdater().AddFinalizer(); res != nil {
-			return nil, res
-		}
-	}
+
 	providerState := s.state.GetProviderState(providerKey)
 	if providerState == nil {
 		return nil, common.ErrorReconcileResult(fmt.Sprintf("failed to get provider state for provider %s", providerKey), false)

--- a/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_reconcile.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_reconcile.go
@@ -119,6 +119,11 @@ func (r *entryReconciliation) doReconcile() common.ReconcileResult {
 	if res != nil {
 		return *res
 	}
+	if len(targetsData.targets) > 0 {
+		if res := r.StatusUpdater().AddFinalizer(); res != nil {
+			return *res
+		}
+	}
 
 	if r.shouldTryRecordTypeDriftRecovery() {
 		r.insertPossibleAlternativeKeys(recordsToCheck)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
  This branch hardens the `EntryStatusUpdater` in the next generation `dnsentry` controller to prevent unnecessary reconcile loops and improve correctness under concurrent mutations.

  **Finalizer placement moved to actual DNS state**

  The finalizer is now added based on **calculated targets** (what was actually provisioned) rather than `spec.targets` (what was declared). An entry that never successfully reconciled has nothing to clean up on the provider side, so it no longer receives a finalizer prematurely. Fully-ignored entries (via the `dns.gardener.cloud/ignore: full` annotation) also have the finalizer dropped, mirroring the existing ignore-handling in the reconcile path.

  **Retry-on-conflict for finalizer mutations**
  
  `AddFinalizer` and `RemoveFinalizer` now use `retry.RetryOnConflict` with a fresh `Get` on each attempt. This avoids clobbering concurrent status or annotation updates that may have happened between when `u.Entry` was fetched and when the patch is applied. On success, `u.Entry.Finalizers` is synced from the freshly fetched copy so callers see the up-to-date state.

  **Conditional status patch**

  `updateStatus` now diffs the old and new status before calling `Client.Status().Patch`. If the modifier produces no change, the patch call is skipped entirely. This eliminates spurious `resourceVersion` bumps that would otherwise re-trigger the reconciler.

  ### Changed files
  
  | File | Change |
  |---|---|
  | `statusupdater.go` | Conditional status patch; retry-on-conflict for `AddFinalizer`/`RemoveFinalizer`; finalizer drop for fully-ignored entries |
  | `providerselector.go` | Remove premature finalizer addition on `spec.targets`; finalizer is now added by the reconcile path on actual targets |
  | `reconciler_reconcile.go` | Add finalizer when calculated targets are non-empty (correct placement) |
  | `statusupdater_test.go` | New test suite covering patch elision, retry-on-conflict, and finalizer semantics |
  | `common_suite_test.go` | New Ginkgo test suite bootstrap |

  ### Test plan

  - `TestCommon` covers:
    - Status patch is elided when the modifier produces no change
    - Status patch fires exactly once when a change occurs, and is elided on the identical second call
    - `AddFinalizer` retries on `Conflict` and eventually succeeds; `u.Entry.Finalizers` is synced afterward
    - `AddFinalizer`/`RemoveFinalizer` skip the PATCH when the desired state already holds
    - `UpdateStatus` finalizer semantics: keeps finalizer only when `Status.Targets` is non-empty and the entry is not fully ignored
    - 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
[next-generation] Prevent self-retrigger: finalizer robustness and status-patch elision for `DNSEntry`
```
