### PR TITLE
Adapt VPA resources to explicitly specify update mode `InPlaceOrRecreate`

### DIFF
--- a/charts/external-dns-management/values.yaml
+++ b/charts/external-dns-management/values.yaml
@@ -28,7 +28,7 @@ vpa:
     cpu: 50m
     memory: 50Mi
   updatePolicy:
-    updateMode: "Recreate"
+    updateMode: "InPlaceOrRecreate"
 
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind cleanup

**What this PR does / why we need it**:
Gardener's `VPAInPlaceUpdates` feature gate has been promoted and unconditionally enabled. This unconditionally enables the Gardener Resource
  Manager's `vpa-in-place-updates` admission webhook, which was previously mutating the value from `Recreate` to `InPlaceOrRecreate` at admission
  time. This change makes the extension explicitly set the correct value, aligning the code with the actual runtime behavior and removing the implicit
  dependency on the webhook mutation.

**Which issue(s) this PR fixes**:

Part of gardener/gardener#12955

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The update mode of the VerticalPodAutoscaler resources deployed by the external-dns-management is now explicitly set to `InPlaceOrRecreate`, reflecting the actual runtime behavior after the unconditional enablement of the `VPAInPlaceUpdates` feature gate.
```
