### PR TITLE
[next-generation] Fix flaky quota test: deduct overlap when entry is both provisioned and reserved

### DIFF
--- a/pkg/dnsman2/controller/controlplane/dnsentry/providerselector/providerselector.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/providerselector/providerselector.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -66,8 +67,7 @@ func (s *providerSelector) calcNewProvider() (*NewProviderData, *common.Reconcil
 
 	// Check entries quota before assigning entry to provider
 	if err := s.checkEntriesQuota(newProvider, providerKey); err != nil {
-		var quotaErr *quotaExceededError
-		if errors.As(err, &quotaErr) {
+		if errors.As(err, new(*quotaExceededError)) {
 			res := common.ErrorReconcileResult(err.Error(), false)
 			res.Result.RequeueAfter = rescheduleTimeQuotaExceeded
 			return nil, res
@@ -113,15 +113,22 @@ func (s *providerSelector) checkEntriesQuota(provider *v1alpha1.DNSProvider, pro
 	}
 
 	// Count provisioned entries (those with status.provider set)
-	provisionedCount, err := CountEntriesForProvider(s.Ctx, s.Client, s.namespace, providerKey)
+	provisionedEntries, err := ListEntriesForProvider(s.Ctx, s.Client, s.namespace, providerKey)
 	if err != nil {
 		return fmt.Errorf("failed to count entries for provider: %w", err)
 	}
+	provisionedKeys := sets.New[client.ObjectKey]()
+	for i := range provisionedEntries {
+		provisionedKeys.Insert(client.ObjectKeyFromObject(&provisionedEntries[i]))
+	}
 
-	// Reserve slot for this entry to prevent race conditions
-	reserved := s.state.GetQuotaReservationsMap().Reserve(client.ObjectKeyFromObject(s.Entry), providerKey, func(reservedCount int32) bool {
-		// Check total count against quota
-		return provisionedCount+reservedCount <= *quota.Entries
+	// Reserve slot for this entry to prevent race conditions.
+	// reservedEntryKeys contains entry keys with active reservations for this provider (including this entry).
+	// Some of those entries may already appear in provisionedKeys (they were provisioned but Release hasn't
+	// been called yet), so we subtract the overlap to avoid double-counting.
+	reserved := s.state.GetQuotaReservationsMap().Reserve(client.ObjectKeyFromObject(s.Entry), providerKey, func(reservedEntryKeys sets.Set[client.ObjectKey]) bool {
+		overlap := provisionedKeys.Intersection(reservedEntryKeys).Len()
+		return provisionedKeys.Len()+reservedEntryKeys.Len()-overlap <= int(*quota.Entries)
 	})
 
 	if !reserved {

--- a/pkg/dnsman2/controller/controlplane/dnsentry/providerselector/quota.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/providerselector/quota.go
@@ -14,18 +14,28 @@ import (
 	"github.com/gardener/external-dns-management/pkg/dnsman2/controller/controlplane/dnsprovider"
 )
 
-// CountEntriesForProvider counts the number of DNSEntry resources currently assigned to the specified provider.
-// It uses the field indexer on status.provider for efficient O(1) lookup.
-// Only entries that have status.provider set are counted (i.e., entries that have been successfully provisioned).
-func CountEntriesForProvider(ctx context.Context, c client.Client, namespace string, providerKey client.ObjectKey) (int32, error) {
+// ListEntriesForProvider returns the DNSEntry resources currently assigned to the specified provider.
+// Only entries that have status.provider set are returned (i.e., entries that have been successfully provisioned).
+func ListEntriesForProvider(ctx context.Context, c client.Client, namespace string, providerKey client.ObjectKey) ([]v1alpha1.DNSEntry, error) {
 	entryList := &v1alpha1.DNSEntryList{}
 	if err := c.List(ctx, entryList,
 		client.InNamespace(namespace),
 		client.MatchingFields{dnsprovider.EntryStatusProvider: providerKey.String()},
 	); err != nil {
+		return nil, err
+	}
+	return entryList.Items, nil
+}
+
+// CountEntriesForProvider counts the number of DNSEntry resources currently assigned to the specified provider.
+// It uses the field indexer on status.provider for efficient O(1) lookup.
+// Only entries that have status.provider set are counted (i.e., entries that have been successfully provisioned).
+func CountEntriesForProvider(ctx context.Context, c client.Client, namespace string, providerKey client.ObjectKey) (int32, error) {
+	entries, err := ListEntriesForProvider(ctx, c, namespace, providerKey)
+	if err != nil {
 		return 0, err
 	}
-	return int32(len(entryList.Items)), nil // #nosec G115 -- number of entries will never reach 2 billion, so int32 is sufficient
+	return int32(len(entries)), nil // #nosec G115 -- number of entries will never reach 2 billion, so int32 is sufficient
 }
 
 // quotaExceededError is returned when a provider has reached its entries quota.

--- a/pkg/dnsman2/controller/controlplane/dnsentry/providerselector/quota.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/providerselector/quota.go
@@ -27,17 +27,6 @@ func ListEntriesForProvider(ctx context.Context, c client.Client, namespace stri
 	return entryList.Items, nil
 }
 
-// CountEntriesForProvider counts the number of DNSEntry resources currently assigned to the specified provider.
-// It uses the field indexer on status.provider for efficient O(1) lookup.
-// Only entries that have status.provider set are counted (i.e., entries that have been successfully provisioned).
-func CountEntriesForProvider(ctx context.Context, c client.Client, namespace string, providerKey client.ObjectKey) (int32, error) {
-	entries, err := ListEntriesForProvider(ctx, c, namespace, providerKey)
-	if err != nil {
-		return 0, err
-	}
-	return int32(len(entries)), nil // #nosec G115 -- number of entries will never reach 2 billion, so int32 is sufficient
-}
-
 // quotaExceededError is returned when a provider has reached its entries quota.
 type quotaExceededError struct {
 	providerKey client.ObjectKey

--- a/pkg/dnsman2/controller/controlplane/dnsentry/providerselector/quota_test.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/providerselector/quota_test.go
@@ -19,7 +19,19 @@ import (
 	"github.com/gardener/external-dns-management/pkg/dnsman2/controller/controlplane/dnsprovider"
 )
 
-var _ = Describe("CountEntriesForProvider", func() {
+func buildFakeClient(scheme *runtime.Scheme, objects ...client.Object) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		WithIndex(&v1alpha1.DNSEntry{}, dnsprovider.EntryStatusProvider,
+			func(obj client.Object) []string {
+				entry := obj.(*v1alpha1.DNSEntry)
+				return []string{ptr.Deref(entry.Status.Provider, "")}
+			}).
+		Build()
+}
+
+var _ = Describe("ListEntriesForProvider", func() {
 	var (
 		ctx         context.Context
 		namespace   string
@@ -34,24 +46,15 @@ var _ = Describe("CountEntriesForProvider", func() {
 		providerKey = client.ObjectKey{Namespace: namespace, Name: "test-provider"}
 	})
 
-	It("should return 0 when no entries exist", func() {
-		fakeClient := fake.NewClientBuilder().
-			WithScheme(scheme).
-			WithIndex(&v1alpha1.DNSEntry{}, dnsprovider.EntryStatusProvider,
-				func(obj client.Object) []string {
-					entry := obj.(*v1alpha1.DNSEntry)
-					return []string{ptr.Deref(entry.Status.Provider, "")}
-				}).
-			Build()
-
-		count, err := CountEntriesForProvider(ctx, fakeClient, namespace, providerKey)
+	It("should return empty list when no entries exist", func() {
+		entries, err := ListEntriesForProvider(ctx, buildFakeClient(scheme), namespace, providerKey)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(count).To(Equal(int32(0)))
+		Expect(entries).To(BeEmpty())
 	})
 
-	It("should count entries with provider set", func() {
+	It("should list entries with provider set", func() {
 		providerName := providerKey.String()
-		entries := []client.Object{
+		fakeClient := buildFakeClient(scheme,
 			&v1alpha1.DNSEntry{
 				ObjectMeta: metav1.ObjectMeta{Name: "entry1", Namespace: namespace},
 				Status:     v1alpha1.DNSEntryStatus{Provider: new(providerName)},
@@ -60,26 +63,16 @@ var _ = Describe("CountEntriesForProvider", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: "entry2", Namespace: namespace},
 				Status:     v1alpha1.DNSEntryStatus{Provider: new(providerName)},
 			},
-		}
+		)
 
-		fakeClient := fake.NewClientBuilder().
-			WithScheme(scheme).
-			WithObjects(entries...).
-			WithIndex(&v1alpha1.DNSEntry{}, dnsprovider.EntryStatusProvider,
-				func(obj client.Object) []string {
-					entry := obj.(*v1alpha1.DNSEntry)
-					return []string{ptr.Deref(entry.Status.Provider, "")}
-				}).
-			Build()
-
-		count, err := CountEntriesForProvider(ctx, fakeClient, namespace, providerKey)
+		entries, err := ListEntriesForProvider(ctx, fakeClient, namespace, providerKey)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(count).To(Equal(int32(2)))
+		Expect(entries).To(HaveLen(2))
 	})
 
-	It("should only count entries with status.provider set", func() {
+	It("should only list entries with status.provider set", func() {
 		providerName := providerKey.String()
-		entries := []client.Object{
+		fakeClient := buildFakeClient(scheme,
 			&v1alpha1.DNSEntry{
 				ObjectMeta: metav1.ObjectMeta{Name: "entry1", Namespace: namespace},
 				Status:     v1alpha1.DNSEntryStatus{Provider: new(providerName)},
@@ -92,26 +85,17 @@ var _ = Describe("CountEntriesForProvider", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: "entry3", Namespace: namespace},
 				Status:     v1alpha1.DNSEntryStatus{},
 			},
-		}
+		)
 
-		fakeClient := fake.NewClientBuilder().
-			WithScheme(scheme).
-			WithObjects(entries...).
-			WithIndex(&v1alpha1.DNSEntry{}, dnsprovider.EntryStatusProvider,
-				func(obj client.Object) []string {
-					entry := obj.(*v1alpha1.DNSEntry)
-					return []string{ptr.Deref(entry.Status.Provider, "")}
-				}).
-			Build()
-
-		count, err := CountEntriesForProvider(ctx, fakeClient, namespace, providerKey)
+		entries, err := ListEntriesForProvider(ctx, fakeClient, namespace, providerKey)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(count).To(Equal(int32(1)))
+		Expect(entries).To(HaveLen(1))
+		Expect(entries[0].Name).To(Equal("entry1"))
 	})
 
-	It("should only count entries for the specified provider", func() {
+	It("should only list entries for the specified provider", func() {
 		providerName := providerKey.String()
-		entries := []client.Object{
+		fakeClient := buildFakeClient(scheme,
 			&v1alpha1.DNSEntry{
 				ObjectMeta: metav1.ObjectMeta{Name: "entry1", Namespace: namespace},
 				Status:     v1alpha1.DNSEntryStatus{Provider: new(providerName)},
@@ -120,21 +104,12 @@ var _ = Describe("CountEntriesForProvider", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: "entry2", Namespace: namespace},
 				Status:     v1alpha1.DNSEntryStatus{Provider: new("default/other-provider")},
 			},
-		}
+		)
 
-		fakeClient := fake.NewClientBuilder().
-			WithScheme(scheme).
-			WithObjects(entries...).
-			WithIndex(&v1alpha1.DNSEntry{}, dnsprovider.EntryStatusProvider,
-				func(obj client.Object) []string {
-					entry := obj.(*v1alpha1.DNSEntry)
-					return []string{ptr.Deref(entry.Status.Provider, "")}
-				}).
-			Build()
-
-		count, err := CountEntriesForProvider(ctx, fakeClient, namespace, providerKey)
+		entries, err := ListEntriesForProvider(ctx, fakeClient, namespace, providerKey)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(count).To(Equal(int32(1)))
+		Expect(entries).To(HaveLen(1))
+		Expect(entries[0].Name).To(Equal("entry1"))
 	})
 })
 

--- a/pkg/dnsman2/dns/state/quota.go
+++ b/pkg/dnsman2/dns/state/quota.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -39,9 +40,9 @@ func newQuotaReservationsMap(clock clock.Clock, ttl time.Duration) *quotaReserva
 }
 
 // Reserve creates a reservation for an entry with the specified provider.
-// The allow function is called with the current count of reservations for the provider (including this one) and should return true if the reservation is allowed (i.e. does not exceed quota).
+// The allow function is called with the set of entry keys currently reserved for the provider (including this entry).
 // Returns true if the reservation was created or already exists.
-func (m *quotaReservationsMap) Reserve(entryKey, providerKey client.ObjectKey, allow func(reservedCount int32) bool) bool {
+func (m *quotaReservationsMap) Reserve(entryKey, providerKey client.ObjectKey, allow func(reservedEntryKeys sets.Set[client.ObjectKey]) bool) bool {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
@@ -54,7 +55,7 @@ func (m *quotaReservationsMap) Reserve(entryKey, providerKey client.ObjectKey, a
 		timestamp:   m.clock.Now(),
 	}
 
-	if !allow(m.countReservationsForProvider(providerKey)) {
+	if !allow(m.reservedEntryKeysForProviderLocked(providerKey)) {
 		delete(m.reservations, entryKey)
 		return false
 	}
@@ -76,18 +77,19 @@ func (m *quotaReservationsMap) CountReservationsForProvider(providerKey client.O
 
 	m.cleanupExpiredLocked()
 
-	return m.countReservationsForProvider(providerKey)
+	return int32(len(m.reservedEntryKeysForProviderLocked(providerKey)))
 }
 
-// countReservationsForProvider counts active (non-expired) reservations for a provider. Must be called with lock held.
-func (m *quotaReservationsMap) countReservationsForProvider(providerKey client.ObjectKey) int32 {
-	var count int32
+// reservedEntryKeysForProviderLocked returns the set of entry keys with active reservations for a provider.
+// Must be called with lock held.
+func (m *quotaReservationsMap) reservedEntryKeysForProviderLocked(providerKey client.ObjectKey) sets.Set[client.ObjectKey] {
+	keys := sets.New[client.ObjectKey]()
 	for _, r := range m.reservations {
 		if r.providerKey == providerKey {
-			count++
+			keys.Insert(r.entryKey)
 		}
 	}
-	return count
+	return keys
 }
 
 // cleanupExpiredLocked removes expired reservations. Must be called with lock held.

--- a/pkg/dnsman2/dns/state/quota.go
+++ b/pkg/dnsman2/dns/state/quota.go
@@ -71,13 +71,13 @@ func (m *quotaReservationsMap) Release(entryKey client.ObjectKey) {
 }
 
 // CountReservationsForProvider counts active (non-expired) reservations for a provider.
-func (m *quotaReservationsMap) CountReservationsForProvider(providerKey client.ObjectKey) int32 {
+func (m *quotaReservationsMap) CountReservationsForProvider(providerKey client.ObjectKey) int {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
 	m.cleanupExpiredLocked()
 
-	return int32(len(m.reservedEntryKeysForProviderLocked(providerKey)))
+	return len(m.reservedEntryKeysForProviderLocked(providerKey))
 }
 
 // reservedEntryKeysForProviderLocked returns the set of entry keys with active reservations for a provider.

--- a/pkg/dnsman2/dns/state/quota_test.go
+++ b/pkg/dnsman2/dns/state/quota_test.go
@@ -40,7 +40,7 @@ var _ = Describe("QuotaReservationsMap", func() {
 			Expect(success).To(BeTrue())
 
 			count := rmap.CountReservationsForProvider(providerKey)
-			Expect(count).To(Equal(int32(1)))
+			Expect(count).To(Equal(1))
 		})
 
 		It("should release reservation", func() {
@@ -51,7 +51,7 @@ var _ = Describe("QuotaReservationsMap", func() {
 			rmap.Release(entryKey)
 
 			count := rmap.CountReservationsForProvider(providerKey)
-			Expect(count).To(Equal(int32(0)))
+			Expect(count).To(Equal(0))
 		})
 
 		It("should reject reservation when allow function returns false", func() {
@@ -64,7 +64,7 @@ var _ = Describe("QuotaReservationsMap", func() {
 			Expect(success).To(BeFalse())
 
 			count := rmap.CountReservationsForProvider(providerKey)
-			Expect(count).To(Equal(int32(0)))
+			Expect(count).To(Equal(0))
 		})
 	})
 
@@ -81,16 +81,16 @@ var _ = Describe("QuotaReservationsMap", func() {
 			rmap.Reserve(entry3, provider2, allowAll)
 
 			count1 := rmap.CountReservationsForProvider(provider1)
-			Expect(count1).To(Equal(int32(2)))
+			Expect(count1).To(Equal(2))
 
 			count2 := rmap.CountReservationsForProvider(provider2)
-			Expect(count2).To(Equal(int32(1)))
+			Expect(count2).To(Equal(1))
 		})
 
 		It("should return 0 for provider with no reservations", func() {
 			providerKey := client.ObjectKey{Namespace: "default", Name: "provider1"}
 			count := rmap.CountReservationsForProvider(providerKey)
-			Expect(count).To(Equal(int32(0)))
+			Expect(count).To(Equal(0))
 		})
 	})
 
@@ -102,12 +102,12 @@ var _ = Describe("QuotaReservationsMap", func() {
 			rmap.Reserve(entryKey, providerKey, allowAll)
 
 			count := rmap.CountReservationsForProvider(providerKey)
-			Expect(count).To(Equal(int32(1)))
+			Expect(count).To(Equal(1))
 
 			clock.Step(testTTL * 3 / 2)
 
 			count = rmap.CountReservationsForProvider(providerKey)
-			Expect(count).To(Equal(int32(0)))
+			Expect(count).To(Equal(0))
 		})
 
 		It("should clean up expired reservations during Reserve", func() {
@@ -116,14 +116,14 @@ var _ = Describe("QuotaReservationsMap", func() {
 			providerKey := client.ObjectKey{Namespace: "default", Name: "provider1"}
 
 			rmap.Reserve(entry1, providerKey, allowAll)
-			Expect(rmap.CountReservationsForProvider(providerKey)).To(Equal(int32(1)))
+			Expect(rmap.CountReservationsForProvider(providerKey)).To(Equal(1))
 
 			clock.Step(testTTL * 3 / 2)
 
 			rmap.Reserve(entry2, providerKey, allowAll)
 
 			count := rmap.CountReservationsForProvider(providerKey)
-			Expect(count).To(Equal(int32(1)))
+			Expect(count).To(Equal(1))
 		})
 
 		It("should allow reservation check function to see current reserved keys", func() {
@@ -145,7 +145,7 @@ var _ = Describe("QuotaReservationsMap", func() {
 			})
 
 			finalCount := rmap.CountReservationsForProvider(providerKey)
-			Expect(finalCount).To(Equal(int32(2)))
+			Expect(finalCount).To(Equal(2))
 		})
 
 		It("should reject reservation when quota would be exceeded", func() {
@@ -163,7 +163,7 @@ var _ = Describe("QuotaReservationsMap", func() {
 			Expect(success).To(BeFalse())
 
 			count := rmap.CountReservationsForProvider(providerKey)
-			Expect(count).To(Equal(int32(2)))
+			Expect(count).To(Equal(2))
 		})
 	})
 
@@ -223,8 +223,8 @@ var _ = Describe("QuotaReservationsMap", func() {
 			count1 := rmap.CountReservationsForProvider(provider1)
 			count2 := rmap.CountReservationsForProvider(provider2)
 
-			Expect(count1).To(Equal(int32(1)))
-			Expect(count2).To(Equal(int32(1)))
+			Expect(count1).To(Equal(1))
+			Expect(count2).To(Equal(1))
 		})
 	})
 })

--- a/pkg/dnsman2/dns/state/quota_test.go
+++ b/pkg/dnsman2/dns/state/quota_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -23,14 +24,19 @@ var _ = Describe("QuotaReservationsMap", func() {
 		rmap = newQuotaReservationsMap(clock, testTTL)
 	})
 
+	allowUpTo := func(quota int) func(sets.Set[client.ObjectKey]) bool {
+		return func(keys sets.Set[client.ObjectKey]) bool {
+			return keys.Len() <= quota
+		}
+	}
+	allowAll := allowUpTo(1000)
+
 	Context("Reserve and Release operations", func() {
 		It("should reserve entry for provider", func() {
 			entryKey := client.ObjectKey{Namespace: "default", Name: "entry1"}
 			providerKey := client.ObjectKey{Namespace: "default", Name: "provider1"}
 
-			success := rmap.Reserve(entryKey, providerKey, func(count int32) bool {
-				return count <= 10
-			})
+			success := rmap.Reserve(entryKey, providerKey, allowUpTo(10))
 			Expect(success).To(BeTrue())
 
 			count := rmap.CountReservationsForProvider(providerKey)
@@ -41,7 +47,7 @@ var _ = Describe("QuotaReservationsMap", func() {
 			entryKey := client.ObjectKey{Namespace: "default", Name: "entry1"}
 			providerKey := client.ObjectKey{Namespace: "default", Name: "provider1"}
 
-			rmap.Reserve(entryKey, providerKey, func(_ int32) bool { return true })
+			rmap.Reserve(entryKey, providerKey, allowAll)
 			rmap.Release(entryKey)
 
 			count := rmap.CountReservationsForProvider(providerKey)
@@ -52,8 +58,8 @@ var _ = Describe("QuotaReservationsMap", func() {
 			entryKey := client.ObjectKey{Namespace: "default", Name: "entry1"}
 			providerKey := client.ObjectKey{Namespace: "default", Name: "provider1"}
 
-			success := rmap.Reserve(entryKey, providerKey, func(_ int32) bool {
-				return false // Reject reservation
+			success := rmap.Reserve(entryKey, providerKey, func(_ sets.Set[client.ObjectKey]) bool {
+				return false
 			})
 			Expect(success).To(BeFalse())
 
@@ -70,9 +76,9 @@ var _ = Describe("QuotaReservationsMap", func() {
 			provider1 := client.ObjectKey{Namespace: "default", Name: "provider1"}
 			provider2 := client.ObjectKey{Namespace: "default", Name: "provider2"}
 
-			rmap.Reserve(entry1, provider1, func(_ int32) bool { return true })
-			rmap.Reserve(entry2, provider1, func(_ int32) bool { return true })
-			rmap.Reserve(entry3, provider2, func(_ int32) bool { return true })
+			rmap.Reserve(entry1, provider1, allowAll)
+			rmap.Reserve(entry2, provider1, allowAll)
+			rmap.Reserve(entry3, provider2, allowAll)
 
 			count1 := rmap.CountReservationsForProvider(provider1)
 			Expect(count1).To(Equal(int32(2)))
@@ -93,16 +99,13 @@ var _ = Describe("QuotaReservationsMap", func() {
 			entryKey := client.ObjectKey{Namespace: "default", Name: "entry1"}
 			providerKey := client.ObjectKey{Namespace: "default", Name: "provider1"}
 
-			rmap.Reserve(entryKey, providerKey, func(_ int32) bool { return true })
+			rmap.Reserve(entryKey, providerKey, allowAll)
 
-			// Initially reservation exists
 			count := rmap.CountReservationsForProvider(providerKey)
 			Expect(count).To(Equal(int32(1)))
 
-			// Wait for TTL to expire
 			clock.Step(testTTL * 3 / 2)
 
-			// Reservation should be cleaned up
 			count = rmap.CountReservationsForProvider(providerKey)
 			Expect(count).To(Equal(int32(0)))
 		})
@@ -112,36 +115,33 @@ var _ = Describe("QuotaReservationsMap", func() {
 			entry2 := client.ObjectKey{Namespace: "default", Name: "entry2"}
 			providerKey := client.ObjectKey{Namespace: "default", Name: "provider1"}
 
-			// Create first reservation
-			rmap.Reserve(entry1, providerKey, func(_ int32) bool { return true })
+			rmap.Reserve(entry1, providerKey, allowAll)
 			Expect(rmap.CountReservationsForProvider(providerKey)).To(Equal(int32(1)))
 
-			// Wait for expiration
 			clock.Step(testTTL * 3 / 2)
 
-			// Create second reservation - should trigger cleanup of first
-			rmap.Reserve(entry2, providerKey, func(_ int32) bool { return true })
+			rmap.Reserve(entry2, providerKey, allowAll)
 
-			// Should only have the new reservation
 			count := rmap.CountReservationsForProvider(providerKey)
 			Expect(count).To(Equal(int32(1)))
 		})
 
-		It("should allow reservation check function to see current count", func() {
+		It("should allow reservation check function to see current reserved keys", func() {
 			entry1 := client.ObjectKey{Namespace: "default", Name: "entry1"}
 			entry2 := client.ObjectKey{Namespace: "default", Name: "entry2"}
 			providerKey := client.ObjectKey{Namespace: "default", Name: "provider1"}
 
-			// First reservation
-			rmap.Reserve(entry1, providerKey, func(count int32) bool {
-				Expect(count).To(Equal(int32(1))) // Including current reservation
-				return count <= 2
+			rmap.Reserve(entry1, providerKey, func(keys sets.Set[client.ObjectKey]) bool {
+				Expect(keys.Len()).To(Equal(1))
+				Expect(keys.Has(entry1)).To(BeTrue())
+				return keys.Len() <= 2
 			})
 
-			// Second reservation should see count of 2
-			rmap.Reserve(entry2, providerKey, func(count int32) bool {
-				Expect(count).To(Equal(int32(2))) // Including current reservation
-				return count <= 2
+			rmap.Reserve(entry2, providerKey, func(keys sets.Set[client.ObjectKey]) bool {
+				Expect(keys.Len()).To(Equal(2))
+				Expect(keys.Has(entry1)).To(BeTrue())
+				Expect(keys.Has(entry2)).To(BeTrue())
+				return keys.Len() <= 2
 			})
 
 			finalCount := rmap.CountReservationsForProvider(providerKey)
@@ -154,19 +154,59 @@ var _ = Describe("QuotaReservationsMap", func() {
 			entry3 := client.ObjectKey{Namespace: "default", Name: "entry3"}
 			providerKey := client.ObjectKey{Namespace: "default", Name: "provider1"}
 
-			quota := int32(2)
+			quota := 2
 
-			// Reserve 2 entries (up to quota)
-			rmap.Reserve(entry1, providerKey, func(count int32) bool { return count <= quota })
-			rmap.Reserve(entry2, providerKey, func(count int32) bool { return count <= quota })
+			rmap.Reserve(entry1, providerKey, allowUpTo(quota))
+			rmap.Reserve(entry2, providerKey, allowUpTo(quota))
 
-			// Third reservation should be rejected
-			success := rmap.Reserve(entry3, providerKey, func(count int32) bool { return count <= quota })
+			success := rmap.Reserve(entry3, providerKey, allowUpTo(quota))
 			Expect(success).To(BeFalse())
 
-			// Should still only have 2 reservations
 			count := rmap.CountReservationsForProvider(providerKey)
 			Expect(count).To(Equal(int32(2)))
+		})
+	})
+
+	Context("Double-counting prevention", func() {
+		It("should not double-count an entry that is both provisioned and reserved", func() {
+			// Simulates the race where entry-0 finished DNS provisioning (status.provider set in k8s cache)
+			// but Release() hasn't been called yet, while entry-1 is checking quota concurrently.
+			entry0 := client.ObjectKey{Namespace: "default", Name: "entry0"}
+			entry1 := client.ObjectKey{Namespace: "default", Name: "entry1"}
+			providerKey := client.ObjectKey{Namespace: "default", Name: "provider1"}
+			quota := 2
+
+			// entry-0 holds a reservation (mid-reconcile, status already patched to k8s)
+			rmap.Reserve(entry0, providerKey, allowAll)
+
+			// entry-1 now checks quota: provisionedKeys = {entry0} (from cache), reservedEntryKeys will be {entry0, entry1}
+			// Without overlap deduction: 1 + 2 = 3 > 2 → wrongly rejected
+			// With overlap deduction: 1 + 2 - 1 = 2 ≤ 2 → correctly allowed
+			provisionedKeys := sets.New(entry0)
+
+			success := rmap.Reserve(entry1, providerKey, func(reservedEntryKeys sets.Set[client.ObjectKey]) bool {
+				overlap := provisionedKeys.Intersection(reservedEntryKeys).Len()
+				return provisionedKeys.Len()+reservedEntryKeys.Len()-overlap <= quota
+			})
+			Expect(success).To(BeTrue(), "entry1 should be allowed when entry0 is double-counted without deduction")
+		})
+
+		It("should correctly reject when quota is truly exceeded without double-counting", func() {
+			entry0 := client.ObjectKey{Namespace: "default", Name: "entry0"}
+			entry1 := client.ObjectKey{Namespace: "default", Name: "entry1"}
+			entry2 := client.ObjectKey{Namespace: "default", Name: "entry2"}
+			providerKey := client.ObjectKey{Namespace: "default", Name: "provider1"}
+			quota := 2
+
+			// entry-0 and entry-1 are both provisioned, no reservations
+			provisionedKeys := sets.New(entry0, entry1)
+
+			// entry-2 tries to reserve: provisioned=2, reserved=1, overlap=0 → 2+1-0=3 > 2 → rejected
+			success := rmap.Reserve(entry2, providerKey, func(reservedEntryKeys sets.Set[client.ObjectKey]) bool {
+				overlap := provisionedKeys.Intersection(reservedEntryKeys).Len()
+				return provisionedKeys.Len()+reservedEntryKeys.Len()-overlap <= quota
+			})
+			Expect(success).To(BeFalse(), "entry2 should be rejected when quota is truly full")
 		})
 	})
 
@@ -177,8 +217,8 @@ var _ = Describe("QuotaReservationsMap", func() {
 			provider1 := client.ObjectKey{Namespace: "default", Name: "provider1"}
 			provider2 := client.ObjectKey{Namespace: "default", Name: "provider2"}
 
-			rmap.Reserve(entry1, provider1, func(_ int32) bool { return true })
-			rmap.Reserve(entry2, provider2, func(_ int32) bool { return true })
+			rmap.Reserve(entry1, provider1, allowAll)
+			rmap.Reserve(entry2, provider2, allowAll)
 
 			count1 := rmap.CountReservationsForProvider(provider1)
 			count2 := rmap.CountReservationsForProvider(provider2)

--- a/test/integration/dnsman2/provider_entry_test.go
+++ b/test/integration/dnsman2/provider_entry_test.go
@@ -316,13 +316,23 @@ var _ = Describe("Provider/Entry collaboration tests", func() {
 			checkEntry(entry)
 		}
 
-		e1.Spec.DNSName = "e1-update.first.example.com"
-		e2.Spec.Targets = []string{"1.1.2.10", "1.1.2.2", "1::20"}
-		e3.Spec.Text = []string{"foo bar2", "blabla2"}
-		e4.Spec.Targets = []string{"1.1.1.1"}
-
 		for _, entry := range []*v1alpha1.DNSEntry{e1, e2, e3, e4} {
-			Expect(testClient.Update(ctx, entry)).To(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(entry), entry)).To(Succeed())
+				switch entry.Name {
+				case "e1":
+					entry.Spec.DNSName = "e1-update.first.example.com"
+				case "e2":
+					entry.Spec.Targets = []string{"1.1.2.10", "1.1.2.2", "1::20"}
+				case "e3":
+					entry.Spec.Text = []string{"foo bar2", "blabla2"}
+				case "e4":
+					entry.Spec.Targets = []string{"1.1.1.1"}
+				default:
+					g.Expect(true).To(BeFalse())
+				}
+				g.Expect(testClient.Update(ctx, entry)).To(Succeed())
+			}).Should(Succeed(), entry.Name)
 		}
 
 		for _, entry := range []*v1alpha1.DNSEntry{e1, e2, e3, e4} {

--- a/test/integration/dnsman2/provider_entry_test.go
+++ b/test/integration/dnsman2/provider_entry_test.go
@@ -580,8 +580,11 @@ var _ = Describe("Provider/Entry collaboration tests", func() {
 		Eventually(func(g Gomega) {
 			checkDeleted(g, ctx, e1)
 		}).Should(Succeed())
-		e2.Annotations = map[string]string{"dns.gardener.cloud/ignore": "full"}
-		Expect(testClient.Update(ctx, e2)).To(Succeed())
+		Eventually(func(g Gomega) {
+			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(e2), e2)).To(Succeed())
+			e2.Annotations = map[string]string{"dns.gardener.cloud/ignore": "full"}
+			g.Expect(testClient.Update(ctx, e2)).To(Succeed())
+		}).Should(Succeed())
 
 		By("Await deletion of provider")
 		Eventually(func(g Gomega) {


### PR DESCRIPTION

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind flake

**What this PR does / why we need it**:
An entry that finishes DNS provisioning has its status.provider written to the k8s cache before Release() is called in reconcile(). A concurrent reconcile of another entry for the same provider would see provisionedCount=1 (the first entry already in cache) plus reservedCount=2 (both entries in the reservation map), totalling 3 against a quota of 2, causing a spurious quota exceeded error.

Fix: change Reserve's allow callback to receive the full set of reserved entry keys instead of a plain count. The caller (checkEntriesQuota) fetches the provisioned entry keys, then computes provisioned + reserved - overlap, where overlap is the set of entries counted in both. This eliminates the double-counting.

Fixed also another flaky test behaviour: retry update on conflict when marking entry as ignored

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
