### PR TITLE
[next-generation] Reduce periodic reconciliation frequency and clean up source controller logging

### DIFF
--- a/docs/api-reference/config.md
+++ b/docs/api-reference/config.md
@@ -344,7 +344,7 @@ integer
 </td>
 <td>
 <em>(Optional)</em>
-<p>SyncPeriod is the periodic reconciliation interval for all DNSEntry objects.<br />Note that even if not set, DNSObjects may still be reconciled periodically if `CacheResyncPeriod` is set<br />for the `ControlPlaneClientConnection` (`ClientConnection` in single-cluster mode).</p>
+<p>SyncPeriod is the periodic reconciliation interval for all DNSEntry objects.<br />Note that even if not set, `DNSEntry` objects may still be reconciled periodically if `CacheResyncPeriod` is set<br />for the `ControlPlaneClientConnection` (`ClientConnection` in single-cluster mode).</p>
 </td>
 </tr>
 <tr>

--- a/docs/api-reference/config.md
+++ b/docs/api-reference/config.md
@@ -344,7 +344,7 @@ integer
 </td>
 <td>
 <em>(Optional)</em>
-<p>SyncPeriod is the periodic reconciliation interval for all DNSEntry objects.</p>
+<p>SyncPeriod is the periodic reconciliation interval for all DNSEntry objects.<br />Note that even if not set, DNSObjects may still be reconciled periodically if `CacheResyncPeriod` is set<br />for the `ControlPlaneClientConnection` (`ClientConnection` in single-cluster mode).</p>
 </td>
 </tr>
 <tr>

--- a/pkg/dnsman2/apis/config/types.go
+++ b/pkg/dnsman2/apis/config/types.go
@@ -148,7 +148,7 @@ type DNSEntryControllerConfig struct {
 	// ConcurrentSyncs is the number of concurrent reconciliations for this controller.
 	ConcurrentSyncs *int
 	// SyncPeriod is the periodic reconciliation interval for all DNSEntry objects.
-	// Note that even if not set, DNSObjects may still be reconciled periodically if `CacheResyncPeriod` is set
+	// Note that even if not set, `DNSEntry` objects may still be reconciled periodically if `CacheResyncPeriod` is set
 	// for the `ControlPlaneClientConnection` (`ClientConnection` in single-cluster mode).
 	SyncPeriod *metav1.Duration
 	// ReconciliationTimeout is the maximum duration a reconciliation of a DNSEntry is allowed to take.

--- a/pkg/dnsman2/apis/config/types.go
+++ b/pkg/dnsman2/apis/config/types.go
@@ -148,6 +148,8 @@ type DNSEntryControllerConfig struct {
 	// ConcurrentSyncs is the number of concurrent reconciliations for this controller.
 	ConcurrentSyncs *int
 	// SyncPeriod is the periodic reconciliation interval for all DNSEntry objects.
+	// Note that even if not set, DNSObjects may still be reconciled periodically if `CacheResyncPeriod` is set
+	// for the `ControlPlaneClientConnection` (`ClientConnection` in single-cluster mode).
 	SyncPeriod *metav1.Duration
 	// ReconciliationTimeout is the maximum duration a reconciliation of a DNSEntry is allowed to take.
 	// Default value is 2 minutes.

--- a/pkg/dnsman2/apis/config/v1alpha1/defaults.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/defaults.go
@@ -47,7 +47,7 @@ func SetDefaults_ClientConnection(obj *ClientConnection) {
 		obj.Burst = 130
 	}
 	if obj.CacheResyncPeriod == nil {
-		obj.CacheResyncPeriod = &metav1.Duration{Duration: time.Hour}
+		obj.CacheResyncPeriod = &metav1.Duration{Duration: 10 * time.Hour}
 	}
 }
 
@@ -60,7 +60,7 @@ func SetDefaults_ControlPlaneClientConnection(obj *ControlPlaneClientConnection)
 		obj.Burst = 130
 	}
 	if obj.CacheResyncPeriod == nil {
-		obj.CacheResyncPeriod = &metav1.Duration{Duration: time.Hour}
+		obj.CacheResyncPeriod = &metav1.Duration{Duration: 10 * time.Hour}
 	}
 }
 

--- a/pkg/dnsman2/apis/config/v1alpha1/defaults.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/defaults.go
@@ -142,10 +142,7 @@ func SetDefaults_DNSEntryControllerConfig(obj *DNSEntryControllerConfig) {
 	if obj.ConcurrentSyncs == nil {
 		obj.ConcurrentSyncs = new(5)
 	}
-	if obj.SyncPeriod == nil {
-		// periodic sync is a safety net, not the primary trigger.
-		obj.SyncPeriod = &metav1.Duration{Duration: 8 * time.Hour}
-	}
+	// SyncPeriod is not activated by default. Instead, rely on the `CacheResyncPeriod` of the `ControlPlaneClientConnection`/`ClientConnection`.
 	if obj.ReconciliationTimeout == nil {
 		obj.ReconciliationTimeout = &metav1.Duration{Duration: 2 * time.Minute}
 	}

--- a/pkg/dnsman2/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/defaults_test.go
@@ -86,7 +86,7 @@ var _ = Describe("Defaults", func() {
 					QPS:   100.0,
 					Burst: 130,
 				}))
-				Expect(obj.ClientConnection.CacheResyncPeriod).To(Equal(&metav1.Duration{Duration: 10*time.Hour}))
+				Expect(obj.ClientConnection.CacheResyncPeriod).To(Equal(&metav1.Duration{Duration: 10 * time.Hour}))
 			})
 
 			It("should correctly default ControlPlaneClientConnection", func() {
@@ -97,7 +97,7 @@ var _ = Describe("Defaults", func() {
 					QPS:   100.0,
 					Burst: 130,
 				}))
-				Expect(obj.ControlPlaneClientConnection.CacheResyncPeriod).To(Equal(&metav1.Duration{Duration: 10*time.Hour}))
+				Expect(obj.ControlPlaneClientConnection.CacheResyncPeriod).To(Equal(&metav1.Duration{Duration: 10 * time.Hour}))
 			})
 		})
 
@@ -194,7 +194,7 @@ var _ = Describe("Defaults", func() {
 					SetDefaults_DNSEntryControllerConfig(obj)
 
 					Expect(obj.ConcurrentSyncs).To(PointTo(Equal(5)))
-					Expect(obj.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 8 * time.Hour})))
+					Expect(obj.SyncPeriod).To(BeNil())
 					Expect(obj.ReconciliationTimeout).To(PointTo(Equal(metav1.Duration{Duration: 2 * time.Minute})))
 					Expect(obj.ZoneMetricsInterval).To(PointTo(Equal(metav1.Duration{Duration: 30 * time.Second})))
 					Expect(obj.PropagationWaitTime).To(PointTo(Equal(metav1.Duration{Duration: 10 * time.Second})))

--- a/pkg/dnsman2/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/defaults_test.go
@@ -86,7 +86,7 @@ var _ = Describe("Defaults", func() {
 					QPS:   100.0,
 					Burst: 130,
 				}))
-				Expect(obj.ClientConnection.CacheResyncPeriod).To(Equal(&metav1.Duration{Duration: time.Hour}))
+				Expect(obj.ClientConnection.CacheResyncPeriod).To(Equal(&metav1.Duration{Duration: 10*time.Hour}))
 			})
 
 			It("should correctly default ControlPlaneClientConnection", func() {
@@ -97,7 +97,7 @@ var _ = Describe("Defaults", func() {
 					QPS:   100.0,
 					Burst: 130,
 				}))
-				Expect(obj.ControlPlaneClientConnection.CacheResyncPeriod).To(Equal(&metav1.Duration{Duration: time.Hour}))
+				Expect(obj.ControlPlaneClientConnection.CacheResyncPeriod).To(Equal(&metav1.Duration{Duration: 10*time.Hour}))
 			})
 		})
 

--- a/pkg/dnsman2/apis/config/v1alpha1/types.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/types.go
@@ -172,7 +172,7 @@ type DNSEntryControllerConfig struct {
 	// +optional
 	ConcurrentSyncs *int `json:"concurrentSyncs,omitempty"`
 	// SyncPeriod is the periodic reconciliation interval for all DNSEntry objects.
-	// Note that even if not set, DNSObjects may still be reconciled periodically if `CacheResyncPeriod` is set
+	// Note that even if not set, `DNSEntry` objects may still be reconciled periodically if `CacheResyncPeriod` is set
 	// for the `ControlPlaneClientConnection` (`ClientConnection` in single-cluster mode).
 	// +optional
 	SyncPeriod *metav1.Duration `json:"syncPeriod,omitempty"`

--- a/pkg/dnsman2/apis/config/v1alpha1/types.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/types.go
@@ -172,6 +172,8 @@ type DNSEntryControllerConfig struct {
 	// +optional
 	ConcurrentSyncs *int `json:"concurrentSyncs,omitempty"`
 	// SyncPeriod is the periodic reconciliation interval for all DNSEntry objects.
+	// Note that even if not set, DNSObjects may still be reconciled periodically if `CacheResyncPeriod` is set
+	// for the `ControlPlaneClientConnection` (`ClientConnection` in single-cluster mode).
 	// +optional
 	SyncPeriod *metav1.Duration `json:"syncPeriod,omitempty"`
 	// ReconciliationTimeout is the maximum duration a reconciliation of a DNSEntry is allowed to take.

--- a/pkg/dnsman2/controller/controlplane/dnsentry/add.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/add.go
@@ -47,6 +47,13 @@ const defaultProviderUpdateCachePeriod = 7 * 24 * time.Hour
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager, controlPlaneCluster cluster.Cluster, cfg *config.DNSManagerConfiguration) error {
 	r.Config = cfg.Controllers.DNSEntry
+	var cacheSyncPeriod *metav1.Duration
+	if mgr == controlPlaneCluster {
+		cacheSyncPeriod = cfg.ClientConnection.CacheResyncPeriod
+	} else {
+		cacheSyncPeriod = cfg.ControlPlaneClientConnection.CacheResyncPeriod
+	}
+
 	r.Class = cfg.Class
 	r.SecondaryClasses = cfg.SecondaryClasses
 	r.Namespace = cfg.Controllers.DNSProvider.Namespace
@@ -127,6 +134,10 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, controlPlaneCluster clust
 			return err
 		}
 		log.Info("Periodic reconciliation enabled", "syncPeriod", r.Config.SyncPeriod.Duration)
+	} else if cacheSyncPeriod != nil && cacheSyncPeriod.Duration > 0 {
+		log.Info("Periodic reconciliation relies on cache resync period", "cacheResyncPeriod", cacheSyncPeriod.Duration)
+	} else {
+		log.Info("No periodic reconciliation")
 	}
 
 	if interval := ptr.Deref(r.Config.ZoneMetricsInterval, metav1.Duration{}).Duration; interval > 0 {

--- a/pkg/dnsman2/controller/source/common/dnsspecinput.go
+++ b/pkg/dnsman2/controller/source/common/dnsspecinput.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,10 +46,10 @@ type DNSSpecInput struct {
 }
 
 // GetDNSSpecInputForService gets the DNS spec input for a service of type loadbalancer.
-func GetDNSSpecInputForService(log logr.Logger, state state.AnnotationState, gvk schema.GroupVersionKind, svc *corev1.Service) (*DNSSpecInput, error) {
+func GetDNSSpecInputForService(state state.AnnotationState, gvk schema.GroupVersionKind, svc *corev1.Service) (*DNSSpecInput, error) {
 	annotations := GetMergedAnnotation(gvk, state, svc)
 
-	names, err := GetDNSNamesFromAnnotations(log, annotations)
+	names, err := GetDNSNamesFromAnnotations(annotations)
 	if err != nil {
 		return nil, err
 	}
@@ -103,10 +102,10 @@ func GetTargetsForService(svc *corev1.Service, annotations map[string]string) *u
 }
 
 // GetDNSSpecInputForIngress gets the DNS spec input for an Ingress resource.
-func GetDNSSpecInputForIngress(log logr.Logger, state state.AnnotationState, gvk schema.GroupVersionKind, ingress *networkingv1.Ingress) (*DNSSpecInput, error) {
+func GetDNSSpecInputForIngress(state state.AnnotationState, gvk schema.GroupVersionKind, ingress *networkingv1.Ingress) (*DNSSpecInput, error) {
 	annotations := GetMergedAnnotation(gvk, state, ingress)
 
-	names, err := getDNSNamesForIngress(log, ingress, annotations)
+	names, err := getDNSNamesForIngress(ingress, annotations)
 	if err != nil {
 		return nil, err
 	}
@@ -121,8 +120,8 @@ func GetDNSSpecInputForIngress(log logr.Logger, state state.AnnotationState, gvk
 	})
 }
 
-func getDNSNamesForIngress(log logr.Logger, ingress *networkingv1.Ingress, annotations map[string]string) (*utils.UniqueStrings, error) {
-	annotatedNames, err := GetDNSNamesFromAnnotations(log, annotations)
+func getDNSNamesForIngress(ingress *networkingv1.Ingress, annotations map[string]string) (*utils.UniqueStrings, error) {
+	annotatedNames, err := GetDNSNamesFromAnnotations(annotations)
 	if err != nil {
 		return nil, err
 	}
@@ -242,10 +241,9 @@ func modifyEntryFor(entry *v1alpha1.DNSEntry, cfg config.SourceControllerConfig,
 }
 
 // GetDNSNamesFromAnnotations extracts DNS names from the corresponding annotation.
-func GetDNSNamesFromAnnotations(log logr.Logger, annotations map[string]string) (*utils.UniqueStrings, error) {
+func GetDNSNamesFromAnnotations(annotations map[string]string) (*utils.UniqueStrings, error) {
 	dnsNames, ok := annotations[dns.AnnotationDNSNames]
 	if !ok {
-		log.V(5).Info("No DNS names annotation", "key", dns.AnnotationDNSNames)
 		return nil, nil
 	}
 	if dnsNames == "" {

--- a/pkg/dnsman2/controller/source/common/dnsspecinput_test.go
+++ b/pkg/dnsman2/controller/source/common/dnsspecinput_test.go
@@ -5,7 +5,6 @@
 package common_test
 
 import (
-	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -21,7 +20,6 @@ import (
 var _ = Describe("DNSSpecInput", func() {
 	Describe("#GetDNSSpecInputForIngress", func() {
 		var (
-			log             = logr.Discard()
 			gkv             = networkingv1.SchemeGroupVersion.WithKind("Ingress")
 			annotationState = state.GetState().GetAnnotationState()
 			ingress         *networkingv1.Ingress
@@ -46,42 +44,42 @@ var _ = Describe("DNSSpecInput", func() {
 		})
 
 		It("should return nil when no dns names are specified", func() {
-			input, err := common.GetDNSSpecInputForIngress(log, annotationState, gkv, ingress)
+			input, err := common.GetDNSSpecInputForIngress(annotationState, gkv, ingress)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(input).To(BeNil())
 		})
 
 		It("should return an error when the dns names annotation is empty", func() {
 			ingress.Annotations[dns.AnnotationDNSNames] = ""
-			input, err := common.GetDNSSpecInputForIngress(log, annotationState, gkv, ingress)
+			input, err := common.GetDNSSpecInputForIngress(annotationState, gkv, ingress)
 			Expect(err).To(MatchError("empty value for annotation \"dns.gardener.cloud/dnsnames\""))
 			Expect(input).To(BeNil())
 		})
 
 		It("should handle the wildcard dns name annotation", func() {
 			ingress.Annotations[dns.AnnotationDNSNames] = "*"
-			input, err := common.GetDNSSpecInputForIngress(log, annotationState, gkv, ingress)
+			input, err := common.GetDNSSpecInputForIngress(annotationState, gkv, ingress)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(input.Names.ToSlice()).To(ConsistOf([]string{"example.com", "gardener.cloud", "wikipedia.org"}))
 		})
 
 		It("should handle the wildcard dns name annotation (alias value 'all')", func() {
 			ingress.Annotations[dns.AnnotationDNSNames] = "all"
-			input, err := common.GetDNSSpecInputForIngress(log, annotationState, gkv, ingress)
+			input, err := common.GetDNSSpecInputForIngress(annotationState, gkv, ingress)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(input.Names.ToSlice()).To(ConsistOf([]string{"example.com", "gardener.cloud", "wikipedia.org"}))
 		})
 
 		It("should handle a subset of dns names", func() {
 			ingress.Annotations[dns.AnnotationDNSNames] = "example.com,gardener.cloud"
-			input, err := common.GetDNSSpecInputForIngress(log, annotationState, gkv, ingress)
+			input, err := common.GetDNSSpecInputForIngress(annotationState, gkv, ingress)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(input.Names.ToSlice()).To(ConsistOf([]string{"example.com", "gardener.cloud"}))
 		})
 
 		It("should reject dns names not found in the ingress rules", func() {
 			ingress.Annotations[dns.AnnotationDNSNames] = "example.com,notfound.com"
-			input, err := common.GetDNSSpecInputForIngress(log, annotationState, gkv, ingress)
+			input, err := common.GetDNSSpecInputForIngress(annotationState, gkv, ingress)
 			Expect(err).To(MatchError("annotated dns names notfound.com not declared by ingress"))
 			Expect(input).To(BeNil())
 		})
@@ -89,7 +87,7 @@ var _ = Describe("DNSSpecInput", func() {
 		It("should set ResolveTargetsToAddresses when annotation is present", func() {
 			ingress.Annotations[dns.AnnotationDNSNames] = "example.com"
 			ingress.Annotations[dns.AnnotationResolveTargetsToAddresses] = "true"
-			input, err := common.GetDNSSpecInputForIngress(log, annotationState, gkv, ingress)
+			input, err := common.GetDNSSpecInputForIngress(annotationState, gkv, ingress)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(input.ResolveTargetsToAddresses).To(Equal(new(true)))
 		})
@@ -97,7 +95,7 @@ var _ = Describe("DNSSpecInput", func() {
 		It("should set IP Targets from ingress status", func() {
 			ingress.Annotations[dns.AnnotationDNSNames] = "example.com"
 			ingress.Status.LoadBalancer.Ingress = []networkingv1.IngressLoadBalancerIngress{{IP: "1.1.1.1"}}
-			input, err := common.GetDNSSpecInputForIngress(log, annotationState, gkv, ingress)
+			input, err := common.GetDNSSpecInputForIngress(annotationState, gkv, ingress)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(input.Targets.ToSlice()).To(ConsistOf([]string{"1.1.1.1"}))
 		})
@@ -105,7 +103,7 @@ var _ = Describe("DNSSpecInput", func() {
 		It("should set hostname Targets from ingress status", func() {
 			ingress.Annotations[dns.AnnotationDNSNames] = "example.com"
 			ingress.Status.LoadBalancer.Ingress = []networkingv1.IngressLoadBalancerIngress{{Hostname: "https://example.org"}}
-			input, err := common.GetDNSSpecInputForIngress(log, annotationState, gkv, ingress)
+			input, err := common.GetDNSSpecInputForIngress(annotationState, gkv, ingress)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(input.Targets.ToSlice()).To(ConsistOf([]string{"https://example.org"}))
 		})
@@ -113,7 +111,7 @@ var _ = Describe("DNSSpecInput", func() {
 		It("should prefer IP Targets over hostnames ingress status", func() {
 			ingress.Annotations[dns.AnnotationDNSNames] = "example.com"
 			ingress.Status.LoadBalancer.Ingress = []networkingv1.IngressLoadBalancerIngress{{IP: "1.1.1.1", Hostname: "https://example.org"}}
-			input, err := common.GetDNSSpecInputForIngress(log, annotationState, gkv, ingress)
+			input, err := common.GetDNSSpecInputForIngress(annotationState, gkv, ingress)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(input.Targets.ToSlice()).To(ConsistOf([]string{"1.1.1.1"}))
 		})
@@ -121,7 +119,7 @@ var _ = Describe("DNSSpecInput", func() {
 		It("should collect multiple, unique Targets from ingress status", func() {
 			ingress.Annotations[dns.AnnotationDNSNames] = "example.com"
 			ingress.Status.LoadBalancer.Ingress = []networkingv1.IngressLoadBalancerIngress{{IP: "1.1.1.1"}, {IP: "1.0.0.1"}, {IP: "1.1.1.1"}}
-			input, err := common.GetDNSSpecInputForIngress(log, annotationState, gkv, ingress)
+			input, err := common.GetDNSSpecInputForIngress(annotationState, gkv, ingress)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(input.Targets.ToSlice()).To(ConsistOf([]string{"1.1.1.1", "1.0.0.1"}))
 		})
@@ -129,7 +127,7 @@ var _ = Describe("DNSSpecInput", func() {
 		It("should set IPStack when annotation is present", func() {
 			ingress.Annotations[dns.AnnotationDNSNames] = "example.com"
 			ingress.Annotations[dns.AnnotationIPStack] = dns.AnnotationValueIPStackIPDualStack
-			input, err := common.GetDNSSpecInputForIngress(log, annotationState, gkv, ingress)
+			input, err := common.GetDNSSpecInputForIngress(annotationState, gkv, ingress)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(input.IPStack).To(Equal("dual-stack"))
 		})

--- a/pkg/dnsman2/controller/source/common/sourcereconciler.go
+++ b/pkg/dnsman2/controller/source/common/sourcereconciler.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/gardener/gardener/pkg/controllerutils"
-	"github.com/go-logr/logr"
 	"golang.org/x/exp/maps"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -21,6 +20,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
@@ -31,7 +31,6 @@ import (
 // SourceReconciler is base for source reconcilers.
 type SourceReconciler[SourceObject client.Object] struct {
 	actuator           SourceActuator[SourceObject]
-	Log                logr.Logger
 	Client             client.Client
 	ControlPlaneClient client.Client
 	Recorder           RecorderWithDeduplication
@@ -109,6 +108,7 @@ func (r *SourceReconciler[SourceObject]) createOrUpdateDNSEntry(
 	dnsName string,
 	entry *dnsv1alpha1.DNSEntry,
 ) error {
+	log := logf.FromContext(ctx)
 	modifier := func() error {
 		modifyEntryFor(entry, r.Config, dnsSpecInput, dnsName)
 		return nil
@@ -120,7 +120,7 @@ func (r *SourceReconciler[SourceObject]) createOrUpdateDNSEntry(
 		if err := r.ControlPlaneClient.Create(ctx, entry); err != nil {
 			return fmt.Errorf("failed to create DNSEntry: %w", err)
 		}
-		r.Log.Info("created DNSEntry", "name", entry.Name)
+		log.Info("created DNSEntry", "name", entry.Name)
 		r.Recorder.Eventf(obj, nil, corev1.EventTypeNormal, "DNSEntryCreated", "Create", "%s: created entry %s in control plane", entry.Spec.DNSName, entry.Name)
 		return nil
 	}
@@ -130,7 +130,7 @@ func (r *SourceReconciler[SourceObject]) createOrUpdateDNSEntry(
 		return fmt.Errorf("failed to patch DNSEntry %s: %w", client.ObjectKeyFromObject(entry), err)
 	}
 	if result == controllerutil.OperationResultUpdated {
-		r.Log.Info("updated DNSEntry", "name", entry.Name)
+		log.Info("updated DNSEntry", "name", entry.Name)
 		r.Recorder.Eventf(obj, nil, corev1.EventTypeNormal, "DNSEntryUpdated", "Update", "%s: updated entry %s in control plane", entry.Spec.DNSName, entry.Name)
 	}
 	return nil
@@ -138,7 +138,8 @@ func (r *SourceReconciler[SourceObject]) createOrUpdateDNSEntry(
 
 // DoDelete performs delete reconciliation for given object.
 func (r *SourceReconciler[SourceObject]) DoDelete(ctx context.Context, obj client.Object) (reconcile.Result, error) {
-	r.Log.Info("cleanup")
+	log := logf.FromContext(ctx)
+	log.Info("cleanup")
 
 	ownedEntries, err := r.getExistingOwnedDNSEntries(ctx, obj)
 	if err != nil {
@@ -191,6 +192,7 @@ func (r *SourceReconciler[SourceObject]) deleteObsoleteOwnedDNSEntries(
 	ownedEntries []dnsv1alpha1.DNSEntry,
 	entriesToKeep []*dnsv1alpha1.DNSEntry,
 ) error {
+	log := logf.FromContext(ctx)
 outer:
 	for _, ownedEntry := range ownedEntries {
 		for _, entryToKeep := range entriesToKeep {
@@ -201,7 +203,7 @@ outer:
 		if err := r.ControlPlaneClient.Delete(ctx, &ownedEntry); client.IgnoreNotFound(err) != nil {
 			return fmt.Errorf("failed to delete obsolete owned DNSEntry %s: %w", client.ObjectKeyFromObject(&ownedEntry), err)
 		}
-		r.Log.Info("delete obsolete owned DNSEntry", "name", ownedEntry.Name)
+		log.Info("delete obsolete owned DNSEntry", "name", ownedEntry.Name)
 		r.Recorder.DedupEventf(obj, corev1.EventTypeNormal, "DNSEntryDeleted", "DNSEntryDeleted", "%s: deleted entry %s in control plane", ownedEntry.Spec.DNSName, ownedEntry.Name)
 	}
 	return nil
@@ -228,10 +230,12 @@ func (r *SourceReconciler[SourceObject]) targetNamespace(owner metav1.Object) st
 
 // Reconcile reconciles source objects using the actuator.
 func (r *SourceReconciler[SourceObject]) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	log := logf.FromContext(ctx).WithName(r.actuator.ControllerName())
+	ctx = logf.IntoContext(ctx, log)
 	sourceObject := r.actuator.NewSourceObject()
 	if err := r.Client.Get(ctx, req.NamespacedName, sourceObject); err != nil {
 		if apierrors.IsNotFound(err) {
-			r.Log.V(1).Info("Object is gone, stop reconciling")
+			log.V(1).Info("Object is gone, stop reconciling")
 			r.actuator.OnDelete(req.NamespacedName)
 			return reconcile.Result{}, nil
 		}

--- a/pkg/dnsman2/controller/source/common/sourcereconciler_add.go
+++ b/pkg/dnsman2/controller/source/common/sourcereconciler_add.go
@@ -19,7 +19,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -62,7 +61,6 @@ func (r *SourceReconciler[SourceObject]) AddToManager(
 	r.SourceClass = config.GetSourceClass(cfg)
 	r.TargetClass = config.GetTargetClass(cfg)
 
-	r.Log = logf.Log.WithName(r.actuator.ControllerName() + "-controller")
 	r.Client = mgr.GetClient()
 	r.ControlPlaneClient = controlPlaneCluster.GetClient()
 	if r.Recorder == nil {

--- a/pkg/dnsman2/controller/source/dnsentry/actuator.go
+++ b/pkg/dnsman2/controller/source/dnsentry/actuator.go
@@ -11,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
@@ -37,7 +38,8 @@ func (a *Actuator) ReconcileSourceObject(
 	reconcile.Result,
 	error,
 ) {
-	r.Log.Info("reconcile")
+	log := logf.FromContext(ctx)
+	log.Info("reconcile")
 
 	var input *common.DNSSpecInput
 	if a.IsRelevantSourceObject(r, entry) {
@@ -52,12 +54,12 @@ func (a *Actuator) ReconcileSourceObject(
 	if targetKey := entry.Annotations[dns.AnnotationTargetEntry]; targetKey != "" {
 		objectKey := getTargetEntryObjectKey(targetKey)
 		if objectKey == nil {
-			r.Log.Error(nil, "Invalid target DNSEntry annotation", "value", targetKey)
+			log.Error(nil, "Invalid target DNSEntry annotation", "value", targetKey)
 			return res, nil
 		}
 		targetEntry := &dnsv1alpha1.DNSEntry{}
 		if err = r.ControlPlaneClient.Get(ctx, *objectKey, targetEntry); client.IgnoreNotFound(err) != nil {
-			r.Log.Error(err, "Could not get target DNSEntry", "key", targetKey)
+			log.Error(err, "Could not get target DNSEntry", "key", targetKey)
 			return res, err
 		}
 		if err == nil && targetEntry.DeletionTimestamp == nil {
@@ -65,7 +67,7 @@ func (a *Actuator) ReconcileSourceObject(
 			entry.Status = *targetEntry.Status.DeepCopy()
 			entry.Status.ObservedGeneration = entry.Generation
 			if err := r.Client.Status().Patch(ctx, entry, patch); err != nil {
-				r.Log.Error(err, "Could not update status")
+				log.Error(err, "Could not update status")
 				return res, err
 			}
 		}

--- a/pkg/dnsman2/controller/source/gatewayapi/common.go
+++ b/pkg/dnsman2/controller/source/gatewayapi/common.go
@@ -125,7 +125,7 @@ func hasRelevantCRDs(apiResources []metav1.APIResource) bool {
 }
 
 func getDNSNames[T client.Object](ctx context.Context, r *common.SourceReconciler[T], gatewayObj client.Object, annotations map[string]string) (*utils.UniqueStrings, error) {
-	annotatedNames, err := common.GetDNSNamesFromAnnotations(r.Log, annotations)
+	annotatedNames, err := common.GetDNSNamesFromAnnotations(annotations)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/dnsman2/controller/source/gatewayapi/common_test.go
+++ b/pkg/dnsman2/controller/source/gatewayapi/common_test.go
@@ -7,7 +7,6 @@ package gatewayapi
 import (
 	"context"
 
-	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -56,7 +55,6 @@ var _ = Describe("Common", func() {
 			reconciler = &common.SourceReconciler[client.Object]{}
 
 			reconciler.Client = fakeClient
-			reconciler.Log = logr.Discard()
 			reconciler.State = state.GetState().GetAnnotationState()
 		})
 
@@ -263,7 +261,6 @@ var _ = Describe("Common", func() {
 			}
 
 			reconciler.Client = fakeClient
-			reconciler.Log = logr.Discard()
 		})
 
 		It("should get a single DNS name based on the annotation", func() {

--- a/pkg/dnsman2/controller/source/gatewayapi/v1/actuator.go
+++ b/pkg/dnsman2/controller/source/gatewayapi/v1/actuator.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayapisv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -44,7 +45,7 @@ func (a *Actuator) ReconcileSourceObject(
 	reconcile.Result,
 	error,
 ) {
-	r.Log.Info("reconcile")
+	logf.FromContext(ctx).Info("reconcile")
 
 	var input *common.DNSSpecInput
 	if a.IsRelevantSourceObject(r, gateway) {

--- a/pkg/dnsman2/controller/source/gatewayapi/v1beta1/actuator.go
+++ b/pkg/dnsman2/controller/source/gatewayapi/v1beta1/actuator.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayapisv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapisv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -45,7 +46,7 @@ func (a *Actuator) ReconcileSourceObject(
 	reconcile.Result,
 	error,
 ) {
-	r.Log.Info("reconcile")
+	logf.FromContext(ctx).Info("reconcile")
 
 	var input *common.DNSSpecInput
 	if a.IsRelevantSourceObject(r, gateway) {

--- a/pkg/dnsman2/controller/source/ingress/actuator.go
+++ b/pkg/dnsman2/controller/source/ingress/actuator.go
@@ -11,6 +11,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/gardener/external-dns-management/pkg/dnsman2/controller/source/common"
@@ -35,12 +36,13 @@ func (a *Actuator) ReconcileSourceObject(
 	reconcile.Result,
 	error,
 ) {
-	r.Log.Info("reconcile")
+	log := logf.FromContext(ctx)
+	log.Info("reconcile")
 
 	var input *common.DNSSpecInput
 	if a.IsRelevantSourceObject(r, ingress) {
 		var err error
-		input, err = common.GetDNSSpecInputForIngress(r.Log, r.State, r.GVK, ingress)
+		input, err = common.GetDNSSpecInputForIngress(r.State, r.GVK, ingress)
 		if err != nil {
 			r.Recorder.DedupEventf(ingress, corev1.EventTypeWarning, "Invalid", "Reconcile", "%s", err)
 			return reconcile.Result{}, err

--- a/pkg/dnsman2/controller/source/istio/common.go
+++ b/pkg/dnsman2/controller/source/istio/common.go
@@ -44,7 +44,7 @@ const (
 func GetDNSSpecInput[T client.Object](ctx context.Context, r *common.SourceReconciler[T], gatewayObj client.Object, state *ObjectToGatewaysState) (*common.DNSSpecInput, error) {
 	annotations := common.GetMergedAnnotation(r.GVK, r.State, gatewayObj)
 
-	annotatedNames, err := common.GetDNSNamesFromAnnotations(r.Log, annotations)
+	annotatedNames, err := common.GetDNSNamesFromAnnotations(annotations)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/dnsman2/controller/source/istio/v1/actuator.go
+++ b/pkg/dnsman2/controller/source/istio/v1/actuator.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/gardener/external-dns-management/pkg/dnsman2/controller/source/common"
@@ -55,7 +56,7 @@ func (a *Actuator) ReconcileSourceObject(
 	reconcile.Result,
 	error,
 ) {
-	r.Log.Info("reconcile")
+	logf.FromContext(ctx).Info("reconcile")
 
 	var input *common.DNSSpecInput
 	if a.IsRelevantSourceObject(r, gateway) {

--- a/pkg/dnsman2/controller/source/istio/v1alpha3/actuator.go
+++ b/pkg/dnsman2/controller/source/istio/v1alpha3/actuator.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/gardener/external-dns-management/pkg/dnsman2/controller/source/common"
@@ -55,7 +56,7 @@ func (a *Actuator) ReconcileSourceObject(
 	reconcile.Result,
 	error,
 ) {
-	r.Log.Info("reconcile")
+	logf.FromContext(ctx).Info("reconcile")
 
 	var input *common.DNSSpecInput
 	if a.IsRelevantSourceObject(r, gateway) {

--- a/pkg/dnsman2/controller/source/istio/v1beta1/actuator.go
+++ b/pkg/dnsman2/controller/source/istio/v1beta1/actuator.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/gardener/external-dns-management/pkg/dnsman2/controller/source/common"
@@ -55,7 +56,7 @@ func (a *Actuator) ReconcileSourceObject(
 	reconcile.Result,
 	error,
 ) {
-	r.Log.Info("reconcile")
+	logf.FromContext(ctx).Info("reconcile")
 
 	var input *common.DNSSpecInput
 	if a.IsRelevantSourceObject(r, gateway) {

--- a/pkg/dnsman2/controller/source/service/actuator.go
+++ b/pkg/dnsman2/controller/source/service/actuator.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/gardener/external-dns-management/pkg/dnsman2/controller/source/common"
@@ -34,12 +35,13 @@ func (a *Actuator) ReconcileSourceObject(
 	reconcile.Result,
 	error,
 ) {
-	r.Log.Info("reconcile")
+	log := logf.FromContext(ctx)
+	log.Info("reconcile")
 
 	var input *common.DNSSpecInput
 	if a.IsRelevantSourceObject(r, service) {
 		var err error
-		input, err = common.GetDNSSpecInputForService(r.Log, r.State, r.GVK, service)
+		input, err = common.GetDNSSpecInputForService(r.State, r.GVK, service)
 		if err != nil {
 			r.Recorder.DedupEventf(service, corev1.EventTypeWarning, "Invalid", "Reconcile", "%s", err)
 			return reconcile.Result{}, err

--- a/test/integration/dnsman2/provider_entry_test.go
+++ b/test/integration/dnsman2/provider_entry_test.go
@@ -153,6 +153,8 @@ var _ = Describe("Provider/Entry collaboration tests", func() {
 		cfg := &config.DNSManagerConfiguration{
 			LogLevel:  "debug",
 			LogFormat: "text",
+			ClientConnection: &config.ClientConnection{},
+			ControlPlaneClientConnection: &config.ControlPlaneClientConnection{},
 			Controllers: config.ControllerConfiguration{
 				DNSProvider: config.DNSProviderControllerConfig{
 					Namespace:  testRunID,

--- a/test/integration/dnsman2/provider_entry_test.go
+++ b/test/integration/dnsman2/provider_entry_test.go
@@ -151,9 +151,9 @@ var _ = Describe("Provider/Entry collaboration tests", func() {
 		})
 
 		cfg := &config.DNSManagerConfiguration{
-			LogLevel:  "debug",
-			LogFormat: "text",
-			ClientConnection: &config.ClientConnection{},
+			LogLevel:                     "debug",
+			LogFormat:                    "text",
+			ClientConnection:             &config.ClientConnection{},
 			ControlPlaneClientConnection: &config.ControlPlaneClientConnection{},
 			Controllers: config.ControllerConfiguration{
 				DNSProvider: config.DNSProviderControllerConfig{

--- a/test/integration/dnsman2/source_test.go
+++ b/test/integration/dnsman2/source_test.go
@@ -156,8 +156,10 @@ var _ = Describe("Provider/Entry/Source collaboration tests", func() {
 		log.Info("Created Namespace for test on source cluster", "namespaceName", sourceNamespace.Name)
 
 		cfg := &config.DNSManagerConfiguration{
-			LogLevel:  "debug",
-			LogFormat: "text",
+			LogLevel:                     "debug",
+			LogFormat:                    "text",
+			ClientConnection:             &config.ClientConnection{},
+			ControlPlaneClientConnection: &config.ControlPlaneClientConnection{},
 			Controllers: config.ControllerConfiguration{
 				DNSProvider: config.DNSProviderControllerConfig{
 					Namespace:  testRunID,


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
  - Set default `CacheResyncPeriod` to 10 hours (from 1 hour) for both `ClientConnection` and
    `ControlPlaneClientConnection` to reduce unnecessary periodic reconciliations. The controller-runtime
    cache resync triggers a full reconcile loop for every watched object. In the control plane this
    includes `DNSEntry` objects, whose reconciliation may invoke calls to external DNS provider APIs
    (e.g. to check or update records). Keeping the resync period at 1 hour would cause gratuitous
    provider API traffic and potentially rate-limit pressure with no benefit, since controllers already
    react to object changes via watches. 10 hours aligns with the `DriftCheckPeriod` default (12 hours),
    making the resync a true safety net rather than a frequent background trigger.
  - Removed the explicit `SyncPeriod` default (was 8 hours) for the `DNSEntry` controller.
    The `SyncPeriod` ticker and `CacheResyncPeriod` both result in the same reconciliation code running;
    having both is redundant. With `CacheResyncPeriod` set to 10 hours, the cache resync serves as the
    periodic safety net, so `SyncPeriod` is left unset by default. Operators can still set it explicitly
    to get a dedicated, independently tunable reconciliation interval. A startup log message now reflects
    which periodic path is active.
  - Refactored source controller logging to use context-propagated loggers (`logf.FromContext(ctx)`)
    instead of a stored `logr.Logger` field on `SourceReconciler`, improving log correlation by
    carrying request context (reconciliation ID, namespace/name) through all log calls.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
[next-generation] Reduce periodic reconciliation frequency and clean up source controller logging
```
