### PR TITLE
[next-generation] Fix flaky provider/entry test — DNSEntry stuck in Error after provider becomes Ready

### DIFF
--- a/pkg/dnsman2/controller/controlplane/dnsentry/add.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/add.go
@@ -198,11 +198,18 @@ func (r *Reconciler) entriesToReconcileOnProviderChanges(ctx context.Context, lo
 			})
 		}
 	}
-	r.lastProviderUpdate.Set(
-		providerKey,
-		providerSnapshot{observedGeneration: observedGeneration, lastUpdateTime: newLastUpdateTime},
-		0,
-	)
+	// Cache the snapshot only when the fan-out actually enqueued entries. Recording it on an empty
+	// fan-out would suppress the identical event even though no entry was triggered yet (e.g. an entry
+	// not yet visible in the informer cache when the provider turned ready), which - without a periodic
+	// SyncPeriod - could leave that entry stuck. Skipping the cache write here lets a later identical
+	// event retry the fan-out; the entry self-requeue is the primary safety net, this avoids relying on it.
+	if len(requests) > 0 {
+		r.lastProviderUpdate.Set(
+			providerKey,
+			providerSnapshot{observedGeneration: observedGeneration, lastUpdateTime: newLastUpdateTime},
+			0,
+		)
+	}
 	log.Info("trigger reconciliation by DNSProvider change", "entries", len(requests), "provider", providerKey)
 	return requests
 }

--- a/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_reconcile.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_reconcile.go
@@ -27,6 +27,11 @@ import (
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/utils"
 )
 
+// waitForProviderRetryInterval is the requeue delay used when an entry cannot proceed because no
+// matching provider was found or its provider is not ready yet. It lets the entry recover on its own
+// (independently of the DNSProvider->entry fan-out) and is kept short so recovery is prompt.
+const waitForProviderRetryInterval = 2 * time.Second
+
 type entryReconciliation struct {
 	common.EntryContext
 	namespace                  string
@@ -248,7 +253,7 @@ func validateDNSEntry(entry *v1alpha1.DNSEntry) error {
 }
 
 func (r *entryReconciliation) updateStatusWithoutProvider() common.ReconcileResult {
-	return r.StatusUpdater().UpdateStatus(func(status *v1alpha1.DNSEntryStatus) error {
+	res := r.StatusUpdater().UpdateStatus(func(status *v1alpha1.DNSEntryStatus) error {
 		status.Provider = nil
 		status.ObservedGeneration = r.Entry.Generation
 		if len(status.Targets) > 0 && status.Zone != nil {
@@ -260,6 +265,12 @@ func (r *entryReconciliation) updateStatusWithoutProvider() common.ReconcileResu
 		status.Message = new("no matching DNS provider found")
 		return nil
 	})
+	// Self-requeue so the entry recovers on its own once a matching provider becomes ready,
+	// even if the DNSProvider->entry fan-out (see entriesToReconcileOnProviderChanges) misses it.
+	if res.Err == nil && res.Result.IsZero() {
+		res.Result.RequeueAfter = waitForProviderRetryInterval
+	}
+	return res
 }
 
 func (r *entryReconciliation) updateStatusWithProvider(targetsData *newTargetsData) common.ReconcileResult {
@@ -356,7 +367,11 @@ func (r *entryReconciliation) checkProviderNotReady(data *providerselector.NewPr
 		} else {
 			msg = fmt.Sprintf("provider %s is not ready yet", data.ProviderKey)
 		}
-		return common.StaleReconcileResult(msg, false)
+		// Self-requeue so the entry recovers on its own once the provider becomes ready, even if the
+		// DNSProvider->entry fan-out (see entriesToReconcileOnProviderChanges) misses it.
+		res := common.StaleReconcileResult(msg, true)
+		res.Result.RequeueAfter = waitForProviderRetryInterval
+		return res
 	}
 	return nil
 }

--- a/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_test.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_test.go
@@ -250,7 +250,13 @@ var _ = Describe("Reconcile", func() {
 			Expect(entry.Status.State).To(Equal(state), "state should match")
 			if state != "Stale" || entry.Status.Provider == nil {
 				Expect(err).ToNot(HaveOccurred(), "failed to reconcile Entry")
-				Expect(result).To(Equal(reconcile.Result{}))
+				if entry.Status.Provider == nil && (state == "Error" || state == "Stale") {
+					// No matching provider found: the entry self-requeues so it recovers once a
+					// provider becomes ready, independently of the DNSProvider->entry fan-out.
+					Expect(result).To(Equal(reconcile.Result{RequeueAfter: waitForProviderRetryInterval}))
+				} else {
+					Expect(result).To(Equal(reconcile.Result{}))
+				}
 			} else {
 				Expect(err).ToNot(HaveOccurred(), "expected successful reconciliation with status update")
 				Expect(entry.Status.Message).NotTo(BeNil(), "expected non-empty status message")


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind flake

**What this PR does / why we need it**:
## Fix flaky provider/entry test — DNSEntry stuck in Error after provider becomes Ready
  
  ### Problem
  A `DNSEntry` that couldn't find a ready provider had **no self-requeue** and relied entirely on the
  `DNSProvider → entry` fan-out to be re-reconciled. When a provider transitions `Error → Ready` in a
  single status patch, that emits **one** watch event; a healthy provider then generates no further
  events. If the fan-out for that one event races with the shared informer cache (entry not yet visible),
  the entry is never enqueued and — with `SyncPeriod` disabled — stays stuck in `Error`. Flaky on slow CI
  VMs, and a real robustness gap in production.

  ### Fix
  - **Self-requeue (load-bearing):** the entry now requeues itself (2s) on the *no matching provider* and
    *provider not ready* paths, so it recovers independently of the fan-out.
  - **Fan-out cache hardening:** `entriesToReconcileOnProviderChanges` no longer records its dedup snapshot
    when zero entries were enqueued, so a later identical provider event isn't permanently suppressed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
