### PR TITLE
[next-generation] Order DNS change requests when transitioning between plain and policy records

### DIFF
--- a/pkg/dnsman2/controller/controlplane/dnsentry/records/dnsrecordmanager.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/records/dnsrecordmanager.go
@@ -55,7 +55,9 @@ func (m *DNSRecordManager) ApplyChangeRequests(providerData *providerselector.Ne
 		if zone == nil {
 			return common.ErrorReconcileResult(fmt.Sprintf("zone %s not found in provider %s", newZoneID.ID, providerData.ProviderKey), true)
 		}
-		for _, changeRequests := range changeRequestsPerName {
+		orderedKeys := m.orderChanges(changeRequestsPerName)
+		for _, key := range orderedKeys {
+			changeRequests := changeRequestsPerName[key]
 			m.Log.V(1).Info("applying change requests", "zone", zone.ZoneID(), "requests", changeRequests)
 			if err := providerData.ProviderState.GetAccount().ExecuteRequests(m.Ctx, zone, *changeRequests); err != nil {
 				return common.ErrorReconcileResult(fmt.Sprintf("failed to execute DNS change requests: %s", err), true)
@@ -63,6 +65,50 @@ func (m *DNSRecordManager) ApplyChangeRequests(providerData *providerselector.Ne
 		}
 	}
 	return nil
+}
+
+func (m *DNSRecordManager) orderChanges(changeRequestsPerName map[dns.DNSSetName]*provider.ChangeRequests) []dns.DNSSetName {
+	// if there are changes transitioning from plain to routing-policy records or vice versa for the same domain name, ensure that the deletion happens first.
+	var (
+		plainKeys   []dns.DNSSetName
+		policyKeys  []dns.DNSSetName
+		orderedKeys []dns.DNSSetName
+	)
+	for key := range changeRequestsPerName {
+		if key.SetIdentifier == "" {
+			plainKeys = append(plainKeys, key)
+		} else {
+			policyKeys = append(policyKeys, key)
+		}
+	}
+	if len(policyKeys) == 0 {
+		return plainKeys
+	}
+	if len(plainKeys) == 0 {
+		return policyKeys
+	}
+
+	handledPolicyKeys := sets.New[dns.DNSSetName]()
+	for _, k1 := range plainKeys {
+		if !isDeletion(changeRequestsPerName[k1]) {
+			for _, k2 := range policyKeys {
+				if k1.DNSName == k2.DNSName {
+					if isDeletion(changeRequestsPerName[k2]) {
+						orderedKeys = append(orderedKeys, k2)
+						handledPolicyKeys.Insert(k2)
+					}
+				}
+			}
+		}
+		orderedKeys = append(orderedKeys, k1)
+	}
+
+	for _, key := range policyKeys {
+		if !handledPolicyKeys.Has(key) {
+			orderedKeys = append(orderedKeys, key)
+		}
+	}
+	return orderedKeys
 }
 
 // QueryRecords queries DNS records for the given set of record keys.
@@ -132,4 +178,13 @@ func (m *DNSRecordManager) cleanupCrossZoneRecords(zoneID dns.ZoneID, perName ma
 		}
 	}
 	return nil
+}
+
+func isDeletion(changeRequests *provider.ChangeRequests) bool {
+	for _, changeRequest := range changeRequests.Updates {
+		if changeRequest.New == nil {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/dnsman2/controller/controlplane/dnsentry/records/dnsrecordmanager.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/records/dnsrecordmanager.go
@@ -55,7 +55,7 @@ func (m *DNSRecordManager) ApplyChangeRequests(providerData *providerselector.Ne
 		if zone == nil {
 			return common.ErrorReconcileResult(fmt.Sprintf("zone %s not found in provider %s", newZoneID.ID, providerData.ProviderKey), true)
 		}
-		orderedKeys := m.orderChanges(changeRequestsPerName)
+		orderedKeys := orderChanges(changeRequestsPerName)
 		for _, key := range orderedKeys {
 			changeRequests := changeRequestsPerName[key]
 			m.Log.V(1).Info("applying change requests", "zone", zone.ZoneID(), "requests", changeRequests)
@@ -65,50 +65,6 @@ func (m *DNSRecordManager) ApplyChangeRequests(providerData *providerselector.Ne
 		}
 	}
 	return nil
-}
-
-func (m *DNSRecordManager) orderChanges(changeRequestsPerName map[dns.DNSSetName]*provider.ChangeRequests) []dns.DNSSetName {
-	// if there are changes transitioning from plain to routing-policy records or vice versa for the same domain name, ensure that the deletion happens first.
-	var (
-		plainKeys   []dns.DNSSetName
-		policyKeys  []dns.DNSSetName
-		orderedKeys []dns.DNSSetName
-	)
-	for key := range changeRequestsPerName {
-		if key.SetIdentifier == "" {
-			plainKeys = append(plainKeys, key)
-		} else {
-			policyKeys = append(policyKeys, key)
-		}
-	}
-	if len(policyKeys) == 0 {
-		return plainKeys
-	}
-	if len(plainKeys) == 0 {
-		return policyKeys
-	}
-
-	handledPolicyKeys := sets.New[dns.DNSSetName]()
-	for _, k1 := range plainKeys {
-		if !isDeletion(changeRequestsPerName[k1]) {
-			for _, k2 := range policyKeys {
-				if k1.DNSName == k2.DNSName {
-					if isDeletion(changeRequestsPerName[k2]) {
-						orderedKeys = append(orderedKeys, k2)
-						handledPolicyKeys.Insert(k2)
-					}
-				}
-			}
-		}
-		orderedKeys = append(orderedKeys, k1)
-	}
-
-	for _, key := range policyKeys {
-		if !handledPolicyKeys.Has(key) {
-			orderedKeys = append(orderedKeys, key)
-		}
-	}
-	return orderedKeys
 }
 
 // QueryRecords queries DNS records for the given set of record keys.
@@ -178,6 +134,50 @@ func (m *DNSRecordManager) cleanupCrossZoneRecords(zoneID dns.ZoneID, perName ma
 		}
 	}
 	return nil
+}
+
+func orderChanges(changeRequestsPerName map[dns.DNSSetName]*provider.ChangeRequests) []dns.DNSSetName {
+	// if there are changes transitioning from plain to routing-policy records or vice versa for the same domain name, ensure that the deletion happens first.
+	var (
+		plainKeys   []dns.DNSSetName
+		policyKeys  []dns.DNSSetName
+		orderedKeys []dns.DNSSetName
+	)
+	for key := range changeRequestsPerName {
+		if key.SetIdentifier == "" {
+			plainKeys = append(plainKeys, key)
+		} else {
+			policyKeys = append(policyKeys, key)
+		}
+	}
+	if len(policyKeys) == 0 {
+		return plainKeys
+	}
+	if len(plainKeys) == 0 {
+		return policyKeys
+	}
+
+	handledPolicyKeys := sets.New[dns.DNSSetName]()
+	for _, k1 := range plainKeys {
+		if !isDeletion(changeRequestsPerName[k1]) {
+			for _, k2 := range policyKeys {
+				if k1.DNSName == k2.DNSName {
+					if isDeletion(changeRequestsPerName[k2]) {
+						orderedKeys = append(orderedKeys, k2)
+						handledPolicyKeys.Insert(k2)
+					}
+				}
+			}
+		}
+		orderedKeys = append(orderedKeys, k1)
+	}
+
+	for _, key := range policyKeys {
+		if !handledPolicyKeys.Has(key) {
+			orderedKeys = append(orderedKeys, key)
+		}
+	}
+	return orderedKeys
 }
 
 func isDeletion(changeRequests *provider.ChangeRequests) bool {

--- a/pkg/dnsman2/controller/controlplane/dnsentry/records/dnsrecordmanager_test.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/records/dnsrecordmanager_test.go
@@ -34,8 +34,6 @@ func deleteCR(dnsName, setID string) *provider.ChangeRequests {
 }
 
 var _ = Describe("orderChanges", func() {
-	var mgr DNSRecordManager
-
 	plain := func(dnsName string) dns.DNSSetName {
 		return dns.DNSSetName{DNSName: dnsName}
 	}
@@ -45,7 +43,7 @@ var _ = Describe("orderChanges", func() {
 
 	DescribeTable("ordering change requests",
 		func(input map[dns.DNSSetName]*provider.ChangeRequests, assertFn func([]dns.DNSSetName)) {
-			result := mgr.orderChanges(input)
+			result := orderChanges(input)
 			assertFn(result)
 		},
 

--- a/pkg/dnsman2/controller/controlplane/dnsentry/records/dnsrecordmanager_test.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/records/dnsrecordmanager_test.go
@@ -1,0 +1,187 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package records
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider"
+)
+
+// helpers to build ChangeRequests concisely
+func createCR(dnsName, setID string) *provider.ChangeRequests {
+	name := dns.DNSSetName{DNSName: dnsName, SetIdentifier: setID}
+	cr := provider.NewChangeRequests(name)
+	cr.Updates[dns.TypeA] = &provider.ChangeRequestUpdate{
+		Old: nil,
+		New: &dns.RecordSet{Type: dns.TypeA},
+	}
+	return cr
+}
+
+func deleteCR(dnsName, setID string) *provider.ChangeRequests {
+	name := dns.DNSSetName{DNSName: dnsName, SetIdentifier: setID}
+	cr := provider.NewChangeRequests(name)
+	cr.Updates[dns.TypeA] = &provider.ChangeRequestUpdate{
+		Old: &dns.RecordSet{Type: dns.TypeA},
+		New: nil,
+	}
+	return cr
+}
+
+var _ = Describe("orderChanges", func() {
+	var mgr DNSRecordManager
+
+	plain := func(dnsName string) dns.DNSSetName {
+		return dns.DNSSetName{DNSName: dnsName}
+	}
+	policy := func(dnsName, id string) dns.DNSSetName {
+		return dns.DNSSetName{DNSName: dnsName, SetIdentifier: id}
+	}
+
+	DescribeTable("ordering change requests",
+		func(input map[dns.DNSSetName]*provider.ChangeRequests, assertFn func([]dns.DNSSetName)) {
+			result := mgr.orderChanges(input)
+			assertFn(result)
+		},
+
+		Entry("empty input returns empty slice",
+			map[dns.DNSSetName]*provider.ChangeRequests{},
+			func(keys []dns.DNSSetName) {
+				Expect(keys).To(BeEmpty())
+			},
+		),
+
+		Entry("only plain keys are returned as-is",
+			map[dns.DNSSetName]*provider.ChangeRequests{
+				plain("a.example.com"): createCR("a.example.com", ""),
+				plain("b.example.com"): deleteCR("b.example.com", ""),
+			},
+			func(keys []dns.DNSSetName) {
+				Expect(keys).To(ConsistOf(plain("a.example.com"), plain("b.example.com")))
+			},
+		),
+
+		Entry("only policy keys are returned as-is",
+			map[dns.DNSSetName]*provider.ChangeRequests{
+				policy("a.example.com", "p1"): createCR("a.example.com", "p1"),
+				policy("a.example.com", "p2"): deleteCR("a.example.com", "p2"),
+			},
+			func(keys []dns.DNSSetName) {
+				Expect(keys).To(ConsistOf(policy("a.example.com", "p1"), policy("a.example.com", "p2")))
+			},
+		),
+
+		Entry("plain create + policy delete for same name: policy delete comes before plain create",
+			map[dns.DNSSetName]*provider.ChangeRequests{
+				plain("a.example.com"):        createCR("a.example.com", ""),
+				policy("a.example.com", "p1"): deleteCR("a.example.com", "p1"),
+			},
+			func(keys []dns.DNSSetName) {
+				Expect(keys).To(HaveLen(2))
+				Expect(keys[0]).To(Equal(policy("a.example.com", "p1")))
+				Expect(keys[1]).To(Equal(plain("a.example.com")))
+			},
+		),
+
+		Entry("plain delete + policy create for same name: no special reordering (plain before policy)",
+			map[dns.DNSSetName]*provider.ChangeRequests{
+				plain("a.example.com"):        deleteCR("a.example.com", ""),
+				policy("a.example.com", "p1"): createCR("a.example.com", "p1"),
+			},
+			func(keys []dns.DNSSetName) {
+				Expect(keys).To(ConsistOf(plain("a.example.com"), policy("a.example.com", "p1")))
+			},
+		),
+
+		Entry("plain create + policy create for same name: both present, no special ordering needed",
+			map[dns.DNSSetName]*provider.ChangeRequests{
+				plain("a.example.com"):        createCR("a.example.com", ""),
+				policy("a.example.com", "p1"): createCR("a.example.com", "p1"),
+			},
+			func(keys []dns.DNSSetName) {
+				Expect(keys).To(ConsistOf(plain("a.example.com"), policy("a.example.com", "p1")))
+			},
+		),
+
+		Entry("plain and policy keys for different names: no special interleaving",
+			map[dns.DNSSetName]*provider.ChangeRequests{
+				plain("a.example.com"):        createCR("a.example.com", ""),
+				policy("b.example.com", "p1"): deleteCR("b.example.com", "p1"),
+			},
+			func(keys []dns.DNSSetName) {
+				Expect(keys).To(ConsistOf(plain("a.example.com"), policy("b.example.com", "p1")))
+			},
+		),
+
+		Entry("multiple policy keys for same plain name: only the deletion policy key is front-ordered",
+			map[dns.DNSSetName]*provider.ChangeRequests{
+				plain("a.example.com"):        createCR("a.example.com", ""),
+				policy("a.example.com", "p1"): deleteCR("a.example.com", "p1"),
+				policy("a.example.com", "p2"): createCR("a.example.com", "p2"),
+			},
+			func(keys []dns.DNSSetName) {
+				Expect(keys).To(HaveLen(3))
+				Expect(keys[0]).To(Equal(policy("a.example.com", "p1")))
+				// plain and p2 follow in any order
+				Expect(keys[1:]).To(ConsistOf(plain("a.example.com"), policy("a.example.com", "p2")))
+			},
+		),
+	)
+})
+
+var _ = Describe("isDeletion", func() {
+	DescribeTable("detecting deletion change requests",
+		func(cr *provider.ChangeRequests, expected bool) {
+			Expect(isDeletion(cr)).To(Equal(expected))
+		},
+
+		Entry("all updates are deletions (New == nil)",
+			&provider.ChangeRequests{
+				Updates: map[dns.RecordType]*provider.ChangeRequestUpdate{
+					dns.TypeA: {Old: &dns.RecordSet{}, New: nil},
+				},
+			},
+			true,
+		),
+
+		Entry("all updates are creates (New != nil)",
+			&provider.ChangeRequests{
+				Updates: map[dns.RecordType]*provider.ChangeRequestUpdate{
+					dns.TypeA: {Old: nil, New: &dns.RecordSet{}},
+				},
+			},
+			false,
+		),
+
+		Entry("mixed updates: at least one deletion returns true",
+			&provider.ChangeRequests{
+				Updates: map[dns.RecordType]*provider.ChangeRequestUpdate{
+					dns.TypeA:    {Old: &dns.RecordSet{}, New: nil},
+					dns.TypeAAAA: {Old: nil, New: &dns.RecordSet{}},
+				},
+			},
+			true,
+		),
+
+		Entry("update (Old and New both set) returns false",
+			&provider.ChangeRequests{
+				Updates: map[dns.RecordType]*provider.ChangeRequestUpdate{
+					dns.TypeA: {Old: &dns.RecordSet{}, New: &dns.RecordSet{}},
+				},
+			},
+			false,
+		),
+
+		Entry("empty updates returns false",
+			&provider.ChangeRequests{
+				Updates: map[dns.RecordType]*provider.ChangeRequestUpdate{},
+			},
+			false,
+		),
+	)
+})

--- a/pkg/dnsman2/controller/controlplane/dnsentry/records/records_suite_test.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/records/records_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package records_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestRecords(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Records Suite")
+}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Order DNS change requests when transitioning between plain and policy records.
Add tests for `orderChanges()` and `isDeletion()` in the records package.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
[next-generation] Order DNS change requests when transitioning between plain and routing policy records.
```
