### PR TITLE
Improve container build: cache mounts, multi-arch, digest pinning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,44 +1,42 @@
+# syntax=docker/dockerfile:1.7
 # SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 
 #############      builder       #############
-FROM golang:1.26.5 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5 AS builder
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /build
 
 # Copy go mod and sum files
 COPY go.mod go.sum ./
-# Download all dependencies. Dependencies will be cached if the go.mod and go.sum files are not changed
-RUN go mod download
+# Download all dependencies. Cached via BuildKit cache mount independent of layer cache.
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 COPY . .
 
-RUN make release
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH make release
 
 ############# base
 FROM gcr.io/distroless/static-debian13:nonroot AS base
+WORKDIR /
+USER nonroot:nonroot
 
 #############      dns-controller-manager     #############
 FROM base AS dns-controller-manager
-WORKDIR /
 
 COPY --from=builder /build/dns-controller-manager /dns-controller-manager
-
-WORKDIR /
-
-USER 65534:65534
 
 ENTRYPOINT ["/dns-controller-manager"]
 
 #############      dns-controller-manager-next-generation     #############
 FROM base AS dns-controller-manager-next-generation
-WORKDIR /
 
 COPY --from=builder /build/dns-controller-manager-next-generation /dns-controller-manager-next-generation
-
-WORKDIR /
-
-USER 65534:65534
 
 ENTRYPOINT ["/dns-controller-manager-next-generation"]

--- a/Makefile
+++ b/Makefile
@@ -66,15 +66,28 @@ build-local:
 	    ./cmd/nextgen
 
 .PHONY: release
-release:
-	@CGO_ENABLED=0 go build -o $(EXECUTABLE) \
-	    -a \
-	    -ldflags "-w -X main.Version=$(VERSION)" \
-	    ./cmd/compound
-	@CGO_ENABLED=0 go build -o $(EXECUTABLE_NG) \
-	    -a \
-	    -ldflags "-w -X main.Version=$(VERSION)" \
-	    ./cmd/nextgen
+release: $(EXECUTABLE) $(EXECUTABLE_NG)
+
+# LDFLAGS_RELEASE:
+#   -s -w  strip symbol table and DWARF (smaller binary; no debuggability loss vs -w alone)
+#   -X ... embed the version. Overridable, e.g. `make release LDFLAGS_RELEASE_EXTRA=-X=...`.
+LDFLAGS_RELEASE ?= -s -w -X main.Version=$(VERSION) $(LDFLAGS_RELEASE_EXTRA)
+
+# GOFLAGS_RELEASE:
+#   -trimpath      remove absolute paths from binaries (reproducible builds).
+#   -buildvcs=false suppress VCS stamping (source tree in the Docker builder has no .git).
+GOFLAGS_RELEASE ?= -trimpath -buildvcs=false
+
+$(EXECUTABLE): FORCE
+	@CGO_ENABLED=0 go build $(GOFLAGS_RELEASE) -o $@ -ldflags '$(LDFLAGS_RELEASE)' ./cmd/compound
+
+$(EXECUTABLE_NG): FORCE
+	@CGO_ENABLED=0 go build $(GOFLAGS_RELEASE) -o $@ -ldflags '$(LDFLAGS_RELEASE)' ./cmd/nextgen
+
+# Phony marker so the two binary rules always re-evaluate (their real freshness
+# is handled by the Go build cache, not by mtime against ./cmd/... source trees).
+.PHONY: FORCE
+FORCE:
 
 .PHONY: unittests
 unittests: $(GINKGO)

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ build-local:
 	    ./cmd/compound
 	@CGO_ENABLED=1 go build -o $(EXECUTABLE_NG) \
 	    -race \
-	    -ldflags "-X main.Version=$(VERSION)-$(shell git rev-parse HEAD)"\
+	    -ldflags "$(LDFLAGS_NG)"\
 	    ./cmd/nextgen
 
 .PHONY: release
@@ -70,8 +70,7 @@ release: $(EXECUTABLE) $(EXECUTABLE_NG)
 
 # LDFLAGS_RELEASE:
 #   -s -w  strip symbol table and DWARF (smaller binary; no debuggability loss vs -w alone)
-#   -X ... embed the version. Overridable, e.g. `make release LDFLAGS_RELEASE_EXTRA=-X=...`.
-LDFLAGS_RELEASE ?= -s -w -X main.Version=$(VERSION) $(LDFLAGS_RELEASE_EXTRA)
+LDFLAGS_RELEASE ?= -s -w
 
 # GOFLAGS_RELEASE:
 #   -trimpath      remove absolute paths from binaries (reproducible builds).
@@ -79,10 +78,14 @@ LDFLAGS_RELEASE ?= -s -w -X main.Version=$(VERSION) $(LDFLAGS_RELEASE_EXTRA)
 GOFLAGS_RELEASE ?= -trimpath -buildvcs=false
 
 $(EXECUTABLE): FORCE
-	@CGO_ENABLED=0 go build $(GOFLAGS_RELEASE) -o $@ -ldflags '$(LDFLAGS_RELEASE)' ./cmd/compound
+	@CGO_ENABLED=0 go build $(GOFLAGS_RELEASE) -o $@ -ldflags '$(LDFLAGS_RELEASE) -X main.Version=$(VERSION)' ./cmd/compound
+
+LDFLAGS_NG := $(shell bash $(GARDENER_HACK_DIR)/get-build-ld-flags.sh k8s.io/component-base $(REPO_ROOT)/VERSION $(EXECUTABLE_NG))
 
 $(EXECUTABLE_NG): FORCE
-	@CGO_ENABLED=0 go build $(GOFLAGS_RELEASE) -o $@ -ldflags '$(LDFLAGS_RELEASE)' ./cmd/nextgen
+	@CGO_ENABLED=0 go build $(GOFLAGS_RELEASE) -o $@ \
+	    -ldflags '$(LDFLAGS_NG) $(LDFLAGS_RELEASE)' \
+	    ./cmd/nextgen
 
 # Phony marker so the two binary rules always re-evaluate (their real freshness
 # is handled by the Go build cache, not by mtime against ./cmd/... source trees).

--- a/renovate.json5
+++ b/renovate.json5
@@ -15,6 +15,13 @@
       groupName: 'gardener/gardener',
       matchPackageNames: ['/^(github\\.com\\/)?gardener\\/gardener(\\/.*)?$/'],
       enabled: true
+    },
+    {
+      // Pin Dockerfile base images by digest for reproducible, supply-chain-safe builds.
+      // Renovate will open a PR to add @sha256:... to any unpinned FROM tag and to
+      // keep the digest in sync with the tag on subsequent updates.
+      matchManagers: ['dockerfile'],
+      pinDigests: true,
     }
   ],
   // The following list of dependencies to ignore is updated by `make generate`.


### PR DESCRIPTION

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind task

**What this PR does / why we need it**:
Dockerfile:
- Enable BuildKit cache mounts for GOMODCACHE and GOCACHE so module downloads and compiled packages persist across builds independent of layer invalidation.
- Add `--platform=$BUILDPLATFORM` with `TARGETOS`/`TARGETARCH` args so the builder cross-compiles natively (no QEMU emulation of the Go compiler) — enables multi-arch images via buildx.
- Switch from hardcoded `USER 65534:65534` (Debian `nobody`) to the distroless-provided `nonroot` user (UID 65532).
- Hoist `WORKDIR`/`USER` into the shared `base` stage and drop the duplicated `WORKDIR /` in the final stages.
- Fix the version LD flags for the next-generation executable

Makefile (release target):
- Factor the two `go build` invocations into per-binary rules to avoid drift and allow building a single binary.
- Drop `-a`: it forces a full package rebuild every invocation and defeats the BuildKit go-build cache mount.
- Add `-s` to ldflags (strip symbol table alongside DWARF), `-trimpath` (reproducible builds), and `-buildvcs=false` (source tree in the Docker builder has no .git).
- Expose `LDFLAGS_RELEASE` / `GOFLAGS_RELEASE` / `LDFLAGS_RELEASE_EXTRA` as override points for CI.

renovate.json5:
- Add a `matchManagers: ['dockerfile']` + `pinDigests: true` rule so Renovate pins Dockerfile FROM tags by sha256 and keeps digests in sync with tag updates.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Improve container build: cache mounts, multi-arch, digest pinning
```
