### PR TITLE
[next-generation] Fix incorrect zone exclusion for included subdomains of excluded domains

### DIFF
--- a/pkg/dns/provider/selection/selection.go
+++ b/pkg/dns/provider/selection/selection.go
@@ -65,6 +65,14 @@ func CalcZoneAndDomainSelection(spec v1alpha1.DNSProviderSpec, allzones []LightD
 		this.Error = err.Error()
 		return this
 	}
+	if err := validateNoOverlap(this.SpecDomainSel.Include, this.SpecDomainSel.Exclude, "domains"); err != nil {
+		this.Error = err.Error()
+		return this
+	}
+	if err := validateNoOverlap(this.SpecZoneSel.Include, this.SpecZoneSel.Exclude, "zones"); err != nil {
+		this.Error = err.Error()
+		return this
+	}
 
 	var zones []LightDNSHostedZone
 	for _, z := range allzones {
@@ -185,6 +193,15 @@ func validateDomains(domains utils.StringSet, name string) error {
 	for domain := range domains {
 		if strings.HasPrefix(domain, "*.") {
 			return fmt.Errorf("wildcards are not allowed in %s '%s' (hint: remove the wildcard)", name, domain)
+		}
+	}
+	return nil
+}
+
+func validateNoOverlap(include, exclude utils.StringSet, kind string) error {
+	for item := range include {
+		if exclude.Contains(item) {
+			return fmt.Errorf("%s '%s' is specified in both include and exclude", kind, item)
 		}
 	}
 	return nil

--- a/pkg/dns/provider/selection/selection_test.go
+++ b/pkg/dns/provider/selection/selection_test.go
@@ -163,6 +163,48 @@ var _ = Describe("Selection", func() {
 		}))
 	})
 
+	It("validates domain include/exclude overlap", func() {
+		spec := v1alpha1.DNSProviderSpec{
+			Type: "test",
+			Domains: &v1alpha1.DNSSelection{
+				Include: []string{"a.b"},
+				Exclude: []string{"a.b"},
+			},
+		}
+		result := CalcZoneAndDomainSelection(spec, allzones)
+		Expect(result).To(Equal(SelectionResult{
+			SpecZoneSel: NewSubSelection(),
+			SpecDomainSel: SubSelection{
+				Include: utils.NewStringSet("a.b"),
+				Exclude: utils.NewStringSet("a.b"),
+			},
+			ZoneSel:   NewSubSelection(),
+			DomainSel: NewSubSelection(),
+			Error:     "domains 'a.b' is specified in both include and exclude",
+		}))
+	})
+
+	It("validates zone include/exclude overlap", func() {
+		spec := v1alpha1.DNSProviderSpec{
+			Type: "test",
+			Zones: &v1alpha1.DNSSelection{
+				Include: []string{"ZAB"},
+				Exclude: []string{"ZAB"},
+			},
+		}
+		result := CalcZoneAndDomainSelection(spec, allzones)
+		Expect(result).To(Equal(SelectionResult{
+			SpecZoneSel: SubSelection{
+				Include: utils.NewStringSet("ZAB"),
+				Exclude: utils.NewStringSet("ZAB"),
+			},
+			SpecDomainSel: NewSubSelection(),
+			ZoneSel:       NewSubSelection(),
+			DomainSel:     NewSubSelection(),
+			Error:         "zones 'ZAB' is specified in both include and exclude",
+		}))
+	})
+
 	It("handles zones exclusion", func() {
 		spec := v1alpha1.DNSProviderSpec{
 			Type: "test",

--- a/pkg/dns/provider/selection/selection_test.go
+++ b/pkg/dns/provider/selection/selection_test.go
@@ -386,6 +386,60 @@ var _ = Describe("Selection", func() {
 		}))
 	})
 
+	It("handles included subdomain of excluded domain", func() {
+		spec := v1alpha1.DNSProviderSpec{
+			Type: "test",
+			Domains: &v1alpha1.DNSSelection{
+				Include: []string{"sub.a.b"},
+				Exclude: []string{"a.b"},
+			},
+		}
+		result := CalcZoneAndDomainSelection(spec, []LightDNSHostedZone{zab})
+		Expect(result).To(Equal(SelectionResult{
+			Zones:       []LightDNSHostedZone{zab},
+			SpecZoneSel: NewSubSelection(),
+			SpecDomainSel: SubSelection{
+				Include: utils.NewStringSet("sub.a.b"),
+				Exclude: utils.NewStringSet("a.b"),
+			},
+			ZoneSel: SubSelection{
+				Include: utils.NewStringSet("ZAB"),
+				Exclude: utils.NewStringSet(),
+			},
+			DomainSel: SubSelection{
+				Include: utils.NewStringSet("sub.a.b"),
+				Exclude: utils.NewStringSet("a.b"),
+			},
+		}))
+	})
+
+	It("handles included subdomain of excluded domain with super zone", func() {
+		spec := v1alpha1.DNSProviderSpec{
+			Type: "test",
+			Domains: &v1alpha1.DNSSelection{
+				Include: []string{"sub.c.a.b"},
+				Exclude: []string{"a.b"},
+			},
+		}
+		result := CalcZoneAndDomainSelection(spec, []LightDNSHostedZone{zab, zcab})
+		Expect(result).To(Equal(SelectionResult{
+			Zones:       []LightDNSHostedZone{zcab},
+			SpecZoneSel: NewSubSelection(),
+			SpecDomainSel: SubSelection{
+				Include: utils.NewStringSet("sub.c.a.b"),
+				Exclude: utils.NewStringSet("a.b"),
+			},
+			ZoneSel: SubSelection{
+				Include: utils.NewStringSet("ZCAB"),
+				Exclude: utils.NewStringSet("ZAB"),
+			},
+			DomainSel: SubSelection{
+				Include: utils.NewStringSet("sub.c.a.b"),
+				Exclude: utils.NewStringSet("a.b"),
+			},
+		}))
+	})
+
 	Context("forwarded own zones", func() {
 		zb := &lightDNSHostedZone{
 			id:               dns.NewZoneID("test", "ZB"),

--- a/pkg/dnsman2/dns/provider/selection/selection.go
+++ b/pkg/dnsman2/dns/provider/selection/selection.go
@@ -207,6 +207,13 @@ outerExclude:
 	for _, zone := range result.Zones {
 		for domain := range result.DomainSel.Exclude {
 			if dnsutils.Match(zone.Domain(), domain) {
+				// Only exclude the zone if no included domain is a subdomain of the excluded domain,
+				// because an included subdomain of an excluded domain still needs the zone.
+				for includedDomain := range result.DomainSel.Include {
+					if dnsutils.Match(includedDomain, domain) && includedDomain != domain {
+						continue outerExclude
+					}
+				}
 				zoneExcludeCandidates.Insert(zone)
 				continue outerExclude
 			}

--- a/pkg/dnsman2/dns/provider/selection/selection.go
+++ b/pkg/dnsman2/dns/provider/selection/selection.go
@@ -80,6 +80,14 @@ func CalcZoneAndDomainSelection(spec v1alpha1.DNSProviderSpec, allzones []LightD
 		result.Error = err.Error()
 		return result
 	}
+	if err := validateNoOverlap(result.SpecDomainSel.Include, result.SpecDomainSel.Exclude, "domains"); err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	if err := validateNoOverlap(result.SpecZoneSel.Include, result.SpecZoneSel.Exclude, "zones"); err != nil {
+		result.Error = err.Error()
+		return result
+	}
 
 	forwardedZones := map[string][]LightDNSHostedZone{}
 	for _, z1 := range allzones {
@@ -252,6 +260,15 @@ func validateDomains(domains sets.Set[string], name string) error {
 	for domain := range domains {
 		if strings.HasPrefix(domain, "*.") {
 			return fmt.Errorf("wildcards are not allowed in %s '%s' (hint: remove the wildcard)", name, domain)
+		}
+	}
+	return nil
+}
+
+func validateNoOverlap(include, exclude sets.Set[string], kind string) error {
+	for item := range include {
+		if exclude.Has(item) {
+			return fmt.Errorf("%s '%s' is specified in both include and exclude", kind, item)
 		}
 	}
 	return nil

--- a/pkg/dnsman2/dns/provider/selection/selection.go
+++ b/pkg/dnsman2/dns/provider/selection/selection.go
@@ -211,19 +211,13 @@ outer:
 		}
 	}
 
-outerExclude:
 	for _, zone := range result.Zones {
 		for domain := range result.DomainSel.Exclude {
 			if dnsutils.Match(zone.Domain(), domain) {
-				// Only exclude the zone if no included domain is a subdomain of the excluded domain,
-				// because an included subdomain of an excluded domain still needs the zone.
-				for includedDomain := range result.DomainSel.Include {
-					if dnsutils.Match(includedDomain, domain) && includedDomain != domain {
-						continue outerExclude
-					}
+				if !hasIncludedSubdomainOf(result.DomainSel.Include, domain) {
+					zoneExcludeCandidates.Insert(zone)
 				}
-				zoneExcludeCandidates.Insert(zone)
-				continue outerExclude
+				break
 			}
 		}
 	}
@@ -254,6 +248,15 @@ outerExcludeDomain:
 	}
 
 	return result
+}
+
+func hasIncludedSubdomainOf(included sets.Set[string], domain string) bool {
+	for d := range included {
+		if dnsutils.Match(d, domain) && d != domain {
+			return true
+		}
+	}
+	return false
 }
 
 func validateDomains(domains sets.Set[string], name string) error {

--- a/pkg/dnsman2/dns/provider/selection/selection_test.go
+++ b/pkg/dnsman2/dns/provider/selection/selection_test.go
@@ -156,6 +156,48 @@ var _ = Describe("Selection", func() {
 		}))
 	})
 
+	It("validates domain include/exclude overlap", func() {
+		spec := v1alpha1.DNSProviderSpec{
+			Type: "test",
+			Domains: &v1alpha1.DNSSelection{
+				Include: []string{"a.b"},
+				Exclude: []string{"a.b"},
+			},
+		}
+		result := CalcZoneAndDomainSelection(spec, allzones)
+		Expect(result).To(Equal(SelectionResult{
+			SpecZoneSel: NewSubSelection(),
+			SpecDomainSel: SubSelection{
+				Include: sets.New("a.b"),
+				Exclude: sets.New("a.b"),
+			},
+			ZoneSel:   NewSubSelection(),
+			DomainSel: NewSubSelection(),
+			Error:     "domains 'a.b' is specified in both include and exclude",
+		}))
+	})
+
+	It("validates zone include/exclude overlap", func() {
+		spec := v1alpha1.DNSProviderSpec{
+			Type: "test",
+			Zones: &v1alpha1.DNSSelection{
+				Include: []string{"ZAB"},
+				Exclude: []string{"ZAB"},
+			},
+		}
+		result := CalcZoneAndDomainSelection(spec, allzones)
+		Expect(result).To(Equal(SelectionResult{
+			SpecZoneSel: SubSelection{
+				Include: sets.New("ZAB"),
+				Exclude: sets.New("ZAB"),
+			},
+			SpecDomainSel: NewSubSelection(),
+			ZoneSel:       NewSubSelection(),
+			DomainSel:     NewSubSelection(),
+			Error:         "zones 'ZAB' is specified in both include and exclude",
+		}))
+	})
+
 	It("handles zones exclusion", func() {
 		spec := v1alpha1.DNSProviderSpec{
 			Type: "test",

--- a/pkg/dnsman2/dns/provider/selection/selection_test.go
+++ b/pkg/dnsman2/dns/provider/selection/selection_test.go
@@ -403,6 +403,60 @@ var _ = Describe("Selection", func() {
 		}))
 	})
 
+	It("handles included subdomain of excluded domain", func() {
+		spec := v1alpha1.DNSProviderSpec{
+			Type: "test",
+			Domains: &v1alpha1.DNSSelection{
+				Include: []string{"sub.a.b"},
+				Exclude: []string{"a.b"},
+			},
+		}
+		result := CalcZoneAndDomainSelection(spec, []LightDNSHostedZone{zab})
+		Expect(result).To(Equal(SelectionResult{
+			Zones:       []LightDNSHostedZone{zab},
+			SpecZoneSel: NewSubSelection(),
+			SpecDomainSel: SubSelection{
+				Include: sets.New[string]("sub.a.b"),
+				Exclude: sets.New[string]("a.b"),
+			},
+			ZoneSel: SubSelection{
+				Include: sets.New[string]("ZAB"),
+				Exclude: sets.New[string](),
+			},
+			DomainSel: SubSelection{
+				Include: sets.New[string]("sub.a.b"),
+				Exclude: sets.New[string]("a.b"),
+			},
+		}))
+	})
+
+	It("handles included subdomain of excluded domain with super zone", func() {
+		spec := v1alpha1.DNSProviderSpec{
+			Type: "test",
+			Domains: &v1alpha1.DNSSelection{
+				Include: []string{"sub.c.a.b"},
+				Exclude: []string{"a.b"},
+			},
+		}
+		result := CalcZoneAndDomainSelection(spec, []LightDNSHostedZone{zab, zcab})
+		Expect(result).To(Equal(SelectionResult{
+			Zones:       []LightDNSHostedZone{zcab},
+			SpecZoneSel: NewSubSelection(),
+			SpecDomainSel: SubSelection{
+				Include: sets.New[string]("sub.c.a.b"),
+				Exclude: sets.New[string]("a.b"),
+			},
+			ZoneSel: SubSelection{
+				Include: sets.New[string]("ZCAB"),
+				Exclude: sets.New[string]("ZAB"),
+			},
+			DomainSel: SubSelection{
+				Include: sets.New[string]("sub.c.a.b"),
+				Exclude: sets.New[string]("a.b"),
+			},
+		}))
+	})
+
 	Context("forwarded own zones", func() {
 		zb := &lightDNSHostedZone{
 			id:     dns.NewZoneID("test", "ZB"),


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
When a DNSProvider spec included a subdomain of an excluded domain — e.g. `include: ["sub.a.b"]`, `exclude: ["a.b"]` — the zone hosting `a.b` was incorrectly excluded from selection, even though it is needed to serve `sub.a.b`. DNS entries for `sub.a.b` would silently fail to be managed.

Additionally, specifying the same entry in both include and exclude for domains or zones is now rejected early for both legacy and next-generation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
[next-generation] Fix incorrect zone exclusion for included subdomains of excluded domains
```
