### PR TITLE
Add per-entry failure backoff and fix finalizer ordering for DNSEntry in next-generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,6 +639,9 @@ Flags:
       --compound.dns.pool.resync-period duration                      Period for resynchronization for pool dns of controller compound
       --compound.dns.pool.size int                                    Worker pool size for pool dns of controller compound
       --compound.dry-run                                              just check, don't modify of controller compound
+      --compound.entry-failure-backoff-base duration                  base delay for the exponential backoff applied to persistently failing entries before they trigger a hosted zone reconciliation again of controller compound
+      --compound.entry-failure-backoff-factor int                     multiplier applied per consecutive failure for the entry failure backoff of controller compound
+      --compound.entry-failure-backoff-max duration                   maximum delay for the entry failure backoff of controller compound
       --compound.google-clouddns.advanced.batch-size int              batch size for change requests (currently only used for aws-route53) of controller compound
       --compound.google-clouddns.advanced.max-retries int             maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53) of controller compound
       --compound.google-clouddns.blocked-zone zone-id                 Blocks a zone given in the format zone-id from a provider as if the zone is not existing. of controller compound
@@ -651,6 +654,12 @@ Flags:
       --compound.infoblox-dns.ratelimiter.burst int                   number of burst requests for rate limiter of controller compound
       --compound.infoblox-dns.ratelimiter.enabled                     enables rate limiter for DNS provider requests of controller compound
       --compound.infoblox-dns.ratelimiter.qps int                     maximum requests/queries per second of controller compound
+      --compound.local.advanced.batch-size int                        batch size for change requests (currently only used for aws-route53) of controller compound
+      --compound.local.advanced.max-retries int                       maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53) of controller compound
+      --compound.local.blocked-zone zone-id                           Blocks a zone given in the format zone-id from a provider as if the zone is not existing. of controller compound
+      --compound.local.ratelimiter.burst int                          number of burst requests for rate limiter of controller compound
+      --compound.local.ratelimiter.enabled                            enables rate limiter for DNS provider requests of controller compound
+      --compound.local.ratelimiter.qps int                            maximum requests/queries per second of controller compound
       --compound.lock-status-check-period duration                    interval for dns lock status checks of controller compound
       --compound.netlify-dns.advanced.batch-size int                  batch size for change requests (currently only used for aws-route53) of controller compound
       --compound.netlify-dns.advanced.max-retries int                 maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53) of controller compound
@@ -740,6 +749,9 @@ Flags:
       --dnsprovider-replication.targets.pool.size int                 Worker pool size for pool targets of controller dnsprovider-replication
       --dry-run                                                       just check, don't modify
       --enable-profiling                                              enables profiling server at path /debug/pprof (needs option --server-port-http)
+      --entry-failure-backoff-base duration                           base delay for the exponential backoff applied to persistently failing entries before they trigger a hosted zone reconciliation again
+      --entry-failure-backoff-factor int                              multiplier applied per consecutive failure for the entry failure backoff
+      --entry-failure-backoff-max duration                            maximum delay for the entry failure backoff
       --exclude-domains stringArray                                   excluded domains
       --force-crd-update                                              enforce update of crds even they are unmanaged
       --google-clouddns.advanced.batch-size int                       batch size for change requests (currently only used for aws-route53)
@@ -804,18 +816,24 @@ Flags:
       --k8s-gateways-dns.targets.pool.size int                        Worker pool size for pool targets of controller k8s-gateways-dns
       --key string                                                    selecting key for annotation
       --kubeconfig string                                             default cluster access
-      --kubeconfig.burst int                                          option to set the maximum burst to the apiserver of the cluster default
+      --kubeconfig.burst int                                          option to set the maximum burst to the apiserver of the cluster default (default 100)
       --kubeconfig.conditional-deploy-crds                            deployment of required crds for cluster default only if there is no managed resource in garden namespace deploying it
       --kubeconfig.crds-shoot-no-cleanup-label                        add the label 'shoot.gardener.cloud/no-cleanup=true' for CRDS deployed on cluster default
       --kubeconfig.disable-deploy-crds                                disable deployment of required crds for cluster default
       --kubeconfig.id string                                          id for cluster default
       --kubeconfig.migration-ids string                               migration id for cluster default
-      --kubeconfig.qps int                                            option to set the maximum QPS to the apiserver of the cluster default
+      --kubeconfig.qps int                                            option to set the maximum QPS to the apiserver of the cluster default (default 50)
       --lease-duration duration                                       lease duration
       --lease-name string                                             name for lease object
       --lease-renew-deadline duration                                 lease renew deadline
       --lease-resource-lock string                                    determines which resource lock to use for leader election, defaults to 'leases'
       --lease-retry-period duration                                   lease retry period
+      --local.advanced.batch-size int                                 batch size for change requests (currently only used for aws-route53)
+      --local.advanced.max-retries int                                maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53)
+      --local.blocked-zone zone-id                                    Blocks a zone given in the format zone-id from a provider as if the zone is not existing.
+      --local.ratelimiter.burst int                                   number of burst requests for rate limiter
+      --local.ratelimiter.enabled                                     enables rate limiter for DNS provider requests
+      --local.ratelimiter.qps int                                     maximum requests/queries per second
       --lock-status-check-period duration                             interval for dns lock status checks
   -D, --log-level string                                              logrus log level
       --maintainer string                                             maintainer key for crds (default "dns-controller-manager")
@@ -846,7 +864,7 @@ Flags:
       --powerdns.ratelimiter.qps int                                  maximum requests/queries per second
       --provider-types string                                         comma separated list of provider types to enable
       --providers string                                              cluster to look for provider objects
-      --providers.burst int                                           option to set the maximum burst to the apiserver of the cluster provider
+      --providers.burst int                                           option to set the maximum burst to the apiserver of the cluster provider (default 100)
       --providers.conditional-deploy-crds                             deployment of required crds for cluster provider only if there is no managed resource in garden namespace deploying it
       --providers.crds-shoot-no-cleanup-label                         add the label 'shoot.gardener.cloud/no-cleanup=true' for CRDS deployed on cluster provider
       --providers.disable-deploy-crds                                 disable deployment of required crds for cluster provider
@@ -854,7 +872,7 @@ Flags:
       --providers.migration-ids string                                migration id for cluster provider
       --providers.pool.resync-period duration                         Period for resynchronization for pool providers
       --providers.pool.size int                                       Worker pool size for pool providers
-      --providers.qps int                                             option to set the maximum QPS to the apiserver of the cluster provider
+      --providers.qps int                                             option to set the maximum QPS to the apiserver of the cluster provider (default 50)
       --ratelimiter.burst int                                         number of burst requests for rate limiter
       --ratelimiter.enabled                                           enables rate limiter for DNS provider requests
       --ratelimiter.qps int                                           maximum requests/queries per second
@@ -898,13 +916,13 @@ Flags:
       --target-name-prefix string                                     name prefix in target namespace for cross cluster generation, name prefix in target namespace for cross cluster replication
       --target-namespace string                                       target namespace for cross cluster generation
       --target-realms string                                          realm(s) to use for generated DNS entries, realm(s) to use for replicated DNS provider
-      --target.burst int                                              option to set the maximum burst to the apiserver of the cluster target
+      --target.burst int                                              option to set the maximum burst to the apiserver of the cluster target (default 100)
       --target.conditional-deploy-crds                                deployment of required crds for cluster target only if there is no managed resource in garden namespace deploying it
       --target.crds-shoot-no-cleanup-label                            add the label 'shoot.gardener.cloud/no-cleanup=true' for CRDS deployed on cluster target
       --target.disable-deploy-crds                                    disable deployment of required crds for cluster target
       --target.id string                                              id for cluster target
       --target.migration-ids string                                   migration id for cluster target
-      --target.qps int                                                option to set the maximum QPS to the apiserver of the cluster target
+      --target.qps int                                                option to set the maximum QPS to the apiserver of the cluster target (default 50)
       --targets.pool.size int                                         Worker pool size for pool targets
       --targetsources.pool.size int                                   Worker pool size for pool targetsources
       --ttl int                                                       Default time-to-live for DNS entries. Defines how long the record is kept in cache by DNS servers or resolvers.

--- a/charts/external-dns-management/templates/deployment.yaml
+++ b/charts/external-dns-management/templates/deployment.yaml
@@ -293,6 +293,15 @@ spec:
         {{- if .Values.configuration.compoundDryRun }}
         - --compound.dry-run={{ .Values.configuration.compoundDryRun }}
         {{- end }}
+        {{- if .Values.configuration.compoundEntryFailureBackoffBase }}
+        - --compound.entry-failure-backoff-base={{ .Values.configuration.compoundEntryFailureBackoffBase }}
+        {{- end }}
+        {{- if .Values.configuration.compoundEntryFailureBackoffFactor }}
+        - --compound.entry-failure-backoff-factor={{ .Values.configuration.compoundEntryFailureBackoffFactor }}
+        {{- end }}
+        {{- if .Values.configuration.compoundEntryFailureBackoffMax }}
+        - --compound.entry-failure-backoff-max={{ .Values.configuration.compoundEntryFailureBackoffMax }}
+        {{- end }}
         {{- if .Values.configuration.compoundGoogleClouddnsAdvancedBatchSize }}
         - --compound.google-clouddns.advanced.batch-size={{ .Values.configuration.compoundGoogleClouddnsAdvancedBatchSize }}
         {{- end }}
@@ -322,6 +331,21 @@ spec:
         {{- end }}
         {{- if .Values.configuration.compoundInfobloxDnsRatelimiterQps }}
         - --compound.infoblox-dns.ratelimiter.qps={{ .Values.configuration.compoundInfobloxDnsRatelimiterQps }}
+        {{- end }}
+        {{- if .Values.configuration.compoundLocalAdvancedBatchSize }}
+        - --compound.local.advanced.batch-size={{ .Values.configuration.compoundLocalAdvancedBatchSize }}
+        {{- end }}
+        {{- if .Values.configuration.compoundLocalAdvancedMaxRetries }}
+        - --compound.local.advanced.max-retries={{ .Values.configuration.compoundLocalAdvancedMaxRetries }}
+        {{- end }}
+        {{- if .Values.configuration.compoundLocalRatelimiterBurst }}
+        - --compound.local.ratelimiter.burst={{ .Values.configuration.compoundLocalRatelimiterBurst }}
+        {{- end }}
+        {{- if .Values.configuration.compoundLocalRatelimiterEnabled }}
+        - --compound.local.ratelimiter.enabled={{ .Values.configuration.compoundLocalRatelimiterEnabled }}
+        {{- end }}
+        {{- if .Values.configuration.compoundLocalRatelimiterQps }}
+        - --compound.local.ratelimiter.qps={{ .Values.configuration.compoundLocalRatelimiterQps }}
         {{- end }}
         {{- if .Values.configuration.compoundLockStatusCheckPeriod }}
         - --compound.lock-status-check-period={{ .Values.configuration.compoundLockStatusCheckPeriod }}
@@ -560,6 +584,15 @@ spec:
         {{- if .Values.configuration.enableProfiling }}
         - --enable-profiling={{ .Values.configuration.enableProfiling }}
         {{- end }}
+        {{- if .Values.configuration.entryFailureBackoffBase }}
+        - --entry-failure-backoff-base={{ .Values.configuration.entryFailureBackoffBase }}
+        {{- end }}
+        {{- if .Values.configuration.entryFailureBackoffFactor }}
+        - --entry-failure-backoff-factor={{ .Values.configuration.entryFailureBackoffFactor }}
+        {{- end }}
+        {{- if .Values.configuration.entryFailureBackoffMax }}
+        - --entry-failure-backoff-max={{ .Values.configuration.entryFailureBackoffMax }}
+        {{- end }}
         {{- if .Values.configuration.excludeDomains }}
         - --exclude-domains={{ .Values.configuration.excludeDomains }}
         {{- end }}
@@ -778,6 +811,21 @@ spec:
         {{- end }}
         {{- if .Values.configuration.leaseRetryPeriod }}
         - --lease-retry-period={{ .Values.configuration.leaseRetryPeriod }}
+        {{- end }}
+        {{- if .Values.configuration.localAdvancedBatchSize }}
+        - --local.advanced.batch-size={{ .Values.configuration.localAdvancedBatchSize }}
+        {{- end }}
+        {{- if .Values.configuration.localAdvancedMaxRetries }}
+        - --local.advanced.max-retries={{ .Values.configuration.localAdvancedMaxRetries }}
+        {{- end }}
+        {{- if .Values.configuration.localRatelimiterBurst }}
+        - --local.ratelimiter.burst={{ .Values.configuration.localRatelimiterBurst }}
+        {{- end }}
+        {{- if .Values.configuration.localRatelimiterEnabled }}
+        - --local.ratelimiter.enabled={{ .Values.configuration.localRatelimiterEnabled }}
+        {{- end }}
+        {{- if .Values.configuration.localRatelimiterQps }}
+        - --local.ratelimiter.qps={{ .Values.configuration.localRatelimiterQps }}
         {{- end }}
         {{- if .Values.configuration.lockStatusCheckPeriod }}
         - --lock-status-check-period={{ .Values.configuration.lockStatusCheckPeriod }}

--- a/charts/external-dns-management/values.yaml
+++ b/charts/external-dns-management/values.yaml
@@ -124,6 +124,9 @@ configuration:
   # compoundDnsPoolResyncPeriod: 30s
   # compoundDnsPoolSize: 1
   # compoundDryRun: false
+  # compoundEntryFailureBackoffBase:
+  # compoundEntryFailureBackoffFactor:
+  # compoundEntryFailureBackoffMax:
   # compoundGoogleClouddnsAdvancedBatchSize:
   # compoundGoogleClouddnsAdvancedMaxRetries:
   # compoundGoogleClouddnsRatelimiterBurst:
@@ -134,6 +137,11 @@ configuration:
   # compoundInfobloxDnsRatelimiterBurst:
   # compoundInfobloxDnsRatelimiterEnabled:
   # compoundInfobloxDnsRatelimiterQps:
+  # compoundLocalAdvancedBatchSize:
+  # compoundLocalAdvancedMaxRetries:
+  # compoundLocalRatelimiterBurst:
+  # compoundLocalRatelimiterEnabled:
+  # compoundLocalRatelimiterQps:
   # compoundLockStatusCheckPeriod:
   # compoundNetlifyDnsAdvancedBatchSize:
   # compoundNetlifyDnsAdvancedMaxRetries:
@@ -213,6 +221,9 @@ configuration:
   # dnsproviderReplicationTargetRealms:
   # dnsproviderReplicationTargetsPoolSize:
   # enableProfiling:
+  # entryFailureBackoffBase:
+  # entryFailureBackoffFactor:
+  # entryFailureBackoffMax:
   # excludeDomains: google.com
   # forceCrdUpdate: false
   # googleCloudDNSAdvancedBatchSize:
@@ -285,10 +296,14 @@ configuration:
   # leaseRenewDeadline:
   # leaseResourceLock:
   # leaseRetryPeriod:
+  # localAdvancedBatchSize:
+  # localAdvancedMaxRetries:
+  # localRatelimiterBurst:
+  # localRatelimiterEnabled:
+  # localRatelimiterQps:
   # lockStatusCheckPeriod:
   # logLevel: info
   # maintainer:
-  # maxMetadataRecordDeletionsPerReconciliation:
   # namespace: default
   # namespaceLocalAccessOnly: false
   # netlifyDnsAdvancedBatchSize:

--- a/docs/api-reference/config.md
+++ b/docs/api-reference/config.md
@@ -464,7 +464,7 @@ integer
 </td>
 <td>
 <em>(Optional)</em>
-<p>EntryFailureBackoffMax is the maximum delay for the entry failure backoff. Default value is 10 minutes.</p>
+<p>EntryFailureBackoffMax is the maximum delay for the entry failure backoff. Default value is 30 minutes.</p>
 </td>
 </tr>
 

--- a/docs/api-reference/config.md
+++ b/docs/api-reference/config.md
@@ -431,6 +431,42 @@ integer
 <p>DriftCheckPeriod is the minimum interval between two record-type drift recovery attempts for the same DNSEntry.<br />When an entry is in Error or Stale state, the reconciler additionally queries the alternative address record types<br />(A, AAAA, CNAME) at the same name to detect a foreign record blocking the entry. This bounds the resulting query<br />amplification: too short causes repeated full-spectrum queries during persistent error states, too long slows<br />recovery once the conflict is resolved. Default value is 12 hours.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>entryFailureBackoffBase</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#duration-v1-meta">Duration</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>EntryFailureBackoffBase is the base delay of the exponential backoff applied to a DNSEntry that keeps ending up in<br />error state (e.g. because a provider update repeatedly fails). While within the backoff window the entry is not<br />reconciled again, reducing the reconciliation frequency of persistently failing entries. Default value is 30 seconds.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>entryFailureBackoffFactor</code></br>
+<em>
+integer
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>EntryFailureBackoffFactor is the multiplier applied per consecutive failure to the entry failure backoff. Default value is 2.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>entryFailureBackoffMax</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#duration-v1-meta">Duration</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>EntryFailureBackoffMax is the maximum delay for the entry failure backoff. Default value is 10 minutes.</p>
+</td>
+</tr>
 
 </tbody>
 </table>

--- a/pkg/controller/provider/aws/execution.go
+++ b/pkg/controller/provider/aws/execution.go
@@ -108,6 +108,7 @@ func (this *Execution) submitChanges(ctx context.Context, metrics provider.Metri
 
 	failed := 0
 	throttlingErrCount := 0
+	successCount := 0
 	limitedChanges := limitChangeSet(this.changes, this.batchSize)
 	this.Infof("require %d batches for %d dns names", len(limitedChanges), len(this.changes))
 	for i, changes := range limitedChanges {
@@ -157,6 +158,7 @@ func (this *Execution) submitChanges(ctx context.Context, metrics provider.Metri
 			this.Errorf("%d records in zone %s fail: %s", len(changes), this.zone.Id(), err)
 		}
 		if len(succeededChanges) > 0 {
+			successCount += len(succeededChanges)
 			for _, c := range succeededChanges {
 				if c.Done != nil {
 					c.Done.Succeeded()
@@ -169,6 +171,9 @@ func (this *Execution) submitChanges(ctx context.Context, metrics provider.Metri
 		err := fmt.Errorf("%d changes failed", failed)
 		if throttlingErrCount == len(limitedChanges) {
 			err = dnserrors.NewThrottlingError(err)
+		}
+		if successCount == 0 {
+			return dnserrors.NewAllChangesFailedError(err)
 		}
 		return err
 	}

--- a/pkg/controller/provider/aws/execution.go
+++ b/pkg/controller/provider/aws/execution.go
@@ -152,7 +152,7 @@ func (this *Execution) submitChanges(ctx context.Context, metrics provider.Metri
 			for _, c := range failedChanges {
 				failed++
 				if c.Done != nil {
-					c.Done.Failed(err)
+					c.Done.Failed(stableError(err))
 				}
 			}
 			this.Errorf("%d records in zone %s fail: %s", len(changes), this.zone.Id(), err)

--- a/pkg/dns/provider/const.go
+++ b/pkg/dns/provider/const.go
@@ -25,6 +25,10 @@ const (
 	OPT_DISABLE_ZONE_STATE_CACHING = "disable-zone-state-caching"
 	OPT_DISABLE_DNSNAME_VALIDATION = "disable-dnsname-validation"
 
+	OPT_ENTRY_FAILURE_BACKOFF_BASE   = "entry-failure-backoff-base"
+	OPT_ENTRY_FAILURE_BACKOFF_FACTOR = "entry-failure-backoff-factor"
+	OPT_ENTRY_FAILURE_BACKOFF_MAX    = "entry-failure-backoff-max"
+
 	OPT_REMOTE_ACCESS_PORT               = "remote-access-port"
 	OPT_REMOTE_ACCESS_CACERT             = "remote-access-cacert"
 	OPT_REMOTE_ACCESS_SERVER_SECRET_NAME = "remote-access-server-secret-name"

--- a/pkg/dns/provider/controller.go
+++ b/pkg/dns/provider/controller.go
@@ -102,6 +102,9 @@ func DNSController(name string, factory DNSHandlerFactory) controller.Configurat
 		DefaultedDurationOption(OPT_DNSDELAY, 10*time.Second, "delay between two dns reconciliations").
 		DefaultedDurationOption(OPT_RESCHEDULEDELAY, 120*time.Second, "reschedule delay after losing provider").
 		DefaultedDurationOption(OPT_LOCKSTATUSCHECKPERIOD, 120*time.Second, "interval for dns lock status checks").
+		DefaultedDurationOption(OPT_ENTRY_FAILURE_BACKOFF_BASE, 30*time.Second, "base delay for the exponential backoff applied to persistently failing entries before they trigger a hosted zone reconciliation again").
+		DefaultedIntOption(OPT_ENTRY_FAILURE_BACKOFF_FACTOR, 2, "multiplier applied per consecutive failure for the entry failure backoff").
+		DefaultedDurationOption(OPT_ENTRY_FAILURE_BACKOFF_MAX, 30*time.Minute, "maximum delay for the entry failure backoff").
 		DefaultedIntOption(OPT_REMOTE_ACCESS_PORT, 0, "port of remote access server for remote-enabled providers").
 		DefaultedStringOption(OPT_REMOTE_ACCESS_CACERT, "", "CA who signed client certs file").
 		DefaultedStringOption(OPT_REMOTE_ACCESS_SERVER_SECRET_NAME, "", "name of secret containing remote access server's certificate").

--- a/pkg/dns/provider/entry_failure_backoff.go
+++ b/pkg/dns/provider/entry_failure_backoff.go
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package provider
+
+import (
+	"math/rand/v2"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gardener/controller-manager-library/pkg/resources"
+
+	"github.com/gardener/external-dns-management/pkg/dns"
+	dnsutils "github.com/gardener/external-dns-management/pkg/dns/utils"
+)
+
+// entryFailureBackoffConfig configures the exponential backoff applied to
+// persistently failing entries.
+type entryFailureBackoffConfig struct {
+	// base is the delay applied after the first failure.
+	base time.Duration
+	// factor is the multiplier applied per additional consecutive failure.
+	factor float64
+	// max is the upper bound for the backoff delay.
+	max time.Duration
+}
+
+// entryFailureBackoff tracks consecutive provider update failures per entry and
+// derives an increasing retry delay. It is used to reduce the reconciliation
+// frequency of entries that keep failing (e.g. because of conflicts).
+type entryFailureBackoff struct {
+	lock     sync.Mutex
+	config   entryFailureBackoffConfig
+	failures map[resources.ObjectName]*failureInfo
+	// now allows overriding the time source in tests.
+	now func() time.Time
+}
+
+type failureInfo struct {
+	count     int
+	nextRetry time.Time
+	// fingerprint captures the entry's generation and relevant annotations at
+	// the time of the failure. If the entry changes, the backoff is dropped so
+	// the change is reconciled immediately.
+	fingerprint entryFingerprint
+}
+
+// entryFingerprint identifies the mutable, user-relevant state of an entry that
+// should reset the failure backoff when changed: the spec generation and all
+// annotations in the dns.gardener.cloud group.
+type entryFingerprint struct {
+	generation  int64
+	annotations string
+}
+
+// computeEntryFingerprint builds a fingerprint from the object's generation and
+// its dns.gardener.cloud annotations.
+func computeEntryFingerprint(generation int64, annotations map[string]string) entryFingerprint {
+	keys := make([]string, 0, len(annotations))
+	for k := range annotations {
+		if strings.HasPrefix(k, dns.ANNOTATION_GROUP+"/") {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	var sb strings.Builder
+	for _, k := range keys {
+		sb.WriteString(k)
+		sb.WriteByte('=')
+		sb.WriteString(annotations[k])
+		sb.WriteByte('\n')
+	}
+	return entryFingerprint{generation: generation, annotations: sb.String()}
+}
+
+func newEntryFailureBackoff(config entryFailureBackoffConfig) *entryFailureBackoff {
+	return &entryFailureBackoff{
+		config:   config,
+		failures: map[resources.ObjectName]*failureInfo{},
+		now:      time.Now,
+	}
+}
+
+// recordFailure registers another failure for the given entry and returns the
+// time until which the entry should not trigger a hosted zone reconciliation
+// again. The entry's generation and dns.gardener.cloud annotations are captured
+// so that a later change resets the backoff.
+func (b *entryFailureBackoff) recordFailure(object *dnsutils.DNSEntryObject) time.Time {
+	return b.recordFailureFor(object.ObjectName(), computeEntryFingerprint(object.GetGeneration(), object.GetAnnotations()))
+}
+
+func (b *entryFailureBackoff) recordFailureFor(name resources.ObjectName, fingerprint entryFingerprint) time.Time {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	info := b.failures[name]
+	if info == nil || info.fingerprint != fingerprint {
+		// new entry or the entry changed since the last failure -> restart backoff
+		info = &failureInfo{}
+		b.failures[name] = info
+	}
+	info.count++
+	info.fingerprint = fingerprint
+	info.nextRetry = b.now().Add(b.backoffDuration(info.count))
+	return info.nextRetry
+}
+
+// clear removes any recorded failure for the given entry, e.g. after a
+// successful reconciliation or when the entry is deleted.
+func (b *entryFailureBackoff) clear(name resources.ObjectName) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	delete(b.failures, name)
+}
+
+// blockedUntil reports whether the entry is still within its backoff window and,
+// if so, the time until which triggering the hosted zone should be suppressed.
+// If the entry changed (different generation or dns.gardener.cloud annotations),
+// the backoff is dropped and the entry is reported as not blocked.
+func (b *entryFailureBackoff) blockedUntil(object *dnsutils.DNSEntryObject) (time.Time, bool) {
+	return b.blockedUntilFor(object.ObjectName(), computeEntryFingerprint(object.GetGeneration(), object.GetAnnotations()))
+}
+
+func (b *entryFailureBackoff) blockedUntilFor(name resources.ObjectName, fingerprint entryFingerprint) (time.Time, bool) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	info := b.failures[name]
+	if info == nil {
+		return time.Time{}, false
+	}
+	if info.fingerprint != fingerprint {
+		// entry changed since the last failure -> reconcile the change immediately
+		delete(b.failures, name)
+		return time.Time{}, false
+	}
+	if !b.now().Before(info.nextRetry) {
+		return time.Time{}, false
+	}
+	return info.nextRetry, true
+}
+
+// backoffDuration returns the delay for the given consecutive failure count
+// (>= 1), applying exponential growth capped at max with ±10% jitter.
+func (b *entryFailureBackoff) backoffDuration(count int) time.Duration {
+	d := float64(b.config.base)
+	for i := 1; i < count; i++ {
+		d *= b.config.factor
+		if d >= float64(b.config.max) {
+			d = float64(b.config.max)
+			break
+		}
+	}
+	if d > float64(b.config.max) {
+		d = float64(b.config.max)
+	}
+	// apply ±10% jitter to avoid synchronized retries of many entries
+	jitter := 1 + (rand.Float64()*0.2 - 0.1) // #nosec G404 -- not used for cryptographic purposes
+	return time.Duration(d * jitter)
+}

--- a/pkg/dns/provider/entry_failure_backoff_test.go
+++ b/pkg/dns/provider/entry_failure_backoff_test.go
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package provider
+
+import (
+	"time"
+
+	"github.com/gardener/controller-manager-library/pkg/resources"
+	g "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = g.Describe("entryFailureBackoff", func() {
+	var (
+		backoff *entryFailureBackoff
+		fakeNow time.Time
+		name    resources.ObjectName
+		fp      entryFingerprint
+	)
+
+	g.BeforeEach(func() {
+		backoff = newEntryFailureBackoff(entryFailureBackoffConfig{
+			base:   30 * time.Second,
+			factor: 2,
+			max:    10 * time.Minute,
+		})
+		fakeNow = time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		backoff.now = func() time.Time { return fakeNow }
+		name = resources.NewObjectName("test", "entry1")
+		fp = computeEntryFingerprint(1, map[string]string{"dns.gardener.cloud/class": "gardendns"})
+	})
+
+	g.It("reports no block for unknown entries", func() {
+		_, blocked := backoff.blockedUntilFor(name, fp)
+		Expect(blocked).To(BeFalse())
+	})
+
+	g.It("blocks after a failure and unblocks once the window elapsed", func() {
+		next := backoff.recordFailureFor(name, fp)
+		Expect(next).To(BeTemporally(">", fakeNow))
+
+		until, blocked := backoff.blockedUntilFor(name, fp)
+		Expect(blocked).To(BeTrue())
+		Expect(until).To(Equal(next))
+
+		fakeNow = next
+		_, blocked = backoff.blockedUntilFor(name, fp)
+		Expect(blocked).To(BeFalse())
+	})
+
+	g.It("does not block when the generation changed", func() {
+		backoff.recordFailureFor(name, fp)
+
+		changed := computeEntryFingerprint(2, map[string]string{"dns.gardener.cloud/class": "gardendns"})
+		_, blocked := backoff.blockedUntilFor(name, changed)
+		Expect(blocked).To(BeFalse())
+	})
+
+	g.It("does not block when a dns.gardener.cloud annotation changed", func() {
+		backoff.recordFailureFor(name, fp)
+
+		changed := computeEntryFingerprint(1, map[string]string{"dns.gardener.cloud/class": "other"})
+		_, blocked := backoff.blockedUntilFor(name, changed)
+		Expect(blocked).To(BeFalse())
+	})
+
+	g.It("ignores annotations outside the dns.gardener.cloud group", func() {
+		backoff.recordFailureFor(name, fp)
+
+		// adding an unrelated annotation must not reset the backoff
+		same := computeEntryFingerprint(1, map[string]string{
+			"dns.gardener.cloud/class":   "gardendns",
+			"other.example.com/whatever": "x",
+		})
+		_, blocked := backoff.blockedUntilFor(name, same)
+		Expect(blocked).To(BeTrue())
+	})
+
+	g.It("restarts the backoff count when the entry changed", func() {
+		backoff.recordFailureFor(name, fp)
+		first := backoff.recordFailureFor(name, fp) // count == 2
+
+		changed := computeEntryFingerprint(2, map[string]string{"dns.gardener.cloud/class": "gardendns"})
+		after := backoff.recordFailureFor(name, changed) // count reset to 1
+
+		// count reset -> window back to base (<= base+jitter), shorter than the count==2 window
+		base := float64(30 * time.Second)
+		Expect(after.Sub(fakeNow)).To(BeNumerically("<=", time.Duration(base*1.1)))
+		Expect(after.Sub(fakeNow)).To(BeNumerically("<", first.Sub(fakeNow)))
+	})
+
+	g.It("grows the backoff duration with consecutive failures", func() {
+		var prev time.Duration
+		for i := 1; i <= 6; i++ {
+			d := backoff.backoffDuration(i)
+			if i > 1 {
+				Expect(d).To(BeNumerically(">", prev))
+			}
+			prev = d
+		}
+	})
+
+	g.It("caps the backoff duration at max (accounting for jitter)", func() {
+		// large count -> capped at max, plus up to ±10% jitter
+		maxDur := float64(10 * time.Minute)
+		maxUpper := time.Duration(maxDur * 1.1)
+		maxLower := time.Duration(maxDur * 0.9)
+		d := backoff.backoffDuration(100)
+		Expect(d).To(BeNumerically("<=", maxUpper))
+		Expect(d).To(BeNumerically(">=", maxLower))
+	})
+
+	g.It("applies jitter within ±10% of the base for the first failure", func() {
+		base := float64(30 * time.Second)
+		lower := time.Duration(base * 0.9)
+		upper := time.Duration(base * 1.1)
+		for range 50 {
+			d := backoff.backoffDuration(1)
+			Expect(d).To(BeNumerically(">=", lower))
+			Expect(d).To(BeNumerically("<=", upper))
+		}
+	})
+
+	g.It("resets the counter on clear", func() {
+		backoff.recordFailureFor(name, fp)
+		backoff.recordFailureFor(name, fp)
+		backoff.clear(name)
+
+		_, blocked := backoff.blockedUntilFor(name, fp)
+		Expect(blocked).To(BeFalse())
+
+		// after clear, next failure starts again at the base window
+		base := float64(30 * time.Second)
+		upper := time.Duration(base * 1.1)
+		next := backoff.recordFailureFor(name, fp)
+		Expect(next.Sub(fakeNow)).To(BeNumerically("<=", upper))
+	})
+})

--- a/pkg/dns/provider/errors/errors.go
+++ b/pkg/dns/provider/errors/errors.go
@@ -44,3 +44,22 @@ func IsThrottlingError(err error) bool {
 	_, ok := err.(*ThrottlingError)
 	return ok
 }
+
+func NewAllChangesFailedError(err error) *AllChangesFailedError {
+	return &AllChangesFailedError{err: err}
+}
+
+// AllChangesFailedError is an error wrapper to mark that all changes have failed.
+// It is used to avoid dropping the zone cache in this case, similar to throttling.
+type AllChangesFailedError struct {
+	err error
+}
+
+func (e *AllChangesFailedError) Error() string {
+	return e.err.Error()
+}
+
+func IsAllChangesFailedError(err error) bool {
+	_, ok := err.(*AllChangesFailedError)
+	return ok
+}

--- a/pkg/dns/provider/interface.go
+++ b/pkg/dns/provider/interface.go
@@ -23,18 +23,21 @@ import (
 )
 
 type Config struct {
-	TTL                      int64
-	CacheTTL                 time.Duration
-	RescheduleDelay          time.Duration
-	StatusCheckPeriod        time.Duration
-	Dryrun                   bool
-	ZoneStateCaching         bool
-	DisableDNSNameValidation bool
-	Delay                    time.Duration
-	EnabledTypes             utils.StringSet
-	Options                  *FactoryOptions
-	Factory                  DNSHandlerFactory
-	RemoteAccessConfig       *embed.RemoteAccessServerConfig
+	TTL                       int64
+	CacheTTL                  time.Duration
+	RescheduleDelay           time.Duration
+	StatusCheckPeriod         time.Duration
+	Dryrun                    bool
+	ZoneStateCaching          bool
+	DisableDNSNameValidation  bool
+	Delay                     time.Duration
+	EntryFailureBackoffBase   time.Duration
+	EntryFailureBackoffFactor float64
+	EntryFailureBackoffMax    time.Duration
+	EnabledTypes              utils.StringSet
+	Options                   *FactoryOptions
+	Factory                   DNSHandlerFactory
+	RemoteAccessConfig        *embed.RemoteAccessServerConfig
 }
 
 func NewConfigForController(c controller.Interface, factory DNSHandlerFactory) (*Config, error) {
@@ -60,6 +63,19 @@ func NewConfigForController(c controller.Interface, factory DNSHandlerFactory) (
 	statuscheckperiod, err := c.GetDurationOption(OPT_LOCKSTATUSCHECKPERIOD)
 	if err != nil {
 		statuscheckperiod = 120 * time.Second
+	}
+
+	entryFailureBackoffBase, err := c.GetDurationOption(OPT_ENTRY_FAILURE_BACKOFF_BASE)
+	if err != nil {
+		entryFailureBackoffBase = 30 * time.Second
+	}
+	entryFailureBackoffFactor, err := c.GetIntOption(OPT_ENTRY_FAILURE_BACKOFF_FACTOR)
+	if err != nil || entryFailureBackoffFactor < 1 {
+		entryFailureBackoffFactor = 2
+	}
+	entryFailureBackoffMax, err := c.GetDurationOption(OPT_ENTRY_FAILURE_BACKOFF_MAX)
+	if err != nil {
+		entryFailureBackoffMax = 30 * time.Minute
 	}
 
 	RemoteAccessClientID, err = c.GetStringOption(OPT_REMOTE_ACCESS_CLIENT_ID)
@@ -96,18 +112,21 @@ func NewConfigForController(c controller.Interface, factory DNSHandlerFactory) (
 	fopts := GetFactoryOptions(osrc)
 
 	return &Config{
-		TTL:                      int64(ttl),
-		CacheTTL:                 time.Duration(cttl) * time.Second,
-		RescheduleDelay:          rescheduleDelay,
-		StatusCheckPeriod:        statuscheckperiod,
-		Dryrun:                   dryrun,
-		ZoneStateCaching:         !disableZoneStateCaching,
-		DisableDNSNameValidation: disableDNSNameValidation,
-		Delay:                    delay,
-		EnabledTypes:             enabled,
-		Options:                  fopts,
-		Factory:                  factory,
-		RemoteAccessConfig:       remoteAccessConfig,
+		TTL:                       int64(ttl),
+		CacheTTL:                  time.Duration(cttl) * time.Second,
+		RescheduleDelay:           rescheduleDelay,
+		StatusCheckPeriod:         statuscheckperiod,
+		Dryrun:                    dryrun,
+		ZoneStateCaching:          !disableZoneStateCaching,
+		DisableDNSNameValidation:  disableDNSNameValidation,
+		Delay:                     delay,
+		EntryFailureBackoffBase:   entryFailureBackoffBase,
+		EntryFailureBackoffFactor: float64(entryFailureBackoffFactor),
+		EntryFailureBackoffMax:    entryFailureBackoffMax,
+		EnabledTypes:              enabled,
+		Options:                   fopts,
+		Factory:                   factory,
+		RemoteAccessConfig:        remoteAccessConfig,
 	}, nil
 }
 

--- a/pkg/dns/provider/state.go
+++ b/pkg/dns/provider/state.go
@@ -127,6 +127,7 @@ type state struct {
 	outdated             *synchronizedEntries
 	blockingEntries      map[resources.ObjectName]time.Time
 	quotaExceededEntries map[resources.ClusterObjectKey]resources.ObjectName
+	entryBackoff         *entryFailureBackoff
 
 	updateEntryBlockedLock sync.Mutex
 	updateEntryBlocked     map[resources.ObjectName]struct{}
@@ -164,6 +165,7 @@ func NewDNSState(pctx ProviderContext, secretresc resources.Interface, classes *
 	pctx.Infof("using default ttl:           %d", config.TTL)
 	pctx.Infof("dry run mode:                %t", config.Dryrun)
 	pctx.Infof("reschedule delay:            %v", config.RescheduleDelay)
+	pctx.Infof("entry failure backoff:       base=%v factor=%v max=%v", config.EntryFailureBackoffBase, config.EntryFailureBackoffFactor, config.EntryFailureBackoffMax)
 	pctx.Infof("zone cache ttl for zones:    %v", config.CacheTTL)
 	pctx.Infof("disable zone state caching:  %t", !config.ZoneStateCaching)
 	pctx.Infof("disable DNS name validation:  %t", config.DisableDNSNameValidation)
@@ -195,11 +197,16 @@ func NewDNSState(pctx ProviderContext, secretresc resources.Interface, classes *
 		outdated:             newSynchronizedEntries(),
 		blockingEntries:      map[resources.ObjectName]time.Time{},
 		quotaExceededEntries: map[resources.ClusterObjectKey]resources.ObjectName{},
-		dnsnames:             map[ZonedDNSSetName]*Entry{},
-		references:           NewReferenceCache(),
-		providerRateLimiter:  map[resources.ObjectName]*rateLimiterData{},
-		updateEntryBlocked:   map[resources.ObjectName]struct{}{},
-		entriesLocking:       newEntriesLocking(),
+		entryBackoff: newEntryFailureBackoff(entryFailureBackoffConfig{
+			base:   config.EntryFailureBackoffBase,
+			factor: config.EntryFailureBackoffFactor,
+			max:    config.EntryFailureBackoffMax,
+		}),
+		dnsnames:            map[ZonedDNSSetName]*Entry{},
+		references:          NewReferenceCache(),
+		providerRateLimiter: map[resources.ObjectName]*rateLimiterData{},
+		updateEntryBlocked:  map[resources.ObjectName]struct{}{},
+		entriesLocking:      newEntriesLocking(),
 	}
 }
 

--- a/pkg/dns/provider/state_entry.go
+++ b/pkg/dns/provider/state_entry.go
@@ -342,6 +342,13 @@ func (this *state) HandleUpdateEntry(logger logger.LogContext, op string, object
 
 	if new != nil {
 		if new.IsModified() && !new.ZoneId().IsEmpty() {
+			if until, blocked := this.entryBackoff.blockedUntil(object); blocked {
+				// entry keeps failing in the provider handler: suppress the hosted zone
+				// trigger and pace the entry itself to reduce the reconciliation frequency.
+				delay := time.Until(until)
+				this.smartInfof(logger, "entry within failure backoff -> skip trigger zone %q, reschedule in %s", new.ZoneId(), delay.Round(time.Second))
+				return reconcile.Succeeded(logger).RescheduleAfter(delay)
+			}
 			this.smartInfof(logger, "trigger zone %q", new.ZoneId())
 			this.triggerHostedZone(new.ZoneId())
 		} else {
@@ -369,6 +376,7 @@ func (this *state) EntryDeleted(logger logger.LogContext, key resources.ClusterO
 
 	delete(this.blockingEntries, key.ObjectName())
 	delete(this.quotaExceededEntries, key)
+	this.entryBackoff.clear(key.ObjectName())
 
 	old := this.entries[key.ObjectName()]
 	if old != nil {

--- a/pkg/dns/provider/statusupdate.go
+++ b/pkg/dns/provider/statusupdate.go
@@ -33,6 +33,7 @@ func (this *StatusUpdate) SetInvalid(err error) {
 	if !this.done {
 		this.done = true
 		this.modified = false
+		this.state.entryBackoff.clear(this.ObjectName())
 		if err := this.fhandler.RemoveFinalizer(this.object); err != nil {
 			this.logger.Errorf("cannot remove finalizer: %s", err)
 		}
@@ -55,6 +56,7 @@ func (this *StatusUpdate) Failed(err error) {
 		} else {
 			newState = api.STATE_STALE
 		}
+		this.state.entryBackoff.recordFailure(this.Object())
 		_, err := this.UpdateStatus(this.logger, newState, err.Error())
 		if err != nil {
 			this.logger.Errorf("cannot update: %s", err)
@@ -66,6 +68,7 @@ func (this *StatusUpdate) Succeeded() {
 	if !this.done {
 		this.done = true
 		this.modified = false
+		this.state.entryBackoff.clear(this.ObjectName())
 		if this.delete {
 			this.logger.Infof("removing finalizer for deleted entry %s", this.ZonedDNSName())
 			if err2 := this.fhandler.RemoveFinalizer(this.Object()); err2 != nil {

--- a/pkg/dns/provider/zonecache.go
+++ b/pkg/dns/provider/zonecache.go
@@ -167,12 +167,19 @@ func (c *defaultZoneCache) ApplyRequests(logctx logger.LogContext, err error, zo
 	if err == nil {
 		c.zoneStates.ExecuteRequests(zone.Id(), reqs)
 	} else {
-		if !errors.IsThrottlingError(err) {
+		untouchedDetails := ""
+		if errors.IsThrottlingError(err) {
+			untouchedDetails = "only throttling"
+		} else if errors.IsAllChangesFailedError(err) {
+			untouchedDetails = "all changes failed"
+		}
+
+		if untouchedDetails == "" {
 			logctx.Infof("zone cache discarded because of error during ExecuteRequests")
 			c.cleanZoneState(zone.Id())
 			metrics.AddZoneCacheDiscarding(zone.Id())
 		} else {
-			logctx.Infof("zone cache untouched (only throttling during ExecuteRequests)")
+			logctx.Infof("zone cache untouched (" + untouchedDetails + " during ExecuteRequests)")
 		}
 	}
 }

--- a/pkg/dnsman2/apis/config/types.go
+++ b/pkg/dnsman2/apis/config/types.go
@@ -178,7 +178,7 @@ type DNSEntryControllerConfig struct {
 	EntryFailureBackoffBase *metav1.Duration
 	// EntryFailureBackoffFactor is the multiplier applied per consecutive failure to the entry failure backoff. Default value is 2.
 	EntryFailureBackoffFactor *int
-	// EntryFailureBackoffMax is the maximum delay for the entry failure backoff. Default value is 10 minutes.
+	// EntryFailureBackoffMax is the maximum delay for the entry failure backoff. Default value is 30 minutes.
 	EntryFailureBackoffMax *metav1.Duration
 }
 

--- a/pkg/dnsman2/apis/config/types.go
+++ b/pkg/dnsman2/apis/config/types.go
@@ -172,6 +172,14 @@ type DNSEntryControllerConfig struct {
 	// amplification: too short causes repeated full-spectrum queries during persistent error states, too long slows
 	// recovery once the conflict is resolved. Default value is 12 hours.
 	DriftCheckPeriod *metav1.Duration
+	// EntryFailureBackoffBase is the base delay of the exponential backoff applied to a DNSEntry that keeps ending up in
+	// error state (e.g. because a provider update repeatedly fails). While within the backoff window the entry is not
+	// reconciled again, reducing the reconciliation frequency of persistently failing entries. Default value is 30 seconds.
+	EntryFailureBackoffBase *metav1.Duration
+	// EntryFailureBackoffFactor is the multiplier applied per consecutive failure to the entry failure backoff. Default value is 2.
+	EntryFailureBackoffFactor *int
+	// EntryFailureBackoffMax is the maximum delay for the entry failure backoff. Default value is 10 minutes.
+	EntryFailureBackoffMax *metav1.Duration
 }
 
 // DNSAnnotationControllerConfig is the configuration for the DNSAnnotation controller.

--- a/pkg/dnsman2/apis/config/v1alpha1/defaults.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/defaults.go
@@ -162,7 +162,7 @@ func SetDefaults_DNSEntryControllerConfig(obj *DNSEntryControllerConfig) {
 		obj.EntryFailureBackoffFactor = new(2)
 	}
 	if obj.EntryFailureBackoffMax == nil {
-		obj.EntryFailureBackoffMax = &metav1.Duration{Duration: 10 * time.Minute}
+		obj.EntryFailureBackoffMax = &metav1.Duration{Duration: 30 * time.Minute}
 	}
 }
 

--- a/pkg/dnsman2/apis/config/v1alpha1/defaults.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/defaults.go
@@ -155,6 +155,15 @@ func SetDefaults_DNSEntryControllerConfig(obj *DNSEntryControllerConfig) {
 	if obj.DriftCheckPeriod == nil {
 		obj.DriftCheckPeriod = &metav1.Duration{Duration: 12 * time.Hour}
 	}
+	if obj.EntryFailureBackoffBase == nil {
+		obj.EntryFailureBackoffBase = &metav1.Duration{Duration: 30 * time.Second}
+	}
+	if obj.EntryFailureBackoffFactor == nil {
+		obj.EntryFailureBackoffFactor = new(2)
+	}
+	if obj.EntryFailureBackoffMax == nil {
+		obj.EntryFailureBackoffMax = &metav1.Duration{Duration: 10 * time.Minute}
+	}
 }
 
 // SetDefaults_SourceControllerConfig sets defaults for the SourceControllerConfig object.

--- a/pkg/dnsman2/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/defaults_test.go
@@ -199,16 +199,22 @@ var _ = Describe("Defaults", func() {
 					Expect(obj.ZoneMetricsInterval).To(PointTo(Equal(metav1.Duration{Duration: 30 * time.Second})))
 					Expect(obj.PropagationWaitTime).To(PointTo(Equal(metav1.Duration{Duration: 10 * time.Second})))
 					Expect(obj.DriftCheckPeriod).To(PointTo(Equal(metav1.Duration{Duration: 12 * time.Hour})))
+					Expect(obj.EntryFailureBackoffBase).To(PointTo(Equal(metav1.Duration{Duration: 30 * time.Second})))
+					Expect(obj.EntryFailureBackoffFactor).To(PointTo(Equal(2)))
+					Expect(obj.EntryFailureBackoffMax).To(PointTo(Equal(metav1.Duration{Duration: 10 * time.Minute})))
 				})
 
 				It("should not overwrite existing values", func() {
 					obj := &DNSEntryControllerConfig{
-						ConcurrentSyncs:       new(7),
-						SyncPeriod:            &metav1.Duration{Duration: 0 * time.Second},
-						ReconciliationTimeout: &metav1.Duration{Duration: 30 * time.Second},
-						ZoneMetricsInterval:   &metav1.Duration{Duration: 0},
-						PropagationWaitTime:   &metav1.Duration{Duration: 5 * time.Second},
-						DriftCheckPeriod:      &metav1.Duration{Duration: 6 * time.Hour},
+						ConcurrentSyncs:           new(7),
+						SyncPeriod:                &metav1.Duration{Duration: 0 * time.Second},
+						ReconciliationTimeout:     &metav1.Duration{Duration: 30 * time.Second},
+						ZoneMetricsInterval:       &metav1.Duration{Duration: 0},
+						PropagationWaitTime:       &metav1.Duration{Duration: 5 * time.Second},
+						DriftCheckPeriod:          &metav1.Duration{Duration: 6 * time.Hour},
+						EntryFailureBackoffBase:   &metav1.Duration{Duration: 15 * time.Second},
+						EntryFailureBackoffFactor: new(3),
+						EntryFailureBackoffMax:    &metav1.Duration{Duration: 5 * time.Minute},
 					}
 
 					SetDefaults_DNSEntryControllerConfig(obj)
@@ -219,6 +225,9 @@ var _ = Describe("Defaults", func() {
 					Expect(obj.ZoneMetricsInterval).To(PointTo(Equal(metav1.Duration{Duration: 0})))
 					Expect(obj.PropagationWaitTime).To(PointTo(Equal(metav1.Duration{Duration: 5 * time.Second})))
 					Expect(obj.DriftCheckPeriod).To(PointTo(Equal(metav1.Duration{Duration: 6 * time.Hour})))
+					Expect(obj.EntryFailureBackoffBase).To(PointTo(Equal(metav1.Duration{Duration: 15 * time.Second})))
+					Expect(obj.EntryFailureBackoffFactor).To(PointTo(Equal(3)))
+					Expect(obj.EntryFailureBackoffMax).To(PointTo(Equal(metav1.Duration{Duration: 5 * time.Minute})))
 				})
 			})
 			Describe("Source controller", func() {

--- a/pkg/dnsman2/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/defaults_test.go
@@ -201,7 +201,7 @@ var _ = Describe("Defaults", func() {
 					Expect(obj.DriftCheckPeriod).To(PointTo(Equal(metav1.Duration{Duration: 12 * time.Hour})))
 					Expect(obj.EntryFailureBackoffBase).To(PointTo(Equal(metav1.Duration{Duration: 30 * time.Second})))
 					Expect(obj.EntryFailureBackoffFactor).To(PointTo(Equal(2)))
-					Expect(obj.EntryFailureBackoffMax).To(PointTo(Equal(metav1.Duration{Duration: 10 * time.Minute})))
+					Expect(obj.EntryFailureBackoffMax).To(PointTo(Equal(metav1.Duration{Duration: 30 * time.Minute})))
 				})
 
 				It("should not overwrite existing values", func() {

--- a/pkg/dnsman2/apis/config/v1alpha1/types.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/types.go
@@ -204,6 +204,17 @@ type DNSEntryControllerConfig struct {
 	// recovery once the conflict is resolved. Default value is 12 hours.
 	// +optional
 	DriftCheckPeriod *metav1.Duration `json:"driftCheckPeriod,omitempty"`
+	// EntryFailureBackoffBase is the base delay of the exponential backoff applied to a DNSEntry that keeps ending up in
+	// error state (e.g. because a provider update repeatedly fails). While within the backoff window the entry is not
+	// reconciled again, reducing the reconciliation frequency of persistently failing entries. Default value is 30 seconds.
+	// +optional
+	EntryFailureBackoffBase *metav1.Duration `json:"entryFailureBackoffBase,omitempty"`
+	// EntryFailureBackoffFactor is the multiplier applied per consecutive failure to the entry failure backoff. Default value is 2.
+	// +optional
+	EntryFailureBackoffFactor *int `json:"entryFailureBackoffFactor,omitempty"`
+	// EntryFailureBackoffMax is the maximum delay for the entry failure backoff. Default value is 10 minutes.
+	// +optional
+	EntryFailureBackoffMax *metav1.Duration `json:"entryFailureBackoffMax,omitempty"`
 }
 
 // DNSAnnotationControllerConfig is the configuration for the DNSAnnotation controller.

--- a/pkg/dnsman2/apis/config/v1alpha1/types.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/types.go
@@ -212,7 +212,7 @@ type DNSEntryControllerConfig struct {
 	// EntryFailureBackoffFactor is the multiplier applied per consecutive failure to the entry failure backoff. Default value is 2.
 	// +optional
 	EntryFailureBackoffFactor *int `json:"entryFailureBackoffFactor,omitempty"`
-	// EntryFailureBackoffMax is the maximum delay for the entry failure backoff. Default value is 10 minutes.
+	// EntryFailureBackoffMax is the maximum delay for the entry failure backoff. Default value is 30 minutes.
 	// +optional
 	EntryFailureBackoffMax *metav1.Duration `json:"entryFailureBackoffMax,omitempty"`
 }

--- a/pkg/dnsman2/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/zz_generated.conversion.go
@@ -303,6 +303,9 @@ func autoConvert_v1alpha1_DNSEntryControllerConfig_To_config_DNSEntryControllerC
 	out.ReconciliationDelayAfterUpdate = (*v1.Duration)(unsafe.Pointer(in.ReconciliationDelayAfterUpdate))
 	out.ZoneMetricsInterval = (*v1.Duration)(unsafe.Pointer(in.ZoneMetricsInterval))
 	out.DriftCheckPeriod = (*v1.Duration)(unsafe.Pointer(in.DriftCheckPeriod))
+	out.EntryFailureBackoffBase = (*v1.Duration)(unsafe.Pointer(in.EntryFailureBackoffBase))
+	out.EntryFailureBackoffFactor = (*int)(unsafe.Pointer(in.EntryFailureBackoffFactor))
+	out.EntryFailureBackoffMax = (*v1.Duration)(unsafe.Pointer(in.EntryFailureBackoffMax))
 	return nil
 }
 
@@ -321,6 +324,9 @@ func autoConvert_config_DNSEntryControllerConfig_To_v1alpha1_DNSEntryControllerC
 	out.ReconciliationDelayAfterUpdate = (*v1.Duration)(unsafe.Pointer(in.ReconciliationDelayAfterUpdate))
 	out.ZoneMetricsInterval = (*v1.Duration)(unsafe.Pointer(in.ZoneMetricsInterval))
 	out.DriftCheckPeriod = (*v1.Duration)(unsafe.Pointer(in.DriftCheckPeriod))
+	out.EntryFailureBackoffBase = (*v1.Duration)(unsafe.Pointer(in.EntryFailureBackoffBase))
+	out.EntryFailureBackoffFactor = (*int)(unsafe.Pointer(in.EntryFailureBackoffFactor))
+	out.EntryFailureBackoffMax = (*v1.Duration)(unsafe.Pointer(in.EntryFailureBackoffMax))
 	return nil
 }
 

--- a/pkg/dnsman2/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/dnsman2/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -188,6 +188,21 @@ func (in *DNSEntryControllerConfig) DeepCopyInto(out *DNSEntryControllerConfig) 
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.EntryFailureBackoffBase != nil {
+		in, out := &in.EntryFailureBackoffBase, &out.EntryFailureBackoffBase
+		*out = new(v1.Duration)
+		**out = **in
+	}
+	if in.EntryFailureBackoffFactor != nil {
+		in, out := &in.EntryFailureBackoffFactor, &out.EntryFailureBackoffFactor
+		*out = new(int)
+		**out = **in
+	}
+	if in.EntryFailureBackoffMax != nil {
+		in, out := &in.EntryFailureBackoffMax, &out.EntryFailureBackoffMax
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/dnsman2/apis/config/zz_generated.deepcopy.go
+++ b/pkg/dnsman2/apis/config/zz_generated.deepcopy.go
@@ -188,6 +188,21 @@ func (in *DNSEntryControllerConfig) DeepCopyInto(out *DNSEntryControllerConfig) 
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.EntryFailureBackoffBase != nil {
+		in, out := &in.EntryFailureBackoffBase, &out.EntryFailureBackoffBase
+		*out = new(v1.Duration)
+		**out = **in
+	}
+	if in.EntryFailureBackoffFactor != nil {
+		in, out := &in.EntryFailureBackoffFactor, &out.EntryFailureBackoffFactor
+		*out = new(int)
+		**out = **in
+	}
+	if in.EntryFailureBackoffMax != nil {
+		in, out := &in.EntryFailureBackoffMax, &out.EntryFailureBackoffMax
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/dnsman2/controller/controlplane/dnsentry/add.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/add.go
@@ -44,6 +44,12 @@ const ControllerName = "dnsentry"
 
 const defaultProviderUpdateCachePeriod = 7 * 24 * time.Hour
 
+const (
+	defaultEntryFailureBackoffBase   = 30 * time.Second
+	defaultEntryFailureBackoffFactor = 2
+	defaultEntryFailureBackoffMax    = 30 * time.Minute
+)
+
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager, controlPlaneCluster cluster.Cluster, cfg *config.DNSManagerConfiguration) error {
 	r.Config = cfg.Controllers.DNSEntry
@@ -67,9 +73,14 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, controlPlaneCluster clust
 	r.MigrationMode = ptr.Deref(cfg.Controllers.DNSProvider.MigrationMode, false)
 	r.state = state.GetState()
 	log := mgr.GetLogger().WithName(ControllerName)
+	r.failureBackoff = newEntryFailureBackoff(entryFailureBackoffConfig{
+		base:   ptr.Deref(r.Config.EntryFailureBackoffBase, metav1.Duration{Duration: defaultEntryFailureBackoffBase}).Duration,
+		factor: float64(ptr.Deref(r.Config.EntryFailureBackoffFactor, defaultEntryFailureBackoffFactor)),
+		max:    ptr.Deref(r.Config.EntryFailureBackoffMax, metav1.Duration{Duration: defaultEntryFailureBackoffMax}).Duration,
+	}, r.Clock)
 	r.lookupProcessor = lookup.NewLookupProcessor(
 		log.WithName("lookupProcessor"),
-		newReconcileTrigger(r.Client),
+		newReconcileTrigger(r.Client, r.failureBackoff),
 		max(ptr.Deref(r.Config.MaxConcurrentLookups, 2), 2),
 		15*time.Second,
 	)
@@ -256,6 +267,19 @@ func (r *Reconciler) setCachePeriods(reconciliationDelayAfterUpdate, driftCheckP
 		ttlcache.WithDisableTouchOnHit[client.ObjectKey, providerSnapshot]())
 }
 
+// initDefaultFailureBackoff initializes the failure backoff with default settings if it has not been set yet.
+// AddToManager sets it from the configured values; this fallback keeps the backoff non-nil when the reconciler
+// is constructed directly (e.g. in tests) without AddToManager.
+func (r *Reconciler) initDefaultFailureBackoff() {
+	if r.failureBackoff == nil {
+		r.failureBackoff = newEntryFailureBackoff(entryFailureBackoffConfig{
+			base:   defaultEntryFailureBackoffBase,
+			factor: float64(defaultEntryFailureBackoffFactor),
+			max:    defaultEntryFailureBackoffMax,
+		}, r.Clock)
+	}
+}
+
 func domainMatches(dnsName string, domains v1alpha1.DNSSelectionStatus) bool {
 	dnsName = dns.NormalizeDomainName(dnsName)
 	for _, domain := range domains.Excluded {
@@ -272,14 +296,16 @@ func domainMatches(dnsName string, domains v1alpha1.DNSSelectionStatus) bool {
 }
 
 type reconcileTrigger struct {
-	client client.Client
+	client         client.Client
+	failureBackoff *entryFailureBackoff
 }
 
 var _ lookup.EntryTrigger = &reconcileTrigger{}
 
-func newReconcileTrigger(c client.Client) lookup.EntryTrigger {
+func newReconcileTrigger(c client.Client, failureBackoff *entryFailureBackoff) lookup.EntryTrigger {
 	return &reconcileTrigger{
-		client: c,
+		client:         c,
+		failureBackoff: failureBackoff,
 	}
 }
 
@@ -290,6 +316,13 @@ func (r *reconcileTrigger) TriggerReconciliation(ctx context.Context, key client
 			return nil // Entry is gone, no need to trigger reconciliation
 		}
 		return err
+	}
+	// Suppress the lookup-driven trigger while the entry is within its failure backoff window. Otherwise a
+	// persistently failing entry with periodic CNAME lookups would keep re-triggering reconciliations (and thus
+	// provider updates) at the lookup cadence. The backoff resets on success and whenever the entry changes
+	// (generation or dns.gardener.cloud annotations), so user edits are still picked up immediately.
+	if _, blocked := r.failureBackoff.blockedUntil(entry); blocked {
+		return nil
 	}
 	return kubernetes.SetAnnotationAndUpdate(ctx, r.client, entry, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
 }

--- a/pkg/dnsman2/controller/controlplane/dnsentry/add_test.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/add_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"time"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/clock"
+	testclock "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -37,7 +40,9 @@ var _ = Describe("Add", func() {
 				Client:    fakeClient,
 				Namespace: "test",
 				state:     state.GetState(),
+				Clock:     clock.RealClock{},
 			}
+			reconciler.initDefaultFailureBackoff()
 			reconciler.setCachePeriods(1*time.Microsecond, defaultDriftCheckPeriod, defaultProviderUpdateCachePeriod)
 
 			Expect(fakeClient.Create(ctx, &v1alpha1.DNSEntry{
@@ -203,5 +208,69 @@ var _ = Describe("Add", func() {
 			Expect(checkEntriesToReconcileOnProviderChanges(ctx, provider)).To(BeEmpty())
 		})
 
+	})
+
+	Describe("#TriggerReconciliation (failure backoff)", func() {
+		var (
+			ctx        = context.Background()
+			fakeClient client.Client
+			fakeClock  *testclock.FakeClock
+			backoff    *entryFailureBackoff
+			trigger    *reconcileTrigger
+			entry      *v1alpha1.DNSEntry
+			key        client.ObjectKey
+		)
+
+		BeforeEach(func() {
+			fakeClient = fakeclient.NewClientBuilder().WithScheme(dnsmanclient.ClusterScheme).Build()
+			fakeClock = testclock.NewFakeClock(time.Now())
+			backoff = newEntryFailureBackoff(entryFailureBackoffConfig{base: 30 * time.Second, factor: 2, max: 10 * time.Minute}, fakeClock)
+			trigger = newReconcileTrigger(fakeClient, backoff).(*reconcileTrigger)
+
+			entry = &v1alpha1.DNSEntry{
+				ObjectMeta: metav1.ObjectMeta{Name: "entry1", Namespace: "test", Generation: 1},
+				Spec:       v1alpha1.DNSEntrySpec{DNSName: "foo.example.com"},
+			}
+			Expect(fakeClient.Create(ctx, entry)).To(Succeed())
+			key = client.ObjectKeyFromObject(entry)
+		})
+
+		hasReconcileAnnotation := func() bool {
+			GinkgoHelper()
+			e := &v1alpha1.DNSEntry{}
+			Expect(fakeClient.Get(ctx, key, e)).To(Succeed())
+			return e.Annotations[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationReconcile
+		}
+
+		It("triggers reconciliation when the entry is not within a backoff window", func() {
+			Expect(trigger.TriggerReconciliation(ctx, key)).To(Succeed())
+			Expect(hasReconcileAnnotation()).To(BeTrue())
+		})
+
+		It("suppresses the trigger while the entry is within its backoff window", func() {
+			backoff.recordFailure(entry)
+
+			Expect(trigger.TriggerReconciliation(ctx, key)).To(Succeed())
+			Expect(hasReconcileAnnotation()).To(BeFalse())
+		})
+
+		It("triggers again once the backoff window elapsed", func() {
+			next := backoff.recordFailure(entry)
+			fakeClock.SetTime(next)
+
+			Expect(trigger.TriggerReconciliation(ctx, key)).To(Succeed())
+			Expect(hasReconcileAnnotation()).To(BeTrue())
+		})
+
+		It("triggers immediately once the entry changed despite an active backoff", func() {
+			backoff.recordFailure(entry)
+
+			// a user edit bumps the generation -> the backoff must not suppress the trigger anymore
+			entry.Generation++
+			Expect(fakeClient.Update(ctx, entry)).To(Succeed())
+
+			Expect(trigger.TriggerReconciliation(ctx, key)).To(Succeed())
+			Expect(hasReconcileAnnotation()).To(BeTrue())
+		})
 	})
 })

--- a/pkg/dnsman2/controller/controlplane/dnsentry/common/statusupdater.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/common/statusupdater.go
@@ -39,6 +39,17 @@ func (u *EntryStatusUpdater) UpdateStatus(modifier func(status *v1alpha1.DNSEntr
 		if res := u.RemoveFinalizer(); res != nil {
 			return *res
 		}
+	} else {
+		// Add the finalizer only once we have provisioned DNS state (Status.Targets is set by
+		// updateStatusWithProvider after a successful apply). Tying add and keep to the same signal
+		// avoids the add/remove flapping seen when ApplyChangeRequests fails before targets are persisted.
+		// Ideally the finalizer would be set before applying the changes to close the crash window between
+		// a successful apply and persisting the finalizer, but that is not possible here: adding it before
+		// the apply reintroduces the flapping, since a failed apply never persists Status.Targets and the
+		// finalizer would then be removed again on the same reconcile.
+		if res := u.AddFinalizer(); res != nil {
+			return *res
+		}
 	}
 
 	return ReconcileResult{}

--- a/pkg/dnsman2/controller/controlplane/dnsentry/failure_backoff.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/failure_backoff.go
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dnsentry
+
+import (
+	"math/rand/v2"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"k8s.io/utils/clock"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+)
+
+// annotationGroupPrefix is the prefix of all dns.gardener.cloud annotations that are relevant for the
+// entry fingerprint. A change to any of these annotations resets the failure backoff.
+const annotationGroupPrefix = "dns.gardener.cloud/"
+
+// entryFailureBackoffConfig configures the exponential backoff applied to
+// persistently failing entries.
+type entryFailureBackoffConfig struct {
+	// base is the delay applied after the first failure.
+	base time.Duration
+	// factor is the multiplier applied per additional consecutive failure.
+	factor float64
+	// max is the upper bound for the backoff delay.
+	max time.Duration
+}
+
+// entryFailureBackoff tracks consecutive provider update failures per entry and
+// derives an increasing retry delay. It is used to reduce the reconciliation
+// frequency of entries that keep failing (e.g. because of conflicts).
+type entryFailureBackoff struct {
+	lock     sync.Mutex
+	config   entryFailureBackoffConfig
+	clock    clock.Clock
+	failures map[client.ObjectKey]*failureInfo
+}
+
+type failureInfo struct {
+	count     int
+	nextRetry time.Time
+	// fingerprint captures the entry's generation and relevant annotations at
+	// the time of the failure. If the entry changes, the backoff is dropped so
+	// the change is reconciled immediately.
+	fingerprint entryFingerprint
+}
+
+// entryFingerprint identifies the mutable, user-relevant state of an entry that
+// should reset the failure backoff when changed: the spec generation and all
+// annotations in the dns.gardener.cloud group.
+type entryFingerprint struct {
+	generation  int64
+	annotations string
+}
+
+// computeEntryFingerprint builds a fingerprint from the object's generation and
+// its dns.gardener.cloud annotations.
+func computeEntryFingerprint(generation int64, annotations map[string]string) entryFingerprint {
+	keys := make([]string, 0, len(annotations))
+	for k := range annotations {
+		if strings.HasPrefix(k, annotationGroupPrefix) {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	var sb strings.Builder
+	for _, k := range keys {
+		sb.WriteString(k)
+		sb.WriteByte('=')
+		sb.WriteString(annotations[k])
+		sb.WriteByte('\n')
+	}
+	return entryFingerprint{generation: generation, annotations: sb.String()}
+}
+
+func newEntryFailureBackoff(config entryFailureBackoffConfig, cl clock.Clock) *entryFailureBackoff {
+	return &entryFailureBackoff{
+		config:   config,
+		clock:    cl,
+		failures: map[client.ObjectKey]*failureInfo{},
+	}
+}
+
+// recordFailure registers another failure for the given entry and returns the
+// time until which the entry should not be reconciled again. The entry's
+// generation and dns.gardener.cloud annotations are captured so that a later
+// change resets the backoff.
+func (b *entryFailureBackoff) recordFailure(entry *v1alpha1.DNSEntry) time.Time {
+	return b.recordFailureFor(client.ObjectKeyFromObject(entry), computeEntryFingerprint(entry.Generation, entry.Annotations))
+}
+
+func (b *entryFailureBackoff) recordFailureFor(key client.ObjectKey, fingerprint entryFingerprint) time.Time {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	info := b.failures[key]
+	if info == nil || info.fingerprint != fingerprint {
+		// new entry or the entry changed since the last failure -> restart backoff
+		info = &failureInfo{}
+		b.failures[key] = info
+	}
+	info.count++
+	info.fingerprint = fingerprint
+	info.nextRetry = b.clock.Now().Add(b.backoffDuration(info.count))
+	return info.nextRetry
+}
+
+// clear removes any recorded failure for the given entry, e.g. after a
+// successful reconciliation or when the entry is deleted.
+func (b *entryFailureBackoff) clear(key client.ObjectKey) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	delete(b.failures, key)
+}
+
+// blockedUntil reports whether the entry is still within its backoff window and,
+// if so, the time until which self-perpetuating re-triggers (e.g. periodic CNAME
+// lookups) should be suppressed. If the entry changed (different generation or
+// dns.gardener.cloud annotations), the backoff is dropped and the entry is
+// reported as not blocked so the change is picked up immediately.
+func (b *entryFailureBackoff) blockedUntil(entry *v1alpha1.DNSEntry) (time.Time, bool) {
+	return b.blockedUntilFor(client.ObjectKeyFromObject(entry), computeEntryFingerprint(entry.Generation, entry.Annotations))
+}
+
+func (b *entryFailureBackoff) blockedUntilFor(key client.ObjectKey, fingerprint entryFingerprint) (time.Time, bool) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	info := b.failures[key]
+	if info == nil {
+		return time.Time{}, false
+	}
+	if info.fingerprint != fingerprint {
+		// entry changed since the last failure -> reconcile the change immediately
+		delete(b.failures, key)
+		return time.Time{}, false
+	}
+	if !b.clock.Now().Before(info.nextRetry) {
+		return time.Time{}, false
+	}
+	return info.nextRetry, true
+}
+
+// backoffDuration returns the delay for the given consecutive failure count
+// (>= 1), applying exponential growth capped at max with ±10% jitter.
+func (b *entryFailureBackoff) backoffDuration(count int) time.Duration {
+	d := float64(b.config.base)
+	for i := 1; i < count; i++ {
+		d *= b.config.factor
+		if d >= float64(b.config.max) {
+			d = float64(b.config.max)
+			break
+		}
+	}
+	if d > float64(b.config.max) {
+		d = float64(b.config.max)
+	}
+	// apply ±10% jitter to avoid synchronized retries of many entries
+	jitter := 1 + (rand.Float64()*0.2 - 0.1) // #nosec G404 -- not used for cryptographic purposes
+	return time.Duration(d * jitter)
+}

--- a/pkg/dnsman2/controller/controlplane/dnsentry/failure_backoff_test.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/failure_backoff_test.go
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dnsentry
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/clock/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("entryFailureBackoff", func() {
+	var (
+		backoff   *entryFailureBackoff
+		fakeClock *testing.FakeClock
+		key       client.ObjectKey
+		fp        entryFingerprint
+	)
+
+	BeforeEach(func() {
+		fakeClock = testing.NewFakeClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+		backoff = newEntryFailureBackoff(entryFailureBackoffConfig{
+			base:   30 * time.Second,
+			factor: 2,
+			max:    10 * time.Minute,
+		}, fakeClock)
+		key = client.ObjectKey{Namespace: "test", Name: "entry1"}
+		fp = computeEntryFingerprint(1, map[string]string{"dns.gardener.cloud/class": "gardendns"})
+	})
+
+	It("reports no block for unknown entries", func() {
+		_, blocked := backoff.blockedUntilFor(key, fp)
+		Expect(blocked).To(BeFalse())
+	})
+
+	It("blocks after a failure and unblocks once the window elapsed", func() {
+		next := backoff.recordFailureFor(key, fp)
+		Expect(next).To(BeTemporally(">", fakeClock.Now()))
+
+		until, blocked := backoff.blockedUntilFor(key, fp)
+		Expect(blocked).To(BeTrue())
+		Expect(until).To(Equal(next))
+
+		fakeClock.SetTime(next)
+		_, blocked = backoff.blockedUntilFor(key, fp)
+		Expect(blocked).To(BeFalse())
+	})
+
+	It("does not block when the generation changed", func() {
+		backoff.recordFailureFor(key, fp)
+
+		changed := computeEntryFingerprint(2, map[string]string{"dns.gardener.cloud/class": "gardendns"})
+		_, blocked := backoff.blockedUntilFor(key, changed)
+		Expect(blocked).To(BeFalse())
+	})
+
+	It("does not block when a dns.gardener.cloud annotation changed", func() {
+		backoff.recordFailureFor(key, fp)
+
+		changed := computeEntryFingerprint(1, map[string]string{"dns.gardener.cloud/class": "other"})
+		_, blocked := backoff.blockedUntilFor(key, changed)
+		Expect(blocked).To(BeFalse())
+	})
+
+	It("ignores annotations outside the dns.gardener.cloud group", func() {
+		backoff.recordFailureFor(key, fp)
+
+		// adding an unrelated annotation must not reset the backoff
+		same := computeEntryFingerprint(1, map[string]string{
+			"dns.gardener.cloud/class":   "gardendns",
+			"other.example.com/whatever": "x",
+		})
+		_, blocked := backoff.blockedUntilFor(key, same)
+		Expect(blocked).To(BeTrue())
+	})
+
+	It("restarts the backoff count when the entry changed", func() {
+		backoff.recordFailureFor(key, fp)
+		first := backoff.recordFailureFor(key, fp) // count == 2
+
+		changed := computeEntryFingerprint(2, map[string]string{"dns.gardener.cloud/class": "gardendns"})
+		after := backoff.recordFailureFor(key, changed) // count reset to 1
+
+		// count reset -> window back to base (<= base+jitter), shorter than the count==2 window
+		base := float64(30 * time.Second)
+		Expect(after.Sub(fakeClock.Now())).To(BeNumerically("<=", time.Duration(base*1.1)))
+		Expect(after.Sub(fakeClock.Now())).To(BeNumerically("<", first.Sub(fakeClock.Now())))
+	})
+
+	It("grows the backoff duration with consecutive failures", func() {
+		var prev time.Duration
+		for i := 1; i <= 6; i++ {
+			d := backoff.backoffDuration(i)
+			if i > 1 {
+				Expect(d).To(BeNumerically(">", prev))
+			}
+			prev = d
+		}
+	})
+
+	It("caps the backoff duration at max (accounting for jitter)", func() {
+		// large count -> capped at max, plus up to ±10% jitter
+		maxDur := float64(10 * time.Minute)
+		maxUpper := time.Duration(maxDur * 1.1)
+		maxLower := time.Duration(maxDur * 0.9)
+		d := backoff.backoffDuration(100)
+		Expect(d).To(BeNumerically("<=", maxUpper))
+		Expect(d).To(BeNumerically(">=", maxLower))
+	})
+
+	It("applies jitter within ±10% of the base for the first failure", func() {
+		base := float64(30 * time.Second)
+		lower := time.Duration(base * 0.9)
+		upper := time.Duration(base * 1.1)
+		for range 50 {
+			d := backoff.backoffDuration(1)
+			Expect(d).To(BeNumerically(">=", lower))
+			Expect(d).To(BeNumerically("<=", upper))
+		}
+	})
+
+	It("resets the counter on clear", func() {
+		backoff.recordFailureFor(key, fp)
+		backoff.recordFailureFor(key, fp)
+		backoff.clear(key)
+
+		_, blocked := backoff.blockedUntilFor(key, fp)
+		Expect(blocked).To(BeFalse())
+
+		// after clear, next failure starts again at the base window
+		base := float64(30 * time.Second)
+		upper := time.Duration(base * 1.1)
+		next := backoff.recordFailureFor(key, fp)
+		Expect(next.Sub(fakeClock.Now())).To(BeNumerically("<=", upper))
+	})
+})

--- a/pkg/dnsman2/controller/controlplane/dnsentry/reconciler.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/reconciler.go
@@ -50,6 +50,7 @@ type Reconciler struct {
 	lastUpdate         *ttlcache.Cache[client.ObjectKey, struct{}]
 	lastDriftCheck     *ttlcache.Cache[client.ObjectKey, struct{}]
 	lastProviderUpdate *ttlcache.Cache[client.ObjectKey, providerSnapshot]
+	failureBackoff     *entryFailureBackoff
 }
 
 type providerSnapshot struct {
@@ -97,6 +98,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		defaultCNAMELookupInterval: r.defaultCNAMELookupInterval,
 		lastUpdate:                 r.lastUpdate,
 		lastDriftCheck:             r.lastDriftCheck,
+		failureBackoff:             r.failureBackoff,
 	}
 	res := er.reconcile()
 	if res.Err != nil {

--- a/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_reconcile.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_reconcile.go
@@ -42,6 +42,7 @@ type entryReconciliation struct {
 	defaultCNAMELookupInterval int64
 	lastUpdate                 *ttlcache.Cache[client.ObjectKey, struct{}]
 	lastDriftCheck             *ttlcache.Cache[client.ObjectKey, struct{}]
+	failureBackoff             *entryFailureBackoff
 }
 
 type newTargetsData struct {
@@ -63,6 +64,8 @@ func (r *entryReconciliation) reconcile() common.ReconcileResult {
 
 	r.state.GetQuotaReservationsMap().Release(client.ObjectKeyFromObject(r.Entry))
 
+	r.applyFailureBackoff(&orgResult)
+
 	// update status if state/message changed
 	res := orgResult
 	if orgResult.State != nil {
@@ -77,6 +80,23 @@ func (r *entryReconciliation) reconcile() common.ReconcileResult {
 		}
 	}
 	return res
+}
+
+// applyFailureBackoff updates the per-entry failure backoff based on the reconciliation outcome. When the entry ends up
+// in error state with a scheduled retry, the retry delay is stretched by the exponential backoff so that persistently
+// failing entries are reconciled less frequently. Any other terminal outcome clears the backoff so the entry recovers
+// promptly. The backoff itself resets whenever the entry changes (see entryFailureBackoff).
+func (r *entryReconciliation) applyFailureBackoff(result *common.ReconcileResult) {
+	key := client.ObjectKeyFromObject(r.Entry)
+	if result.Err == nil && ptr.Deref(result.State, "") == v1alpha1.StateError && result.Result.RequeueAfter > 0 {
+		nextRetry := r.failureBackoff.recordFailure(r.Entry)
+		if backoff := nextRetry.Sub(r.Clock.Now()); backoff > result.Result.RequeueAfter {
+			result.Result.RequeueAfter = backoff
+		}
+		return
+	}
+	// Not a retryable error outcome -> reset the backoff so the next failure starts from the base delay again.
+	r.failureBackoff.clear(key)
 }
 
 func (r *entryReconciliation) doReconcile() common.ReconcileResult {

--- a/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_reconcile.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_reconcile.go
@@ -144,11 +144,6 @@ func (r *entryReconciliation) doReconcile() common.ReconcileResult {
 	if res != nil {
 		return *res
 	}
-	if len(targetsData.targets) > 0 {
-		if res := r.StatusUpdater().AddFinalizer(); res != nil {
-			return *res
-		}
-	}
 
 	if r.shouldTryRecordTypeDriftRecovery() {
 		r.insertPossibleAlternativeKeys(recordsToCheck)

--- a/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_test.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/apis/config"
 	dnsmanclient "github.com/gardener/external-dns-management/pkg/dnsman2/client"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/controller/controlplane/dnsentry/common"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/controller/controlplane/dnsentry/lookup"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns"
 	dnsprovider "github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider"
@@ -350,6 +351,7 @@ var _ = Describe("Reconcile", func() {
 			state:           state.GetState(),
 			lookupProcessor: lookup.NewLookupProcessor(log.WithName("lookup-processor"), lookup.NewNullTrigger(), 1, 250*time.Millisecond),
 		}
+		reconciler.initDefaultFailureBackoff()
 		reconciler.setCachePeriods(1*time.Microsecond, defaultDriftCheckPeriod, defaultProviderUpdateCachePeriod)
 		state.GetState().SetDNSHandlerFactory(registry)
 
@@ -1163,5 +1165,48 @@ var _ = Describe("Reconcile", func() {
 				unexpectedFinalizers:     []string{"class-b.dns.gardener.cloud/compound", "class-c.dns.gardener.cloud/compound", "class-d.dns.gardener.cloud/compound"},
 			}),
 		)
+	})
+
+	Context("failure backoff", func() {
+		It("grows the error requeue delay and resets it on success", func() {
+			er := &entryReconciliation{
+				EntryContext:   common.EntryContext{Clock: clock, Log: log, Entry: entryA},
+				failureBackoff: reconciler.failureBackoff,
+			}
+
+			errResult := func() common.ReconcileResult {
+				return common.ReconcileResult{State: ptr.To(v1alpha1.StateError), Result: reconcile.Result{RequeueAfter: 5 * time.Second}}
+			}
+
+			first := errResult()
+			er.applyFailureBackoff(&first)
+			// base 30s +/- 10% jitter, always longer than the original 5s
+			Expect(first.Result.RequeueAfter).To(BeNumerically(">", 5*time.Second))
+
+			second := errResult()
+			er.applyFailureBackoff(&second)
+			// second consecutive failure -> ~base*factor, longer than the first
+			Expect(second.Result.RequeueAfter).To(BeNumerically(">", first.Result.RequeueAfter))
+
+			// a successful reconciliation clears the backoff, so the next failure starts again from the base delay
+			success := common.ReconcileResult{State: ptr.To(v1alpha1.StateReady)}
+			er.applyFailureBackoff(&success)
+
+			third := errResult()
+			er.applyFailureBackoff(&third)
+			Expect(third.Result.RequeueAfter).To(BeNumerically("<", second.Result.RequeueAfter))
+		})
+
+		It("does not stretch the requeue for non-error outcomes", func() {
+			er := &entryReconciliation{
+				EntryContext:   common.EntryContext{Clock: clock, Log: log, Entry: entryA},
+				failureBackoff: reconciler.failureBackoff,
+			}
+
+			// a stale self-requeue keeps its short delay (it is not paced by the failure backoff)
+			stale := common.ReconcileResult{State: ptr.To(v1alpha1.StateStale), Result: reconcile.Result{RequeueAfter: waitForProviderRetryInterval}}
+			er.applyFailureBackoff(&stale)
+			Expect(stale.Result.RequeueAfter).To(Equal(waitForProviderRetryInterval))
+		})
 	})
 })

--- a/pkg/dnsman2/dns/provider/handler/aws/execution.go
+++ b/pkg/dnsman2/dns/provider/handler/aws/execution.go
@@ -140,7 +140,7 @@ func (ex *execution) submitChanges(ctx context.Context, metrics provider.Metrics
 		if len(failedChanges) > 0 {
 			failed += len(failedChanges)
 			ex.log.Error(err, fmt.Sprintf("%d records failed", len(failedChanges)), "zoneID", ex.zoneID)
-			failedErr = errors.Join(failedErr, err)
+			failedErr = errors.Join(failedErr, stableError(err))
 		}
 		if len(succeededChanges) > 0 {
 			ex.log.Info(fmt.Sprintf("%d records were successfully updated", len(succeededChanges)), "zoneID", ex.zoneID)

--- a/test/integration/dnsman2/provider_entry_test.go
+++ b/test/integration/dnsman2/provider_entry_test.go
@@ -162,6 +162,9 @@ var _ = Describe("Provider/Entry collaboration tests", func() {
 				},
 				DNSEntry: config.DNSEntryControllerConfig{
 					ReconciliationDelayAfterUpdate: new(metav1.Duration{Duration: 10 * time.Millisecond}),
+					// keep the failure backoff short so temporary-backend-failure recovery is observed within retryTimeout
+					EntryFailureBackoffBase: new(metav1.Duration{Duration: 50 * time.Millisecond}),
+					EntryFailureBackoffMax:  new(metav1.Duration{Duration: 500 * time.Millisecond}),
 				},
 				SkipNameValidation: new(true),
 			},


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
When a provider update for a DNS entry keeps failing (e.g. due to conflicts), the entry status is set to error, which re-enqueues the entry and re-triggers a full hosted zone reconciliation at the fixed zone cadence — indefinitely. This causes unnecessary load on both the controller and the DNS provider API.

Additionally:
- the AWS provider was unnecessarily dropping its zone cache when all changes failed
- in the next-generation DNSEntry controller the finalizer was added to a DNSEntry before applying changes, which caused the finalizer to be immediately removed again on failure and trigger a redundant reconciliation.

Changes:
  - Add per-entry exponential failure backoff (base=30s, factor=2, max=30m, with jitter) to reduce reconciliation frequency for persistently failing DNS entries, in both the legacy `pkg/dns/provider` and `dnsman2` paths
  - Reset backoff on success or when the entry changes (generation or `dns.gardener.cloud` annotations), so user edits are always reconciled immediately
  - Fix finalizer ordering in `dnsman2`: add finalizer *after* applying changes, not before, to avoid spurious removal + re-reconciliation on failure
  - Avoid dropping the AWS zone cache when all changes in a batch fail
  - Return stable error messages from `applyChanges` (no request IDs) so error state changes are detectable across retries
  - Add unit tests for the backoff logic in both code paths; extend reconciler and integration tests
  - Add new config fields `entryFailureBackoffBase/Factor/Max` with defaults and generated deepcopy/conversion code
  - Update `docs/api-reference/config.md` with the new config fields
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Per-entry exponential backoff for persistently failing DNS entries: when a provider update keeps failing, the entry's hosted zone reconciliation is suppressed for an increasing delay (default: base 30s, factor 2, max 30m, with jitter) instead of retrying at the full zone cadence. The backoff resets immediately on success or when the entry is modified.
```

```bugfix operator
[next-generation] Fixed spurious re-reconciliation caused by finalizer being added to`DNSEntry` before changes were applied.
```

```bugfix operator
Fixed unnecessary AWS zone cache invalidation when all DNS changes in a batch fail.
```

