### PR TITLE
[aws-route53] Raise maximum length for AWS_SESSION_TOKEN to 8192

### DIFF
--- a/pkg/controller/provider/aws/validation/adapter.go
+++ b/pkg/controller/provider/aws/validation/adapter.go
@@ -47,7 +47,7 @@ func NewAdapter() provider.DNSHandlerAdapter {
 	checks.Add(provider.OptionalProperty("AWS_USE_CREDENTIALS_CHAIN").
 		Validators(provider.NoTrailingWhitespaceValidator, provider.BoolValidator))
 	checks.Add(provider.OptionalProperty("AWS_SESSION_TOKEN", "sessionToken").
-		Validators(provider.MaxLengthValidator(512)).
+		Validators(provider.MaxLengthValidator(8192)). // AWS does not specify a maximum size for session tokens. Therefore, the typical maximum length of HTTP headers is used.
 		HideValue())
 	checks.Add(provider.OptionalProperty(securityv1alpha1constants.DataKeyToken).
 		Validators(provider.MaxLengthValidator(4096)))

--- a/pkg/dnsman2/dns/provider/handler/aws/factory.go
+++ b/pkg/dnsman2/dns/provider/handler/aws/factory.go
@@ -73,7 +73,7 @@ func newAdapter() provider.DNSHandlerAdapter {
 	checks.Add(provider.OptionalProperty("AWS_USE_CREDENTIALS_CHAIN").
 		Validators(provider.NoTrailingWhitespaceValidator, provider.BoolValidator))
 	checks.Add(provider.OptionalProperty("AWS_SESSION_TOKEN", "sessionToken").
-		Validators(provider.MaxLengthValidator(512)).
+		Validators(provider.MaxLengthValidator(8192)). // AWS does not specify a maximum size for session tokens. Therefore, the typical maximum length of HTTP headers is used.
 		HideValue())
 	checks.Add(provider.OptionalProperty(securityv1alpha1constants.DataKeyToken).
 		Validators(provider.MaxLengthValidator(4096)))


### PR DESCRIPTION
**How to categorize this PR?**

/kind bug

**What this PR does / why we need it**:

Configuring an `aws-route53` `DNSProvider` with temporary STS credentials fails validation with:

```
validation failed for property AWS_SESSION_TOKEN: value exceeds maximum length of 512 characters
```

The `AWS_SESSION_TOKEN` / `sessionToken` property is validated with `MaxLengthValidator(512)`. That limit was introduced together with the provider secret validation in #535 without a stated rationale, and has been carried over unchanged ever since (copied to the dnsman2 adapter in #553, moved into its own package in #589, alias `sessionToken` added in #781).

512 characters is well below what AWS actually returns. AWS explicitly documents that the session token size is *not* fixed:

> The size of the session token that AWS STS API operations return is not fixed. We strongly recommend that you make no assumptions about the maximum size. The typical token size is less than 4096 bytes, but that can vary.

-- [Requesting temporary security credentials](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html)

There is also no session token entry in the [IAM and STS character limits](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html) table, so there is no hard upper bound that could be used here. Token size grows with session tags, inline session policies and managed policy ARNs, so tokens beyond 512 characters are perfectly normal -- in particular for credentials obtained via `AssumeRole`.

Since AWS specifies no maximum, this PR raises the limit to 8192, following the same reasoning already applied to the PowerDNS API key: the session token is transmitted in the `X-Amz-Security-Token` HTTP header, so the typical maximum length of HTTP headers is used as the upper bound.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

The limit is defined in two places -- once for dnsman1 (`pkg/controller/provider/aws/validation/adapter.go`) and once for dnsman2 (`pkg/dnsman2/dns/provider/handler/aws/factory.go`). Both are updated to keep the two adapters consistent.

**Release note**:

```bugfix user
Validation of `aws-route53` provider secrets no longer rejects valid `AWS_SESSION_TOKEN`/`sessionToken` values. The maximum accepted length was raised from 512 to 8192 characters, because AWS does not specify a maximum size for STS session tokens.
```
