### PR TITLE
Add Google Distributed Cloud (GDC) air-gapped DNS provider support

### DIFF
--- a/cmd/compound/main.go
+++ b/cmd/compound/main.go
@@ -35,6 +35,7 @@ import (
 	_ "github.com/gardener/external-dns-management/pkg/controller/provider/azure-private"
 	_ "github.com/gardener/external-dns-management/pkg/controller/provider/cloudflare"
 	_ "github.com/gardener/external-dns-management/pkg/controller/provider/compound/controller"
+	_ "github.com/gardener/external-dns-management/pkg/controller/provider/gdc"
 	_ "github.com/gardener/external-dns-management/pkg/controller/provider/google"
 	_ "github.com/gardener/external-dns-management/pkg/controller/provider/infoblox"
 	_ "github.com/gardener/external-dns-management/pkg/controller/provider/local"

--- a/docs/gdc-dns/README.md
+++ b/docs/gdc-dns/README.md
@@ -1,0 +1,85 @@
+# Google Distributed Cloud (GDC) air-gapped DNS Provider
+
+This DNS provider allows you to create and manage DNS entries in Google Distributed Cloud (GDC) air-gapped Managed DNS zones.
+
+## Overview
+
+The `gdch-dns` provider synchronizes DNS records with GDC `ManagedDNSZone` and `ResourceRecordSet` custom resources using GDC service account credentials and STS authentication.
+
+### Supported Record Types
+The provider supports the following DNS record types: `A`, `CNAME`, `TXT`, `PTR`, `DS`, and `MX`.
+> **Note**: `AAAA` (IPv6) records are currently not supported by GDC Managed DNS.
+
+## Required Credentials
+
+You need to provide a Kubernetes secret containing two keys:
+1. `serviceaccount.json`: The GDC service account credential JSON.
+2. `gdch-config`: Configuration JSON containing the org cluster API URL and CA certificate.
+
+### Example Service Account (`serviceaccount.json`)
+
+```json
+{
+  "type": "gdch_service_account",
+  "name": "dns-sa",
+  "project": "my-project",
+  "private_key_id": "key-id",
+  "private_key": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n",
+  "token_uri": "https://identity.org.gdc.example.com/oauth/token"
+}
+```
+
+### Example GDC Config (`gdch-config`)
+
+```json
+{
+  "orgClusterURL": "https://global-api.org.gdc.example.com",
+  "caData": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCg..."
+}
+```
+
+## Creating Credentials Secret
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gdc-credentials
+  namespace: default
+type: Opaque
+data:
+  serviceaccount.json: <base64-encoded-serviceaccount.json>
+  gdch-config: <base64-encoded-gdch-config>
+```
+
+## Creating DNSProvider
+
+```yaml
+apiVersion: dns.gardener.cloud/v1alpha1
+kind: DNSProvider
+metadata:
+  name: gdc-provider
+  namespace: default
+spec:
+  type: gdch-dns
+  secretRef:
+    name: gdc-credentials
+  domains:
+    include:
+      - zone1.google.gdc.example.com
+```
+
+## Creating DNSEntry
+
+```yaml
+apiVersion: dns.gardener.cloud/v1alpha1
+kind: DNSEntry
+metadata:
+  name: gdc-entry
+  namespace: default
+spec:
+  dnsName: "service.zone1.google.gdc.example.com"
+  ttl: 300
+  targets:
+    - 1.2.3.4
+```

--- a/examples/20-secret-gdc-credentials.yaml
+++ b/examples/20-secret-gdc-credentials.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gdc-credentials
+  namespace: default
+type: Opaque
+data:
+  # replace '...' with base64 encoded service account JSON file
+  serviceaccount.json: ...
+  # replace '...' with base64 encoded org cluster config JSON (orgClusterURL and caData)
+  gdch-config: ...

--- a/examples/30-provider-gdc.yaml
+++ b/examples/30-provider-gdc.yaml
@@ -1,0 +1,13 @@
+apiVersion: dns.gardener.cloud/v1alpha1
+kind: DNSProvider
+metadata:
+  name: gdc
+  namespace: default
+spec:
+  type: gdch-dns
+  secretRef:
+    name: gdc-credentials
+  domains:
+    include:
+    # this must be a (sub)domain of the hosted zone
+    - mydns.org-1.zone1.google.gdc.test

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,10 @@ require (
 	github.com/go-logr/logr v1.4.4
 	github.com/go-openapi/runtime v0.33.0
 	github.com/go-openapi/strfmt v0.27.0
+	github.com/google/go-cmp v0.7.0
+	github.com/google/tink/go v1.7.0
 	github.com/google/uuid v1.6.0
+	github.com/googlecloudplatform/google-distributed-cloud-apis v0.0.0-20260824201624-0c18fa0ddc04
 	github.com/gophercloud/gophercloud/v2 v2.14.0
 	github.com/gophercloud/utils/v2 v2.0.0-20260824073324-42b9474d09d4
 	github.com/infobloxopen/infoblox-go-client/v2 v2.11.0
@@ -156,7 +159,6 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/cel-go v0.29.2 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20260604005048-7023385849c0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -569,6 +569,8 @@ github.com/google/pprof v0.0.0-20260604005048-7023385849c0/go.mod h1:MxpfABSjhmI
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=
 github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=
+github.com/google/tink/go v1.7.0 h1:6Eox8zONGebBFcCBqkVmt60LaWZa6xg1cl/DwAh/J1w=
+github.com/google/tink/go v1.7.0/go.mod h1:GAUOd+QE3pgj9q8VKIGTCP33c/B7eb4NhxLcgTJZStM=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -580,6 +582,8 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/googleapis/gax-go/v2 v2.24.0 h1:myMaPYyF9MecEmvQqMqomIwn9t/4KCZN9qnwsS76wlg=
 github.com/googleapis/gax-go/v2 v2.24.0/go.mod h1:IaTHBDd7NHxSCiu0vEs8pQZu4dGZrWwuSoxCnk16OFM=
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
+github.com/googlecloudplatform/google-distributed-cloud-apis v0.0.0-20260824201624-0c18fa0ddc04 h1:PZ7ftiG8NprfmJOUi5HVkb/gXSvkWjCWf9BOfgo4R6s=
+github.com/googlecloudplatform/google-distributed-cloud-apis v0.0.0-20260824201624-0c18fa0ddc04/go.mod h1:6M6PSslRb+8R4QBRDuteW9d75FD6a+yzqEJRdlqHVS4=
 github.com/gophercloud/gophercloud/v2 v2.14.0 h1:xGxKCvyaOxJDc5FqrnKDNqtdYn43ocQPuJ2Cm4KX/cs=
 github.com/gophercloud/gophercloud/v2 v2.14.0/go.mod h1:4fs5I9VH6Wg2LyocDL9xf0ASb8VD63tyLA8sgAX/69U=
 github.com/gophercloud/utils/v2 v2.0.0-20260824073324-42b9474d09d4 h1:VKbePn/0e1cg6HSvVB5CKeXpVcKmD2AuMk6WQhjexuI=

--- a/pkg/controller/provider/compound/validation/adaptors.go
+++ b/pkg/controller/provider/compound/validation/adaptors.go
@@ -9,7 +9,7 @@ import (
 	awsvalidation "github.com/gardener/external-dns-management/pkg/controller/provider/aws/validation"
 	azurevalidation "github.com/gardener/external-dns-management/pkg/controller/provider/azure/validation"
 	cloudflarevalidation "github.com/gardener/external-dns-management/pkg/controller/provider/cloudflare/validation"
-	gdchvalidation "github.com/gardener/external-dns-management/pkg/controller/provider/gdch/validation"
+	gdcvalidation "github.com/gardener/external-dns-management/pkg/controller/provider/gdc/validation"
 	googlevalidation "github.com/gardener/external-dns-management/pkg/controller/provider/google/validation"
 	infobloxvalidation "github.com/gardener/external-dns-management/pkg/controller/provider/infoblox/validation"
 	netlifyvalidation "github.com/gardener/external-dns-management/pkg/controller/provider/netlify/validation"
@@ -31,7 +31,7 @@ func init() {
 		azurevalidation.NewAdapter(azurevalidation.ProviderTypeAzurePrivateDNS),
 		cloudflarevalidation.NewAdapter(),
 		googlevalidation.NewAdapter(),
-		gdchvalidation.NewAdapter(),
+		gdcvalidation.NewAdapter(),
 		infobloxvalidation.NewAdapter(),
 		netlifyvalidation.NewAdapter(),
 		openstackvalidation.NewAdapter(),

--- a/pkg/controller/provider/gdc/client/auth/config.go
+++ b/pkg/controller/provider/gdc/client/auth/config.go
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: Contributors to the Gardener project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+// ServiceAccount config of GDC service identity private key.
+type ServiceAccount struct {
+	// Name is the Service account name. It will be used as the `iss` and `sub` claim in the self signed JWT.
+	Name string `json:"name"`
+
+	// Project ID associated with the service account credential.
+	Project string `json:"project"`
+
+	// The OAuth 2.0 Token URI.
+	TokenURI string `json:"token_uri"`
+
+	// ID of private key
+	PrivateKeyID string `json:"private_key_id"`
+
+	// Private key plain text content
+	PrivateKey string `json:"private_key"`
+}

--- a/pkg/controller/provider/gdc/client/auth/jwt.go
+++ b/pkg/controller/provider/gdc/client/auth/jwt.go
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: Contributors to the Gardener project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"time"
+
+	"github.com/google/tink/go/insecurecleartextkeyset"
+	"github.com/google/tink/go/jwt"
+	"github.com/google/tink/go/keyset"
+	"github.com/google/tink/go/proto/jwt_ecdsa_go_proto"
+	"github.com/google/tink/go/proto/tink_go_proto"
+	"golang.org/x/oauth2"
+	"google.golang.org/protobuf/proto"
+	"k8s.io/utils/ptr"
+)
+
+type jwtSigner interface {
+	signJWTWithKey(kid, key, sub, issuer, audience string) (string, error)
+}
+
+type defaultSigner struct{}
+
+func (s *defaultSigner) signJWTWithKey(kid, key, sub, issuer, audience string) (string, error) {
+	return signJWTWithKey(kid, key, sub, issuer, audience)
+}
+
+func newJWTTokenSource(config *ServiceAccount) oauth2.TokenSource {
+	return &jwtTokenSource{
+		config: config,
+		signer: &defaultSigner{},
+	}
+}
+
+type jwtTokenSource struct {
+	config *ServiceAccount
+	signer jwtSigner
+}
+
+func (ts *jwtTokenSource) Token() (*oauth2.Token, error) {
+	// The service account name is both the issuer and the subject of the signed JWT.
+	issSubValue := fmt.Sprintf("system:serviceaccount:%s:%s", ts.config.Project, ts.config.Name)
+	jwtToken, err := ts.signer.signJWTWithKey(ts.config.PrivateKeyID, ts.config.PrivateKey, issSubValue, issSubValue, ts.config.TokenURI)
+	if err != nil {
+		return nil, fmt.Errorf("jwt token: %w", err)
+	}
+
+	// No need to populate expiry as JWT is for token exchange
+	return &oauth2.Token{AccessToken: jwtToken}, nil
+}
+
+// signJWTWithKey signs a JWT using a known private key to be used with
+// the service identity server in order to exchange for an audienced
+// STS token. This only supports signing the JWT with ECDSA 256 keys.
+func signJWTWithKey(kid, key, sub, issuer, audience string) (string, error) {
+	priv, err := parsePrivateKey(key)
+	if err != nil {
+		return "", err
+	}
+
+	privKey := &jwt_ecdsa_go_proto.JwtEcdsaPrivateKey{
+		PublicKey: &jwt_ecdsa_go_proto.JwtEcdsaPublicKey{
+			Algorithm: jwt_ecdsa_go_proto.JwtEcdsaAlgorithm_ES256,
+			X:         priv.X.Bytes(),
+			Y:         priv.Y.Bytes(),
+			CustomKid: &jwt_ecdsa_go_proto.JwtEcdsaPublicKey_CustomKid{Value: kid},
+		},
+		//nolint:staticcheck // priv.D is required for tink ES256 protobuf key serialization
+		KeyValue: priv.D.Bytes(),
+	}
+	serializedKey, err := proto.Marshal(privKey)
+	if err != nil {
+		return "", err
+	}
+
+	ks := &tink_go_proto.Keyset{
+		PrimaryKeyId: 1,
+		Key: []*tink_go_proto.Keyset_Key{
+			{
+				KeyData: &tink_go_proto.KeyData{
+					TypeUrl:         jwt.ES256Template().TypeUrl,
+					Value:           serializedKey,
+					KeyMaterialType: tink_go_proto.KeyData_ASYMMETRIC_PRIVATE,
+				},
+				Status:           tink_go_proto.KeyStatusType_ENABLED,
+				KeyId:            1,
+				OutputPrefixType: tink_go_proto.OutputPrefixType_RAW,
+			},
+		},
+	}
+	serializedKs, err := proto.Marshal(ks)
+	if err != nil {
+		return "", err
+	}
+
+	// The private key is already stored on the disk. It should be safe to use
+	// insecurecleartext because the only endpoint the JWT is used with is the
+	// service identity server which verifies the signature of the JWT using the
+	// public key.
+	handle, err := insecurecleartextkeyset.Read(keyset.NewBinaryReader(bytes.NewBuffer(serializedKs)))
+	if err != nil {
+		return "", err
+	}
+
+	token, err := generateJWT(handle, issuer, audience, sub)
+	if err != nil {
+		return "", err
+	}
+	return token, nil
+}
+
+// generateJWT generates a signed JWT for the requested issuer, audience, and subject.
+func generateJWT(handle *keyset.Handle, issuer, audience, subject string) (string, error) {
+	jwtOpts := &jwt.RawJWTOptions{
+		Issuer:     ptr.To(issuer),
+		Subject:    ptr.To(subject),
+		Audience:   ptr.To(audience),
+		ExpiresAt:  refTime(time.Now().Add(time.Hour * 24)),
+		IssuedAt:   refTime(time.Now()),
+		TypeHeader: ptr.To("JWT"),
+	}
+
+	rawJWT, err := jwt.NewRawJWT(jwtOpts)
+	if err != nil {
+		return "", fmt.Errorf("could not create raw JWT: %v", err)
+	}
+
+	signer, err := jwt.NewSigner(handle)
+	if err != nil {
+		return "", fmt.Errorf("failed to create signer: %v", err)
+	}
+	jwtString, err := signer.SignAndEncode(rawJWT)
+	if err != nil {
+		return "", fmt.Errorf("failed to sign and encode JWT: %v", err)
+	}
+	return jwtString, nil
+}
+
+// parsePrivateKey parses a private key string into an *ecdsa.PrivateKey.
+func parsePrivateKey(key string) (*ecdsa.PrivateKey, error) {
+	block, _ := pem.Decode([]byte(key))
+	if block == nil {
+		return nil, fmt.Errorf("private key decoded into nil PEM block")
+	}
+	return x509.ParseECPrivateKey(block.Bytes)
+}
+
+func refTime(t time.Time) *time.Time {
+	return &t
+}

--- a/pkg/controller/provider/gdc/client/auth/jwt_test.go
+++ b/pkg/controller/provider/gdc/client/auth/jwt_test.go
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: Contributors to the Gardener project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"errors"
+	"testing"
+)
+
+const (
+	accessToken = "test-access-token"
+)
+
+func TestJWTToken(t *testing.T) {
+	saConfig := serviceAccountKey()
+	jwtTS := &jwtTokenSource{
+		config: saConfig,
+		signer: &mockSigner{},
+	}
+
+	token, err := jwtTS.Token()
+	if err != nil {
+		t.Fatalf("got error: %v", err)
+	}
+
+	if token.AccessToken != accessToken {
+		t.Fatalf("got access token (%s), expected (%s)", token.AccessToken, accessToken)
+	}
+}
+
+func TestToken_Failed(t *testing.T) {
+	saConfig := serviceAccountKey()
+	jwtTS := &jwtTokenSource{
+		config: saConfig,
+		signer: &mockSignerError{},
+	}
+
+	_, err := jwtTS.Token()
+	if err == nil {
+		t.Fatal("got nil, expected error")
+	}
+}
+
+func serviceAccountKey() *ServiceAccount {
+	return &ServiceAccount{
+		Name:         "name",
+		Project:      "project",
+		TokenURI:     "token_uri",
+		PrivateKeyID: "1234",
+		PrivateKey:   "key",
+	}
+}
+
+type mockSigner struct {
+}
+
+func (m *mockSigner) signJWTWithKey(_, _, _, _, _ string) (string, error) {
+	return accessToken, nil
+}
+
+type mockSignerError struct {
+}
+
+func (m *mockSignerError) signJWTWithKey(_, _, _, _, _ string) (string, error) {
+	return "", errors.New("failed")
+}

--- a/pkg/controller/provider/gdc/client/auth/sts.go
+++ b/pkg/controller/provider/gdc/client/auth/sts.go
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: Contributors to the Gardener project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"golang.org/x/oauth2"
+	"k8s.io/client-go/transport"
+	"k8s.io/utils/clock"
+)
+
+const (
+	tokenExchangeType      = "urn:ietf:params:oauth:token-type:token-exchange" // #nosec G101 -- false positive
+	accessTokenType        = "urn:ietf:params:oauth:token-type:access_token"   // #nosec G101 -- false positive
+	serviceAccoutTokenType = "urn:k8s:params:oauth:token-type:serviceaccount"  // #nosec G101 -- false positive
+)
+
+// Option configures optional parameters for STS token source creation.
+type Option func(*optionalConfig)
+
+// WithCACert sets the CA certificate to be used for server certificate
+// validation.
+func WithCACert(caCert []byte) Option {
+	return func(cfg *optionalConfig) {
+		cfg.caCert = caCert
+	}
+}
+
+// NewCachedSTSTokenSource creates an oauth2.TokenSource that caches STS tokens for the specified audience.
+// The CachedSTSTokenSource will request a new STS token when the STS token is
+// expired or nearing the expiry time.
+func NewCachedSTSTokenSource(
+	audience string,
+	saConfig *ServiceAccount,
+	opts ...Option,
+) oauth2.TokenSource {
+	stsTS := NewSTSTokenSource(audience, saConfig, opts...)
+	return transport.NewCachedTokenSource(stsTS)
+}
+
+type optionalConfig struct {
+	caCert []byte
+}
+
+// NewSTSTokenSource creates an oauth2.TokenSource for STS token exchange.
+func NewSTSTokenSource(
+	audience string,
+	saConfig *ServiceAccount,
+	opts ...Option,
+) oauth2.TokenSource {
+	cfg := &optionalConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	jwtTS := newJWTTokenSource(saConfig)
+	return &stsTokenSource{
+		caCert:         cfg.caCert,
+		tokenURI:       saConfig.TokenURI,
+		audience:       audience,
+		jwtTokenSource: jwtTS,
+		clock:          clock.RealClock{},
+	}
+}
+
+type stsTokenSource struct {
+	caCert         []byte
+	tokenURI       string
+	audience       string
+	jwtTokenSource oauth2.TokenSource
+	clock          clock.PassiveClock
+}
+
+type generateAccessTokenResp struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int64  `json:"expires_in"` // relative seconds from now
+}
+
+// Token exchanges signed JWT token for STS token.
+func (ts *stsTokenSource) Token() (*oauth2.Token, error) {
+	jwtToken, err := ts.jwtTokenSource.Token()
+	if err != nil {
+		return nil, fmt.Errorf("jwt token: %w", err)
+	}
+
+	data := map[string]string{
+		"grant_type":           tokenExchangeType,
+		"audience":             ts.audience,
+		"requested_token_type": accessTokenType,
+		"subject_token":        jwtToken.AccessToken,
+		"subject_token_type":   serviceAccoutTokenType,
+	}
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request body: %w", err)
+	}
+
+	body := bytes.NewReader(jsonData)
+	req, err := http.NewRequest("POST", ts.tokenURI, body)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	hc := &http.Client{}
+
+	if len(ts.caCert) != 0 {
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(ts.caCert)
+		hc.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs: caCertPool,
+			},
+		}
+	}
+
+	resp, err := hc.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch token: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read fetched token: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &oauth2.RetrieveError{
+			Response: resp,
+			Body:     respBody,
+		}
+	}
+
+	var tokenResp generateAccessTokenResp
+	if err := json.Unmarshal(respBody, &tokenResp); err != nil {
+		return nil, fmt.Errorf("unmarshal: %w", err)
+	}
+	expiry := ts.clock.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+	return &oauth2.Token{
+		AccessToken: tokenResp.AccessToken,
+		TokenType:   "Bearer",
+		Expiry:      expiry,
+	}, nil
+}

--- a/pkg/controller/provider/gdc/client/auth/sts_test.go
+++ b/pkg/controller/provider/gdc/client/auth/sts_test.go
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: Contributors to the Gardener project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"golang.org/x/oauth2"
+	clock "k8s.io/utils/clock/testing"
+)
+
+const (
+	jwtAccessToken   = "test-jwt-access-token"
+	stsAccessToken   = "test-sts-access-token"
+	expiresInSeconds = 1700434861
+)
+
+var testTimeNow = time.Date(2023, 1, 1, 1, 1, 1, 1, time.UTC)
+
+func TestSTSToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, mockResponse())
+	}))
+	defer server.Close()
+
+	stsTS := &stsTokenSource{
+		caCert:         []byte("caData"),
+		tokenURI:       server.URL,
+		audience:       "audience",
+		jwtTokenSource: &mockJWTTokenSource{},
+		clock:          clock.NewFakePassiveClock(testTimeNow),
+	}
+
+	got, err := stsTS.Token()
+	if err != nil {
+		t.Fatalf("got error: %v", err)
+	}
+
+	expected := &oauth2.Token{
+		AccessToken: stsAccessToken,
+		TokenType:   "Bearer",
+		Expiry:      testTimeNow.Add(time.Duration(expiresInSeconds) * time.Second),
+	}
+
+	if diff := cmp.Diff(expected, got, cmpopts.IgnoreUnexported(oauth2.Token{})); diff != "" {
+		t.Errorf("test requests diff (-want +got):\n%s", diff)
+	}
+}
+
+func TestSTSToken_Failed(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = fmt.Fprint(w, mockResponse())
+	}))
+	defer server.Close()
+
+	stsTS := &stsTokenSource{
+		caCert:         []byte("caData"),
+		tokenURI:       server.URL,
+		audience:       "audience",
+		jwtTokenSource: &mockJWTTokenSource{},
+	}
+
+	_, err := stsTS.Token()
+	if err == nil {
+		t.Fatal("got nil, expected error")
+	}
+}
+
+type mockJWTTokenSource struct {
+}
+
+func (mts *mockJWTTokenSource) Token() (*oauth2.Token, error) {
+	return &oauth2.Token{AccessToken: jwtAccessToken}, nil
+}
+
+func mockResponse() string {
+	tokenResp := &generateAccessTokenResp{
+		AccessToken: stsAccessToken,
+		ExpiresIn:   expiresInSeconds,
+	}
+
+	jsonData, _ := json.Marshal(tokenResp)
+	return string(jsonData)
+}

--- a/pkg/controller/provider/gdc/client/client.go
+++ b/pkg/controller/provider/gdc/client/client.go
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Contributors to the Gardener project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package client provides a common function to authenticate and instantiate a
+// Kubernetes client for GDC.
+package client
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/transport"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/external-dns-management/pkg/controller/provider/gdc/client/auth"
+)
+
+// Get returns a Kubernetes client to the specified cluster of GDC.
+func Get(
+	config *OrgClusterConfig,
+	serviceAccount *auth.ServiceAccount,
+	scheme *runtime.Scheme,
+) (client.WithWatch, error) {
+	restConfig, err := getRESTConfig(config, serviceAccount)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving Kubernetes REST configuration: %w", err)
+	}
+
+	c, err := client.NewWithWatch(restConfig, client.Options{
+		Scheme: scheme,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create kubernetes client from config: %w", err)
+	}
+
+	return c, nil
+}
+
+func getRESTConfig(config *OrgClusterConfig, serviceAccount *auth.ServiceAccount) (*rest.Config, error) {
+	certData, err := base64.StdEncoding.DecodeString(config.CAData)
+	if err != nil {
+		return nil, fmt.Errorf("decode cadata: %w", err)
+	}
+	audience := config.OrgClusterURL
+
+	stsTS := auth.NewCachedSTSTokenSource(audience, serviceAccount, auth.WithCACert(certData))
+	cfg := &rest.Config{
+		Host: config.OrgClusterURL,
+		TLSClientConfig: rest.TLSClientConfig{
+			CAData: certData,
+		},
+	}
+
+	// Injects STS tokens as the bearer authorization header in the requests.
+	cfg.Wrap(transport.TokenSourceWrapTransport(stsTS))
+
+	return cfg, nil
+}

--- a/pkg/controller/provider/gdc/client/config.go
+++ b/pkg/controller/provider/gdc/client/config.go
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: Contributors to the Gardener project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+// OrgClusterConfig contains settings for an org cluster on GDC.
+type OrgClusterConfig struct {
+	// The URL to the org cluster.
+	OrgClusterURL string `json:"orgClusterURL"`
+
+	// Base64 encoded CA certificate.
+	CAData string `json:"caData"`
+}

--- a/pkg/controller/provider/gdc/client/constants/constants.go
+++ b/pkg/controller/provider/gdc/client/constants/constants.go
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: Contributors to the Gardener project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package constants
+
+const (
+	// ServiceAccountJSONField is the field in a secret where the service account JSON is stored at.
+	ServiceAccountJSONField = "serviceaccount.json"
+
+	// GDCHConfigJSONField is the field in a secret where the GDCH configuration is stored at.
+	GDCHConfigJSONField = "gdch-config"
+)

--- a/pkg/controller/provider/gdc/client/dns/const.go
+++ b/pkg/controller/provider/gdc/client/dns/const.go
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: Contributors to the Gardener project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dns
+
+const (
+	// DNSDefaultTTL is the default TTL for DNS records in seconds.
+	DNSDefaultTTL = 300 // 300 seconds
+)

--- a/pkg/controller/provider/gdc/client/dns/dns_name.go
+++ b/pkg/controller/provider/gdc/client/dns/dns_name.go
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Contributors to the Gardener project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dns
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// invalidCharsRegex is a regular expression that matches one or more consecutive characters
+// that are not a lowercase letter, a number, a hyphen, or a period.
+var invalidCharsRegex = regexp.MustCompile(`[^a-z0-9-.]+`)
+
+// GetDNSRecordSetName generates a valid DNS ResourceRecordSet name from a record type and a DNS name.
+//
+// Cloud DNS providers often have strict validation rules for ResourceRecordSet names
+// (e.g., must match regex "[^a-z0-9-.]+").
+// This function transforms a Gardener DNS record name into a compliant format by applying several rules.
+//
+// The transformations are:
+//  1. The lowercase record type is prepended to the name, followed by a hyphen.
+//  2. A leading wildcard prefix "*." is trimmed from the DNS name.
+//  3. Any invalid characters (like the underscore in "_acme-challenge") are replaced with a hyphen.
+//
+// For example:
+//   - ("A", "mydns.org") -> "a-mydns.org"
+//   - ("TXT", "*.wildcard.org") -> "txt-wildcard.org"
+//   - ("TXT", "_acme-challenge.mydns.org") -> "txt--acme-challenge.mydns.org"
+//
+// Note: Since this transformation can cause different inputs to map to the same output,
+// the caller is responsible for handling potential name collisions.
+func GetDNSRecordSetName(recordType string, name string) string {
+	objName := fmt.Sprintf("%s-%s", recordType, strings.TrimPrefix(name, "*."))
+	return invalidCharsRegex.ReplaceAllString(strings.ToLower(objName), "-")
+}

--- a/pkg/controller/provider/gdc/client/dns/dns_name_test.go
+++ b/pkg/controller/provider/gdc/client/dns/dns_name_test.go
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: Contributors to the Gardener project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dns
+
+import "testing"
+
+func TestGetDNSRecordSetName(t *testing.T) {
+	// Define a series of test cases in a "table"
+	testCases := []struct {
+		name       string // Name of the test case
+		recordType string // Input recordType
+		dnsName    string // Input DNS name
+		want       string // Expected output
+	}{
+		// --- Basic Functionality ---
+		{
+			name:       "standard a record",
+			recordType: "A",
+			dnsName:    "mydns.org",
+			want:       "a-mydns.org",
+		},
+		// --- Transformation Tests ---
+		{
+			name:       "uppercase record type",
+			recordType: "CNAME",
+			dnsName:    "sub.domain.com",
+			want:       "cname-sub.domain.com",
+		},
+		{
+			name:       "wildcard prefix",
+			recordType: "TXT",
+			dnsName:    "*.wildcard.org",
+			want:       "txt-wildcard.org",
+		},
+		// --- Character Validation Tests ---
+		{
+			name:       "name with numbers is valid",
+			recordType: "A",
+			dnsName:    "3xample.goog1e.c0m",
+			want:       "a-3xample.goog1e.c0m",
+		},
+		{
+			name:       "name with uppercase letters",
+			recordType: "A",
+			dnsName:    "Example.gooGle.cOm",
+			want:       "a-example.google.com",
+		},
+		{
+			name:       "acme challenge with underscore",
+			recordType: "TXT",
+			dnsName:    "_acme-challenge.mydns.org",
+			want:       "txt--acme-challenge.mydns.org",
+		},
+		{
+			name:       "name with mixed invalid characters",
+			recordType: "A",
+			dnsName:    "a_b@c.com/!#d",
+			// The regex replaces each invalid char or sequence with a single hyphen.
+			want: "a-a-b-c.com-d",
+		},
+		// --- Test cases for wildcard ingress domains ---
+		{
+			name:       "sample 1 name with *",
+			recordType: "A",
+			dnsName:    "*.ingress.dev.gdc.gardener.cloud.sap",
+			want:       "a-ingress.dev.gdc.gardener.cloud.sap",
+		},
+		{
+			name:       "sample 2 name with *",
+			recordType: "A",
+			dnsName:    "*.ingress.orchestration.dog1-orc-hc-dev-gdc.dev.gdc.hc-poc.hanacloud.ondemand.com",
+			want:       "a-ingress.orchestration.dog1-orc-hc-dev-gdc.dev.gdc.hc-poc.hanacloud.ondemand.com",
+		},
+		{
+			name:       "name creating an invalid leading hyphen",
+			recordType: "A",
+			dnsName:    "*.-ingress.orchestration.com",
+			want:       "a--ingress.orchestration.com",
+		},
+	}
+
+	// Iterate over the test cases
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := GetDNSRecordSetName(tc.recordType, tc.dnsName)
+
+			if got != tc.want {
+				t.Errorf("GetDNSRecordSetName(%q, %q) = %q; want %q", tc.recordType, tc.dnsName, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/provider/gdc/controller/controller.go
+++ b/pkg/controller/provider/gdc/controller/controller.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Contributors to the Gardener project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"github.com/gardener/external-dns-management/pkg/controller/provider/gdc"
+	"github.com/gardener/external-dns-management/pkg/dns/provider"
+)
+
+func init() {
+	provider.DNSController("", gdc.Factory).
+		FinalizerDomain("dns.gardener.cloud").
+		MustRegister(provider.CONTROLLER_GROUP_DNS_CONTROLLERS)
+}

--- a/pkg/controller/provider/gdc/execution.go
+++ b/pkg/controller/provider/gdc/execution.go
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: Contributors to the Gardener project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gdc
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/gardener/controller-manager-library/pkg/logger"
+	globalnetworkingv1 "github.com/googlecloudplatform/google-distributed-cloud-apis/pkg/apis/public/global/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	dnsutil "github.com/gardener/external-dns-management/pkg/controller/provider/gdc/client/dns"
+	"github.com/gardener/external-dns-management/pkg/dns"
+	"github.com/gardener/external-dns-management/pkg/dns/provider"
+)
+
+type Change struct {
+	RecordSet      *resourceRecordSet
+	RecordType     string // supported record type: A, TXT
+	ChangeType     string // supported change type: create, update, delete
+	ObjectMetaName string // ResourceRecordSet Name
+}
+
+type Execution struct {
+	logger.LogContext
+	handler *Handler
+	zone    provider.DNSHostedZone
+}
+
+func NewExecution(log logger.LogContext, h *Handler, zone provider.DNSHostedZone) *Execution {
+	return &Execution{
+		LogContext: log,
+		handler:    h,
+		zone:       zone,
+	}
+}
+
+func (exec *Execution) prepareChange(req *provider.ChangeRequest) (*Change, error) {
+	var dnsset *dns.DNSSet
+	switch req.Action {
+	case provider.R_CREATE, provider.R_UPDATE:
+		dnsset = req.Addition
+	case provider.R_DELETE:
+		dnsset = req.Deletion
+	}
+
+	// MapToProvider func will also convert META to TXT.
+	newSet := dnsset.Sets[req.Type]
+	if !slices.Contains(supportedRecordTypes, newSet.Type) {
+		return nil, fmt.Errorf("unsupported record type %s", req.Type)
+	}
+
+	objectMetaName := dnsutil.GetDNSRecordSetName(newSet.Type, dnsset.Name.DNSName)
+
+	exec.Infof("%s %s record set %s[%s]: %s(%d)", req.Action, newSet.Type, dnsset.Name.DNSName, exec.zone.Id(), newSet.RecordString(), newSet.TTL)
+
+	rrSet := mapRecordSet(dnsset.Name.DNSName, newSet)
+	return &Change{
+		RecordSet:      rrSet,
+		RecordType:     newSet.Type,
+		ChangeType:     req.Action,
+		ObjectMetaName: objectMetaName,
+	}, nil
+}
+
+func (exec *Execution) applyChange(change *Change) error {
+	if len(change.RecordSet.data) == 0 {
+		return nil
+	}
+
+	exec.Infof("processing changes for zone %s", exec.zone.Id())
+	exec.handler.config.Metrics.AddZoneRequests(exec.zone.Id().ID, provider.M_UPDATERECORDS, 1)
+	exec.handler.config.RateLimiter.Accept()
+
+	ttl := uint32(change.RecordSet.ttl) // #nosec G115 -- TTL is safe bounded integer
+	recordSet := &globalnetworkingv1.ResourceRecordSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      change.ObjectMetaName,
+			Namespace: exec.handler.project,
+		},
+	}
+
+	if change.ChangeType == provider.R_CREATE || change.ChangeType == provider.R_UPDATE {
+		_, err := controllerutil.CreateOrUpdate(context.Background(), exec.handler.client, recordSet, func() error {
+			recordSet.Spec = globalnetworkingv1.ResourceRecordSetSpec{
+				Name:       change.RecordSet.fqdn,
+				TTLSeconds: &ttl,
+				Type:       change.RecordType,
+				RRData:     change.RecordSet.data,
+				DNSZone:    exec.zone.Key(),
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	if change.ChangeType == provider.R_DELETE {
+		err := exec.handler.client.Delete(context.Background(), recordSet)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// mapRecordSet maps dns.RecordSet to recordsets.ResourceRecordSet of gdc
+func mapRecordSet(dnsName string, rs *dns.RecordSet) *resourceRecordSet {
+	rrSetData := []string{}
+	for _, record := range rs.Records {
+		rrSetData = append(rrSetData, record.Value)
+	}
+
+	ttl := int(rs.TTL)
+	if ttl <= 0 {
+		ttl = dnsutil.DNSDefaultTTL
+	}
+
+	rrset := &resourceRecordSet{
+		fqdn: dnsName,
+		ttl:  ttl,
+		data: rrSetData,
+	}
+
+	return rrset
+}
+
+type resourceRecordSet struct {
+	data []string
+	fqdn string
+	ttl  int
+}

--- a/pkg/controller/provider/gdc/execution_test.go
+++ b/pkg/controller/provider/gdc/execution_test.go
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: Contributors to the Gardener project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gdc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gardener/controller-manager-library/pkg/logger"
+	"github.com/google/go-cmp/cmp"
+	globalnetworkingv1 "github.com/googlecloudplatform/google-distributed-cloud-apis/pkg/apis/public/global/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/flowcontrol"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/gardener/external-dns-management/pkg/dns/provider"
+)
+
+type MockMetrics struct{}
+
+func (m *MockMetrics) AddGenericRequests(_ string, _ int) {}
+func (m *MockMetrics) AddZoneRequests(_, _ string, _ int) {}
+
+func TestApplyChange(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = globalnetworkingv1.AddToScheme(scheme)
+	ttl := uint32(300)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	handler := &Handler{
+		client:  fakeClient,
+		project: "test-project",
+		config: provider.DNSHandlerConfig{
+			Metrics:     &MockMetrics{},
+			RateLimiter: flowcontrol.NewTokenBucketRateLimiter(5.0, 10),
+		},
+	}
+
+	exec := &Execution{
+		LogContext: logger.NewContext("test", "applyChange"),
+		handler:    handler,
+		zone:       provider.NewDNSHostedZone("GDC", "test-zone-id", "test.com", "test-zone-key", true),
+	}
+
+	tests := []struct {
+		name    string
+		change  *Change
+		wantRRS *globalnetworkingv1.ResourceRecordSet
+	}{
+		{
+			name: "Create DNS record",
+			change: &Change{
+				RecordSet: &resourceRecordSet{
+					fqdn: "test.example.com",
+					ttl:  300,
+					data: []string{"1.2.3.4"},
+				},
+				RecordType:     "A",
+				ChangeType:     provider.R_CREATE,
+				ObjectMetaName: "a-test.example.com",
+			},
+			wantRRS: &globalnetworkingv1.ResourceRecordSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "a-test.example.com", Namespace: "test-project", ResourceVersion: "1"},
+				Spec: globalnetworkingv1.ResourceRecordSetSpec{
+					Name:       "test.example.com",
+					TTLSeconds: &ttl,
+					Type:       "A",
+					RRData:     []string{"1.2.3.4"},
+					DNSZone:    "test-zone-key",
+				},
+			},
+		},
+		{
+			name: "Update DNS record",
+			change: &Change{
+				RecordSet: &resourceRecordSet{
+					fqdn: "test.example.com",
+					ttl:  300,
+					data: []string{"5.6.7.8"},
+				},
+				RecordType:     "A",
+				ChangeType:     provider.R_UPDATE,
+				ObjectMetaName: "a-test.example.com",
+			},
+			wantRRS: &globalnetworkingv1.ResourceRecordSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "a-test.example.com", Namespace: "test-project", ResourceVersion: "2"},
+				Spec: globalnetworkingv1.ResourceRecordSetSpec{
+					Name:       "test.example.com",
+					TTLSeconds: &ttl,
+					Type:       "A",
+					RRData:     []string{"5.6.7.8"},
+					DNSZone:    "test-zone-key",
+				},
+			},
+		},
+		{
+			name: "Delete DNS record",
+			change: &Change{
+				RecordSet:      &resourceRecordSet{},
+				RecordType:     "A",
+				ChangeType:     provider.R_DELETE,
+				ObjectMetaName: "a-test.example.com",
+			},
+			wantRRS: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := exec.applyChange(tt.change)
+			if err != nil {
+				t.Errorf("applyChange() Got error = %v, expected nil", err)
+			}
+
+			if tt.wantRRS != nil {
+				got := &globalnetworkingv1.ResourceRecordSet{}
+				err = fakeClient.Get(context.Background(), client.ObjectKey{Name: tt.wantRRS.Name, Namespace: tt.wantRRS.Namespace}, got)
+
+				if err != nil {
+					t.Errorf("failed to get created ResourceRecordSet: %v", err)
+				}
+				if diff := cmp.Diff(tt.wantRRS, got); diff != "" {
+					t.Errorf("unexpected ResourceRecordSet (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/pkg/controller/provider/gdc/factory.go
+++ b/pkg/controller/provider/gdc/factory.go
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Contributors to the Gardener project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gdc
+
+import (
+	"github.com/gardener/external-dns-management/pkg/controller/provider/compound"
+	"github.com/gardener/external-dns-management/pkg/controller/provider/gdc/validation"
+	"github.com/gardener/external-dns-management/pkg/dns/provider"
+)
+
+const TYPE_CODE = validation.ProviderType
+
+var rateLimiterDefaults = provider.RateLimiterOptions{
+	Enabled: true,
+	QPS:     100,
+	Burst:   20,
+}
+
+var Factory = provider.NewDNSHandlerFactory(NewHandler, validation.NewAdapter()).
+	SetGenericFactoryOptionDefaults(provider.GenericFactoryOptionDefaults.SetRateLimiterOptions(rateLimiterDefaults))
+
+func init() {
+	compound.MustRegister(Factory)
+}

--- a/pkg/controller/provider/gdc/handler.go
+++ b/pkg/controller/provider/gdc/handler.go
@@ -1,0 +1,241 @@
+// SPDX-FileCopyrightText: Contributors to the Gardener project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gdc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/gardener/controller-manager-library/pkg/logger"
+	globalnetworkingv1 "github.com/googlecloudplatform/google-distributed-cloud-apis/pkg/apis/public/global/networking/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gdcclient "github.com/gardener/external-dns-management/pkg/controller/provider/gdc/client"
+	"github.com/gardener/external-dns-management/pkg/controller/provider/gdc/client/auth"
+	"github.com/gardener/external-dns-management/pkg/controller/provider/gdc/client/constants"
+	dnsconst "github.com/gardener/external-dns-management/pkg/controller/provider/gdc/client/dns"
+	"github.com/gardener/external-dns-management/pkg/dns"
+	"github.com/gardener/external-dns-management/pkg/dns/provider"
+)
+
+type Handler struct {
+	provider.DefaultDNSHandler
+	config  provider.DNSHandlerConfig
+	cache   provider.ZoneCache
+	project string
+	client  client.WithWatch
+}
+
+var _ provider.DNSHandler = &Handler{}
+
+func NewHandler(config *provider.DNSHandlerConfig) (provider.DNSHandler, error) {
+	var err error
+
+	h := &Handler{
+		DefaultDNSHandler: provider.NewDefaultDNSHandler(TYPE_CODE),
+		config:            *config,
+	}
+
+	gdchConfigStr := h.config.Properties[constants.GDCHConfigJSONField]
+	if gdchConfigStr == "" {
+		return nil, fmt.Errorf("%s required in secret", constants.GDCHConfigJSONField)
+	}
+
+	serviceAccountStr := h.config.Properties[constants.ServiceAccountJSONField]
+	if serviceAccountStr == "" {
+		return nil, fmt.Errorf("%s required in secret", constants.ServiceAccountJSONField)
+	}
+
+	gdcConfig := &gdcclient.OrgClusterConfig{}
+	if err := json.Unmarshal([]byte(gdchConfigStr), gdcConfig); err != nil {
+		return nil, fmt.Errorf("failed to parse GDC Config %w", err)
+	}
+
+	serviceAccount := &auth.ServiceAccount{}
+	if err := json.Unmarshal([]byte(serviceAccountStr), serviceAccount); err != nil {
+		return nil, fmt.Errorf("failed to parse service account %w", err)
+	}
+
+	scheme := runtime.NewScheme()
+	if err := globalnetworkingv1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("add global networking types to kubernetes client: %w", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("add core types to kubernetes client: %w", err)
+	}
+
+	h.client, err = gdcclient.Get(gdcConfig, serviceAccount, scheme)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Global kubeClient %w", err)
+	}
+
+	h.project = serviceAccount.Project
+	h.cache, err = config.ZoneCacheFactory.CreateZoneCache(provider.CacheZoneState, config.Metrics, h.getZones, h.getZoneState)
+	if err != nil {
+		return nil, err
+	}
+
+	return h, nil
+}
+
+func (h *Handler) Release() {
+	h.cache.Release()
+}
+
+// GetZones gets DNSHostedZones from cache.
+func (h *Handler) GetZones() (provider.DNSHostedZones, error) {
+	return h.cache.GetZones()
+}
+
+func (h *Handler) getZones(_ provider.ZoneCache) (provider.DNSHostedZones, error) {
+	// Update metrics of list zone call.
+	rt := provider.M_LISTZONES
+	h.config.Metrics.AddGenericRequests(rt, 1)
+	h.config.RateLimiter.Accept()
+
+	return h.getManagedDNSZones()
+}
+
+func (h *Handler) getManagedDNSZones() (provider.DNSHostedZones, error) {
+	zones := provider.DNSHostedZones{}
+
+	managedZoneList := &globalnetworkingv1.ManagedDNSZoneList{}
+	listOptions := client.InNamespace(h.project)
+	if err := h.client.List(context.Background(), managedZoneList, listOptions); err != nil {
+		return nil, fmt.Errorf("failed to list ManagedDNSZone in project %q: %v", h.project, err)
+	}
+
+	for _, zone := range managedZoneList.Items {
+		hostedZone := provider.NewDNSHostedZone(h.ProviderType(), h.makeZoneID(zone.Name), dns.NormalizeHostname(zone.Spec.DNSName), zone.Name, false)
+		zones = append(zones, hostedZone)
+	}
+	return zones, nil
+}
+
+// GetZoneState gets DNSHostedZoneState from cache.
+func (h *Handler) GetZoneState(zone provider.DNSHostedZone) (provider.DNSZoneState, error) {
+	return h.cache.GetZoneState(zone)
+}
+
+func (h *Handler) getZoneState(zone provider.DNSHostedZone, _ provider.ZoneCache) (provider.DNSZoneState, error) {
+	// Update metrics of list records call.
+	rt := provider.M_LISTRECORDS
+	h.config.Metrics.AddZoneRequests(zone.Id().ID, rt, 1)
+	h.config.RateLimiter.Accept()
+
+	dnssets := dns.DNSSets{}
+	resourceRecordSetList := &globalnetworkingv1.ResourceRecordSetList{}
+	err := h.client.List(
+		context.Background(),
+		resourceRecordSetList,
+		client.InNamespace(h.project),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve recordset in project %s: %w", h.project, err)
+	}
+
+	for _, rrSet := range resourceRecordSetList.Items {
+		var records []*dns.Record
+		spec := rrSet.Spec
+		recordType := spec.Type
+		if spec.DNSZone == zone.Key() && isRecordTypeSupported(recordType) {
+			ttl := dnsconst.DNSDefaultTTL
+			if spec.TTLSeconds != nil && *spec.TTLSeconds > 0 {
+				ttl = int(*spec.TTLSeconds)
+			}
+
+			for _, value := range spec.RRData {
+				records = append(records, &dns.Record{
+					Value: value,
+				})
+			}
+			logger.Infof("DNS Name: %v, Records of type %s: %s", rrSet.Spec.Name, recordType, spec.RRData)
+			dnssets.AddRecordSetFromProvider(rrSet.Spec.Name, dns.NewRecordSet(recordType, int64(ttl), records))
+		}
+	}
+
+	return provider.NewDNSZoneState(dnssets), nil
+}
+
+func isRecordTypeSupported(recordType string) bool {
+	for _, supportedRecordType := range supportedRecordTypes {
+		if recordType == supportedRecordType {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *Handler) ExecuteRequests(logger logger.LogContext, zone provider.DNSHostedZone, state provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
+	err := h.executeRequests(logger, zone, state, reqs)
+	h.cache.ApplyRequests(logger, err, zone, reqs)
+	return err
+}
+
+func (h *Handler) executeRequests(logger logger.LogContext, zone provider.DNSHostedZone, _ provider.DNSZoneState, reqs []*provider.ChangeRequest) error {
+	exec := NewExecution(logger, h, zone)
+
+	var succeeded, failed int
+	for _, r := range reqs {
+		change, err := exec.prepareChange(r)
+		if err != nil {
+			if r.Done != nil {
+				r.Done.SetInvalid(err)
+			}
+			logger.Infof("Invalid updates for records in zone %s: %v", zone.Domain(), err)
+			continue
+		}
+
+		if h.config.DryRun {
+			continue
+		}
+
+		err = exec.applyChange(change)
+		if err != nil {
+			failed++
+			if r.Done != nil {
+				r.Done.Failed(err)
+			}
+			logger.Infof("Failed updates for records in zone %s: %v", zone.Domain(), err)
+		} else {
+			succeeded++
+			if r.Done != nil {
+				r.Done.Succeeded()
+			}
+		}
+	}
+
+	if h.config.DryRun {
+		logger.Infof("no changes in dryrun mode for GDC")
+		return nil
+	}
+
+	if succeeded > 0 {
+		logger.Infof("Summary: succeeded updates for records in zone %s: %d", zone.Domain(), succeeded)
+	}
+	if failed > 0 {
+		logger.Infof("Summary: failed updates for records in zone %s: %d", zone.Domain(), failed)
+		return fmt.Errorf("%d changes failed", failed)
+	}
+
+	return nil
+}
+
+func (h *Handler) makeZoneID(zoneName string) string {
+	return fmt.Sprintf("%s/%s", h.project, zoneName)
+}
+
+// SplitZoneID splits the zone id into project id and zone name
+func SplitZoneID(id string) (string, string, error) {
+	parts := strings.SplitN(id, "/", 2)
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("invalid zone id: %s", id)
+	}
+	return parts[0], parts[1], nil
+}

--- a/pkg/controller/provider/gdc/handler_test.go
+++ b/pkg/controller/provider/gdc/handler_test.go
@@ -1,0 +1,800 @@
+// SPDX-FileCopyrightText: Contributors to the Gardener project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gdc
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gardener/controller-manager-library/pkg/logger"
+	"github.com/google/go-cmp/cmp"
+	globalnetworkingv1 "github.com/googlecloudplatform/google-distributed-cloud-apis/pkg/apis/public/global/networking/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	runtimeutil "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/gardener/external-dns-management/pkg/controller/provider/gdc/client/constants"
+	dnsconst "github.com/gardener/external-dns-management/pkg/controller/provider/gdc/client/dns"
+	"github.com/gardener/external-dns-management/pkg/dns"
+	dnsProvider "github.com/gardener/external-dns-management/pkg/dns/provider"
+)
+
+const (
+	project       = "fake-project"
+	testZoneName  = "test-zone"
+	testZoneName1 = "test-zone-1"
+	testZoneName2 = "test-zone-2"
+	testDomain    = "zone1.test"
+	testFQDN1     = "test1.zone1.test"
+	testFQDN2     = "test2.zone1.test"
+	testTTL       = dnsconst.DNSDefaultTTL
+)
+
+var (
+	dnsSetName1    = dns.DNSSetName{DNSName: testFQDN1}
+	dnsSetName2    = dns.DNSSetName{DNSName: testFQDN2}
+	testZoneDomain = dnsProvider.NewDNSHostedZone(
+		TYPE_CODE,
+		fmt.Sprintf("%s/%s", project, testZoneName),
+		testDomain,
+		testZoneName,
+		false,
+	)
+	testZone1 = dnsProvider.NewDNSHostedZone(
+		TYPE_CODE,
+		fmt.Sprintf("%s/%s", project, testZoneName1),
+		testFQDN1,
+		testZoneName1,
+		false,
+	)
+	ttl = uint32(testTTL)
+)
+
+type Config = dnsProvider.DNSHandlerConfig
+
+func TestNewHandler(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  Config
+		wantErr bool
+	}{
+		{
+			name:    "should return error if empty configuration is provided",
+			config:  Config{},
+			wantErr: true,
+		},
+		{
+			name: "should return error if config properties does not have service account json",
+			config: Config{
+				Properties: map[string]string{
+					constants.GDCHConfigJSONField: "{}",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "should return error if config properties has invalid config",
+			config: Config{
+				Properties: map[string]string{
+					constants.GDCHConfigJSONField:     "invalid-config",
+					constants.ServiceAccountJSONField: "{}",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "should return error if config properties has invalid serviceaccount.json",
+			config: Config{
+				Properties: map[string]string{
+					constants.GDCHConfigJSONField:     "{}",
+					constants.ServiceAccountJSONField: "invalid-service-account",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "should return the handler with gdch-config",
+			config: Config{
+				Properties: map[string]string{
+					constants.GDCHConfigJSONField:     "{}",
+					constants.ServiceAccountJSONField: "{}",
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewHandler(&tc.config)
+
+			if err == nil && tc.wantErr {
+				t.Errorf("expected error calling NewHandler, got nil")
+			}
+
+			if err != nil && !tc.wantErr {
+				t.Errorf("unexpected error calling NewHandler: %s", err)
+			}
+		})
+	}
+}
+
+func TestGetZones(t *testing.T) {
+	h := mockHandler(t, []client.Object{
+		&globalnetworkingv1.ManagedDNSZone{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-zone",
+				Namespace: project,
+			},
+			Spec: globalnetworkingv1.ManagedDNSZoneSpec{
+				DNSName:    "test.zone",
+				Visibility: "PRIVATE",
+			},
+		},
+	})
+	zones, err := h.GetZones()
+
+	if err != nil {
+		t.Errorf("GetZones() expects no error, got: %v", err)
+	}
+
+	var expectedZones dnsProvider.DNSHostedZones = []dnsProvider.DNSHostedZone{
+		dnsProvider.NewDNSHostedZone(TYPE_CODE, "fake-project/test-zone", "test.zone", "test-zone", false),
+	}
+	// Cannot use cmp because it leads to panic of unexported field zoneid.
+	if !zones.EquivalentTo(expectedZones) {
+		t.Errorf("expected zones %s, got %s", expectedZones, zones)
+	}
+}
+
+func TestGetZoneState(t *testing.T) {
+	testcases := []struct {
+		name              string
+		rrSetCRName       string
+		rrsetCR           *globalnetworkingv1.ResourceRecordSet
+		wantDNSRecordSets dns.RecordSets
+	}{
+		{
+			name:        "A record",
+			rrSetCRName: fmt.Sprintf("a-%s", testFQDN1),
+			rrsetCR: &globalnetworkingv1.ResourceRecordSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("a-%s", testFQDN1),
+					Namespace: project,
+				},
+				Spec: globalnetworkingv1.ResourceRecordSetSpec{
+					Name:       testFQDN1,
+					TTLSeconds: &ttl,
+					Type:       "A",
+					RRData:     []string{"1.1.1.1"},
+					DNSZone:    testZoneName1,
+				},
+			},
+			wantDNSRecordSets: dns.RecordSets{
+				"A": {
+					Type:      "A",
+					TTL:       dnsconst.DNSDefaultTTL,
+					IgnoreTTL: false,
+					Records: []*dns.Record{
+						{
+							Value: "1.1.1.1",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "TXT record",
+			rrSetCRName: fmt.Sprintf("txt-%s", testFQDN1),
+			rrsetCR: &globalnetworkingv1.ResourceRecordSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("txt-%s", testFQDN1),
+					Namespace: project,
+				},
+				Spec: globalnetworkingv1.ResourceRecordSetSpec{
+					Name:       testFQDN1,
+					TTLSeconds: &ttl,
+					Type:       "TXT",
+					RRData: []string{
+						`"foo_key=foo_val"`,
+					},
+					DNSZone: testZoneName1,
+				},
+			},
+			wantDNSRecordSets: dns.RecordSets{
+				"TXT": {
+					Type:      "TXT",
+					TTL:       dnsconst.DNSDefaultTTL,
+					IgnoreTTL: false,
+					Records: []*dns.Record{
+						{
+							Value: `"foo_key=foo_val"`,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "CNAME record",
+			rrSetCRName: fmt.Sprintf("cname-%s", testFQDN1),
+			rrsetCR: &globalnetworkingv1.ResourceRecordSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("cname-%s", testFQDN1),
+					Namespace: project,
+				},
+				Spec: globalnetworkingv1.ResourceRecordSetSpec{
+					Name:       testFQDN1,
+					TTLSeconds: &ttl,
+					Type:       "CNAME",
+					RRData: []string{
+						"target.zone1.test",
+					},
+					DNSZone: testZoneName1,
+				},
+			},
+			wantDNSRecordSets: dns.RecordSets{
+				"CNAME": {
+					Type:      "CNAME",
+					TTL:       dnsconst.DNSDefaultTTL,
+					IgnoreTTL: false,
+					Records: []*dns.Record{
+						{
+							Value: "target.zone1.test",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "PTR record",
+			rrSetCRName: fmt.Sprintf("ptr-%s", testFQDN1),
+			rrsetCR: &globalnetworkingv1.ResourceRecordSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("ptr-%s", testFQDN1),
+					Namespace: project,
+				},
+				Spec: globalnetworkingv1.ResourceRecordSetSpec{
+					Name:       testFQDN1,
+					TTLSeconds: &ttl,
+					Type:       "PTR",
+					RRData: []string{
+						"host1.zone1.test",
+					},
+					DNSZone: testZoneName1,
+				},
+			},
+			wantDNSRecordSets: dns.RecordSets{
+				"PTR": {
+					Type:      "PTR",
+					TTL:       dnsconst.DNSDefaultTTL,
+					IgnoreTTL: false,
+					Records: []*dns.Record{
+						{
+							Value: "host1.zone1.test",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "DS record",
+			rrSetCRName: fmt.Sprintf("ds-%s", testFQDN1),
+			rrsetCR: &globalnetworkingv1.ResourceRecordSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("ds-%s", testFQDN1),
+					Namespace: project,
+				},
+				Spec: globalnetworkingv1.ResourceRecordSetSpec{
+					Name:       testFQDN1,
+					TTLSeconds: &ttl,
+					Type:       "DS",
+					RRData: []string{
+						"12345 3 1 123456789abcdef67890123456789abcdef67890",
+					},
+					DNSZone: testZoneName1,
+				},
+			},
+			wantDNSRecordSets: dns.RecordSets{
+				"DS": {
+					Type:      "DS",
+					TTL:       dnsconst.DNSDefaultTTL,
+					IgnoreTTL: false,
+					Records: []*dns.Record{
+						{
+							Value: "12345 3 1 123456789abcdef67890123456789abcdef67890",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "MX record",
+			rrSetCRName: fmt.Sprintf("mx-%s", testFQDN1),
+			rrsetCR: &globalnetworkingv1.ResourceRecordSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("mx-%s", testFQDN1),
+					Namespace: project,
+				},
+				Spec: globalnetworkingv1.ResourceRecordSetSpec{
+					Name:       testFQDN1,
+					TTLSeconds: &ttl,
+					Type:       "MX",
+					RRData: []string{
+						"10 mail.example.com.",
+					},
+					DNSZone: testZoneName1,
+				},
+			},
+			wantDNSRecordSets: dns.RecordSets{
+				"MX": {
+					Type:      "MX",
+					TTL:       dnsconst.DNSDefaultTTL,
+					IgnoreTTL: false,
+					Records: []*dns.Record{
+						{
+							Value: "10 mail.example.com.",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "Not related records",
+			rrSetCRName: fmt.Sprintf("ns-%s", testFQDN1),
+			rrsetCR: &globalnetworkingv1.ResourceRecordSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("ns-%s", testFQDN1),
+					Namespace: project,
+				},
+				Spec: globalnetworkingv1.ResourceRecordSetSpec{
+					Name:       testFQDN1,
+					TTLSeconds: &ttl,
+					Type:       "NS",
+					RRData: []string{
+						"ns1.zone1.test",
+						"ns2.zone1.test",
+					},
+					DNSZone: testZoneName1,
+				},
+			},
+			wantDNSRecordSets: dns.RecordSets{},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := mockHandler(t, []client.Object{
+				tc.rrsetCR,
+			})
+
+			got, err := h.GetZoneState(testZone1)
+			if err != nil {
+				t.Errorf("GetZoneState() expects no error, got: %v", err)
+			}
+
+			for _, v := range got.GetDNSSets() {
+				expectedSets := &dns.DNSSet{
+					Name: dns.DNSSetName{
+						DNSName: tc.rrsetCR.Spec.Name,
+					},
+					Sets: tc.wantDNSRecordSets,
+				}
+				if diff := cmp.Diff(expectedSets, v); diff != "" {
+					t.Errorf("DNSSet (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestExecuteRequests(t *testing.T) {
+	// Initialize record sets for testFQDN1.
+	initHandlerWithRecordSets := func() Handler {
+		aRecord := &globalnetworkingv1.ResourceRecordSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("a-%s", testFQDN1),
+				Namespace: project,
+			},
+			Spec: globalnetworkingv1.ResourceRecordSetSpec{
+				Name:       testFQDN1,
+				TTLSeconds: &ttl,
+				Type:       "A",
+				RRData:     []string{"1.1.1.1"},
+				DNSZone:    testZoneName,
+			},
+		}
+
+		txtRecord := &globalnetworkingv1.ResourceRecordSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("txt-%s", testFQDN1),
+				Namespace: project,
+			},
+			Spec: globalnetworkingv1.ResourceRecordSetSpec{
+				Name:       testFQDN1,
+				TTLSeconds: &ttl,
+				Type:       "TXT",
+				RRData:     []string{`"foo_key=foo_val"`},
+				DNSZone:    testZoneName,
+			},
+		}
+
+		return *mockHandler(t, []client.Object{
+			aRecord, txtRecord,
+		})
+	}
+
+	testcases := []struct {
+		name             string
+		reqs             []*dnsProvider.ChangeRequest
+		wantDNSSets      dns.DNSSets
+		wantError        bool
+		wantInvalidCount int
+		wantFailedCount  int
+	}{
+		{
+			name: "Create Requests for different dns set",
+			reqs: []*dnsProvider.ChangeRequest{
+				{
+					Action: dnsProvider.R_CREATE,
+					Type:   "A",
+					Addition: &dns.DNSSet{
+						Name: dnsSetName2,
+						Sets: dns.RecordSets{
+							"A": buildRecordSet("A", dnsconst.DNSDefaultTTL, "11.22.33.44"),
+						},
+						UpdateGroup: project,
+					},
+				},
+				{
+					Action: dnsProvider.R_CREATE,
+					Type:   "TXT",
+					Addition: &dns.DNSSet{
+						Name: dnsSetName2,
+						Sets: dns.RecordSets{
+							"TXT": buildRecordSet("TXT", dnsconst.DNSDefaultTTL, `"bar_key=bar_val"`),
+						},
+						UpdateGroup: project,
+					},
+				},
+			},
+			wantDNSSets: dns.DNSSets{
+				dnsSetName1: &dns.DNSSet{
+					Name: dnsSetName1,
+					Sets: dns.RecordSets{
+						"A":   buildRecordSet("A", dnsconst.DNSDefaultTTL, "1.1.1.1"),
+						"TXT": buildRecordSet("TXT", dnsconst.DNSDefaultTTL, `"foo_key=foo_val"`),
+					},
+				},
+				dnsSetName2: &dns.DNSSet{
+					Name: dnsSetName2,
+					Sets: dns.RecordSets{
+						"A":   buildRecordSet("A", dnsconst.DNSDefaultTTL, "11.22.33.44"),
+						"TXT": buildRecordSet("TXT", dnsconst.DNSDefaultTTL, `"bar_key=bar_val"`),
+					},
+				},
+			},
+		},
+		{
+			name: "Update Requests for same dns set",
+			reqs: []*dnsProvider.ChangeRequest{
+				{
+					Action: dnsProvider.R_UPDATE,
+					Type:   "A",
+					Addition: &dns.DNSSet{
+						Name: dnsSetName1,
+						Sets: dns.RecordSets{
+							"A": buildRecordSet("A", dnsconst.DNSDefaultTTL, "11.22.33.44"),
+						},
+						UpdateGroup: project,
+					},
+				},
+				{
+					Action: dnsProvider.R_UPDATE,
+					Type:   "TXT",
+					Addition: &dns.DNSSet{
+						Name: dnsSetName1,
+						Sets: dns.RecordSets{
+							"TXT": buildRecordSet("TXT", dnsconst.DNSDefaultTTL, `"bar_key=bar_val"`),
+						},
+						UpdateGroup: project,
+					},
+				},
+			},
+			wantDNSSets: dns.DNSSets{
+				dnsSetName1: &dns.DNSSet{
+					Name: dnsSetName1,
+					Sets: dns.RecordSets{
+						"A":   buildRecordSet("A", dnsconst.DNSDefaultTTL, "11.22.33.44"),
+						"TXT": buildRecordSet("TXT", dnsconst.DNSDefaultTTL, `"bar_key=bar_val"`),
+					},
+				},
+			},
+		},
+		{
+			name: "Delete Requests",
+			reqs: []*dnsProvider.ChangeRequest{
+				{
+					Action: dnsProvider.R_DELETE,
+					Type:   "A",
+					Deletion: &dns.DNSSet{
+						Name: dnsSetName1,
+						Sets: dns.RecordSets{
+							"A": buildRecordSet("A", dnsconst.DNSDefaultTTL, ""),
+						},
+						UpdateGroup: project,
+					},
+				},
+				{
+					Action: dnsProvider.R_DELETE,
+					Type:   "TXT",
+					Deletion: &dns.DNSSet{
+						Name: dnsSetName1,
+						Sets: dns.RecordSets{
+							"TXT": buildRecordSet("TXT", dnsconst.DNSDefaultTTL, ""),
+						},
+						UpdateGroup: project,
+					},
+				},
+			},
+			wantDNSSets: dns.DNSSets{},
+		},
+		{
+			name: "Requests with Invalid Resource Record Type",
+			reqs: []*dnsProvider.ChangeRequest{
+				{
+					Action: dnsProvider.R_CREATE,
+					Type:   "AAAA",
+					Addition: &dns.DNSSet{
+						Name: dnsSetName1,
+						Sets: dns.RecordSets{
+							"AAAA": buildRecordSet("AAAA", dnsconst.DNSDefaultTTL, "0000:0000:0000:0000:0000:0000:0000:0000"),
+						},
+					},
+				},
+				{
+					Action: dnsProvider.R_DELETE,
+					Type:   "NS",
+					Deletion: &dns.DNSSet{
+						Name: dnsSetName1,
+						Sets: dns.RecordSets{
+							"NS": buildRecordSet("NS", dnsconst.DNSDefaultTTL, "sub-vpc.zone1.test"),
+						},
+					},
+				},
+			},
+			wantDNSSets: dns.DNSSets{
+				dnsSetName1: &dns.DNSSet{
+					Name: dnsSetName1,
+					Sets: dns.RecordSets{
+						"A":   buildRecordSet("A", dnsconst.DNSDefaultTTL, "1.1.1.1"),
+						"TXT": buildRecordSet("TXT", dnsconst.DNSDefaultTTL, `"foo_key=foo_val"`),
+					},
+				},
+			},
+			wantInvalidCount: 2,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := initHandlerWithRecordSets()
+			zoneState, err := h.GetZoneState(testZoneDomain)
+			if err != nil {
+				t.Errorf("GetZoneState(%v) unexpect error: %v", testZoneDomain, err)
+			}
+
+			doneHandler := &testDoneHandler{}
+			for _, r := range tc.reqs {
+				r.Done = doneHandler
+			}
+
+			err = h.ExecuteRequests(logger.New(), testZoneDomain, zoneState, tc.reqs)
+			if err != nil && !tc.wantError {
+				t.Errorf("ExecuteRequests unexpect error: %v", err)
+			}
+			if err == nil && tc.wantError {
+				t.Error("ExecuteRequests expects error but got nil")
+			}
+
+			if diff := cmp.Diff(doneHandler.invalidCount, tc.wantInvalidCount); diff != "" {
+				t.Errorf("Invalid Count (-want +got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(doneHandler.failedCount, tc.wantFailedCount); diff != "" {
+				t.Errorf("Failed Count (-want +got):\n%s", diff)
+			}
+
+			got, err := h.GetZoneState(testZoneDomain)
+			if err != nil {
+				t.Errorf("GetZoneState(%v) unexpect error : %v", testZoneDomain, err)
+			}
+
+			if diff := cmp.Diff(sortDNSSets(tc.wantDNSSets), sortDNSSets(got.GetDNSSets())); diff != "" {
+				t.Errorf("DNSSet (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+type testServer struct {
+	DomPorts []string
+}
+
+type testCorefile struct {
+	Servers []*testServer
+}
+
+func zoneNames(cf *testCorefile) []string {
+	seenZones := make(map[string]bool)
+	var zoneNames []string
+	for _, s := range cf.Servers {
+		for _, d := range s.DomPorts {
+			// The field can be just the zone, or <zone>:<port>.
+			name := strings.Split(d, ":")[0]
+			if !seenZones[name] {
+				zoneNames = append(zoneNames, name)
+				seenZones[name] = true
+			}
+		}
+	}
+	sort.Strings(zoneNames)
+	return zoneNames
+}
+
+func TestZoneNames(t *testing.T) {
+	tests := []struct {
+		name     string
+		corefile *testCorefile
+		want     []string
+	}{
+		{
+			name: "simple corefile",
+			corefile: &testCorefile{
+				Servers: []*testServer{
+					{
+						DomPorts: []string{"example-1.com"},
+					},
+				},
+			},
+			want: []string{"example-1.com"},
+		},
+		{
+			name: "complex corefile",
+			corefile: &testCorefile{
+				Servers: []*testServer{
+					{
+						DomPorts: []string{"example-1.com", "example-2.com"},
+					},
+					{
+						DomPorts: []string{"example-1.com:123", "example-2.com:123"},
+					},
+				},
+			},
+			want: []string{"example-1.com", "example-2.com"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := zoneNames(tc.corefile)
+
+			if diff := cmp.Diff(got, tc.want); diff != "" {
+				t.Errorf("zoneNames(%v) (-want +got):\n%s", tc.corefile, diff)
+			}
+		})
+	}
+}
+
+func TestMakeAndSplitZoneID(t *testing.T) {
+	h := mockHandler(t, []client.Object{})
+	projectName := "fake-project"
+	h.project = projectName
+	zoneName := "fake-zone-name"
+	zoneID := h.makeZoneID(zoneName)
+
+	if zoneID != "fake-project/fake-zone-name" {
+		t.Errorf("makeZoneID(%v) = %v, want %v", zoneName, zoneID, "fake-project/fake-zone-name")
+	}
+
+	gotProjectName, gotZoneName, err := SplitZoneID(zoneID)
+	if err != nil {
+		t.Errorf("SplitZoneID(%v) = (%v, %v), err %v", zoneID, gotZoneName, gotProjectName, err)
+	}
+	if gotZoneName != zoneName || gotProjectName != projectName {
+		t.Errorf("SplitZoneID(%v) = (%v, %v), want (%v, %v)", zoneID, gotZoneName, gotProjectName, zoneName, projectName)
+	}
+}
+
+func mockHandler(t *testing.T, objects []client.Object) *Handler {
+	c := initTestClient(objects)
+
+	var rateLimiterConfig *dnsProvider.RateLimiterConfig
+	rateLimiter, _ := rateLimiterConfig.NewRateLimiter()
+
+	h := &Handler{
+		client:            c,
+		DefaultDNSHandler: dnsProvider.NewDefaultDNSHandler(TYPE_CODE),
+		config: Config{
+			Metrics: &dnsProvider.NullMetrics{},
+			Options: &dnsProvider.FactoryOptions{
+				GenericFactoryOptions: dnsProvider.GenericFactoryOptions{},
+			},
+			RateLimiter: rateLimiter,
+		},
+		project: project,
+	}
+
+	cacheFactory := dnsProvider.NewTestZoneCacheFactory(60*time.Second, 0*time.Second)
+	cache, err := cacheFactory.CreateZoneCache(dnsProvider.CacheZoneState, h.config.Metrics, h.getZones, h.getZoneState)
+	if err != nil {
+		t.Fatal("fail to initialize zone cache of handler")
+	}
+	h.cache = cache
+
+	return h
+}
+
+func initTestClient(objects []client.Object) client.WithWatch {
+	scheme := runtime.NewScheme()
+	runtimeutil.Must(globalnetworkingv1.AddToScheme(scheme))
+	runtimeutil.Must(corev1.AddToScheme(scheme))
+	src := fake.NewClientBuilder().WithScheme(scheme)
+	if len(objects) > 0 {
+		src = src.WithObjects(objects...)
+	}
+	return src.Build()
+}
+
+func buildRecordSet(rrtype string, ttl int, recordValues ...string) *dns.RecordSet {
+	var records dns.Records
+	for _, value := range recordValues {
+		records = append(records, &dns.Record{Value: value})
+	}
+	return &dns.RecordSet{Type: rrtype, TTL: int64(ttl), Records: records}
+}
+
+type testDoneHandler struct {
+	invalidCount int
+	failedCount  int
+	lastMessage  string
+}
+
+var _ dnsProvider.DoneHandler = &testDoneHandler{}
+
+func (h *testDoneHandler) SetInvalid(err error) {
+	h.invalidCount++
+	h.lastMessage = err.Error()
+}
+
+func (h *testDoneHandler) Failed(err error) {
+	h.failedCount++
+	h.lastMessage = err.Error()
+}
+
+func (h *testDoneHandler) Throttled() {}
+func (h *testDoneHandler) Succeeded() {}
+
+// sortDNSSets sorts the DNSSet by name and then by record type.
+func sortDNSSets(sets dns.DNSSets) dns.DNSSets {
+	sortedSets := make(dns.DNSSets, len(sets))
+	keys := make([]dns.DNSSetName, len(sets))
+	for k := range sets {
+		keys = append(keys, k)
+	}
+
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i].DNSName < keys[j].DNSName
+	})
+
+	for _, k := range keys {
+		sortedSets[k] = sets[k]
+	}
+
+	return sortedSets
+}

--- a/pkg/controller/provider/gdc/utils.go
+++ b/pkg/controller/provider/gdc/utils.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Contributors to the Gardener project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gdc
+
+const (
+	RS_A     = "A"
+	RS_TXT   = "TXT"
+	RS_CNAME = "CNAME"
+	RS_PTR   = "PTR"
+	RS_DS    = "DS"
+	RS_MX    = "MX"
+)
+
+var supportedRecordTypes = []string{RS_A, RS_TXT, RS_CNAME, RS_PTR, RS_DS, RS_MX}

--- a/pkg/controller/provider/gdc/validation/adaptor.go
+++ b/pkg/controller/provider/gdc/validation/adaptor.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/json"
 
+	"github.com/gardener/external-dns-management/pkg/controller/provider/gdc/client/constants"
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 )
 
@@ -33,14 +34,14 @@ type adapter struct {
 	checks *provider.DNSHandlerAdapterChecks
 }
 
-// NewAdapter creates a new DNSHandlerAdapter for the Google Cloud DNS provider.
+// NewAdapter creates a new DNSHandlerAdapter for the GDC DNS provider.
 func NewAdapter() provider.DNSHandlerAdapter {
 	checks := provider.NewDNSHandlerAdapterChecks()
-	checks.Add(provider.RequiredProperty("serviceaccount.json").Validators(func(value string) error {
+	checks.Add(provider.RequiredProperty(constants.ServiceAccountJSONField).Validators(func(value string) error {
 		_, err := ValidateServiceAccountJSON([]byte(value))
 		return err
 	}).HideValue())
-	checks.Add(provider.RequiredProperty("gdch-config").HideValue())
+	checks.Add(provider.RequiredProperty(constants.GDCHConfigJSONField).HideValue())
 	return &adapter{checks: checks}
 }
 
@@ -61,13 +62,13 @@ func ValidateServiceAccountJSON(data []byte) (LightCredentialsFile, error) {
 	var credInfo LightCredentialsFile
 
 	if err := json.Unmarshal(data, &credInfo); err != nil {
-		return credInfo, fmt.Errorf("'serviceaccount.json' data field does not contain a valid JSON: %s", err)
+		return credInfo, fmt.Errorf("'%s' data field does not contain a valid JSON: %s", constants.ServiceAccountJSONField, err)
 	}
 	if !projectIDRegexp.MatchString(credInfo.Project) {
-		return credInfo, fmt.Errorf("'serviceaccount.json' field 'project' is not a valid project")
+		return credInfo, fmt.Errorf("'%s' field 'project' is not a valid project", constants.ServiceAccountJSONField)
 	}
 	if credInfo.Type != "gdch_service_account" {
-		return credInfo, fmt.Errorf("'serviceaccount.json' field 'type' is not 'gdch_service_account'")
+		return credInfo, fmt.Errorf("'%s' field 'type' is not 'gdch_service_account'", constants.ServiceAccountJSONField)
 	}
 	return credInfo, nil
 }

--- a/pkg/dnsman2/.import-restrictions
+++ b/pkg/dnsman2/.import-restrictions
@@ -3,6 +3,7 @@ rules:
     allowedPrefixes:
       - github.com/gardener/external-dns-management/pkg/apis
       - github.com/gardener/external-dns-management/pkg/dnsman2
+      - github.com/gardener/external-dns-management/pkg/controller/provider/gdc/client
   - selectorRegexp: github[.]com/gardener/controller-manager-library
     forbiddenPrefixes:
       - ''

--- a/pkg/dnsman2/controller/controlplane/dnsentry/lookup/processor.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/lookup/processor.go
@@ -429,6 +429,9 @@ func lookupIPs(hostname string) lookupIPsResult {
 }
 
 func sleep(ctx context.Context, d time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if d < 1*time.Microsecond {
 		return nil
 	} else if d > 30*time.Second {

--- a/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_test.go
+++ b/pkg/dnsman2/controller/controlplane/dnsentry/reconciler_test.go
@@ -370,7 +370,7 @@ var _ = Describe("Reconcile", func() {
 		cancelLookupProcessor = func() {
 			mlh.Stop()
 			ctxCancel()
-			Eventually(reconciler.lookupProcessor.IsRunning).WithPolling(1 * time.Millisecond).WithTimeout(500 * time.Millisecond).Should(BeFalse())
+			Eventually(reconciler.lookupProcessor.IsRunning).WithPolling(1 * time.Millisecond).WithTimeout(5 * time.Second).Should(BeFalse())
 		}
 		go func() {
 			_ = reconciler.lookupProcessor.Start(lookupCtx)

--- a/pkg/dnsman2/dns/provider/handler/gdc/factory.go
+++ b/pkg/dnsman2/dns/provider/handler/gdc/factory.go
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: Contributors to the Gardener project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gdc
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gardener/external-dns-management/pkg/controller/provider/gdc/client/constants"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/apis/config"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/utils"
+)
+
+// ProviderType is the type code for GDC DNS provider.
+const ProviderType = "gdch-dns"
+
+// RegisterTo registers the GDC DNS handler to the registry.
+func RegisterTo(registry *provider.DNSHandlerRegistry) {
+	registry.Register(ProviderType, NewHandler, newAdapter(), &config.RateLimiterOptions{
+		Enabled: true,
+		QPS:     100,
+		Burst:   20,
+	}, nil)
+}
+
+type adapter struct {
+	checks *provider.DNSHandlerAdapterChecks
+}
+
+var _ provider.DNSHandlerAdapter = &adapter{}
+
+func newAdapter() provider.DNSHandlerAdapter {
+	checks := provider.NewDNSHandlerAdapterChecks()
+	checks.Add(provider.RequiredProperty(constants.ServiceAccountJSONField).Validators(func(value string) error {
+		_, err := validateServiceAccountJSON([]byte(value))
+		return err
+	}).HideValue())
+	checks.Add(provider.RequiredProperty(constants.GDCHConfigJSONField).HideValue())
+	return &adapter{checks: checks}
+}
+
+func (a *adapter) ProviderType() string {
+	return ProviderType
+}
+
+func (a *adapter) ValidateCredentialsAndProviderConfig(properties utils.Properties, config *runtime.RawExtension) error {
+	if config != nil && len(config.Raw) > 0 {
+		return fmt.Errorf("provider config not supported for %s provider", a.ProviderType())
+	}
+	return a.checks.ValidateProperties(a.ProviderType(), properties)
+}
+
+type lightCredentialsFile struct {
+	Type string `json:"type"`
+
+	// Service Account fields
+	Name         string `json:"name"`
+	PrivateKeyID string `json:"private_key_id"`
+	PrivateKey   string `json:"private_key"` // #nosec G117 - false positive
+	Project      string `json:"project"`
+}
+
+var projectIDRegexp = regexp.MustCompile(`^(?P<project>[a-z][a-z0-9-]{4,30}[a-z0-9])$`)
+
+func validateServiceAccountJSON(data []byte) (lightCredentialsFile, error) {
+	var credInfo lightCredentialsFile
+
+	if err := json.Unmarshal(data, &credInfo); err != nil {
+		return credInfo, fmt.Errorf("'%s' data field does not contain a valid JSON: %s", constants.ServiceAccountJSONField, err)
+	}
+	if !projectIDRegexp.MatchString(credInfo.Project) {
+		return credInfo, fmt.Errorf("'%s' field 'project' is not a valid project", constants.ServiceAccountJSONField)
+	}
+	if credInfo.Type != "gdch_service_account" {
+		return credInfo, fmt.Errorf("'%s' field 'type' is not 'gdch_service_account'", constants.ServiceAccountJSONField)
+	}
+	return credInfo, nil
+}

--- a/pkg/dnsman2/dns/provider/handler/gdc/factory_test.go
+++ b/pkg/dnsman2/dns/provider/handler/gdc/factory_test.go
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: Contributors to the Gardener project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gdc
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/clock"
+
+	"github.com/gardener/external-dns-management/pkg/controller/provider/gdc/client/constants"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/utils"
+)
+
+func TestRegisterAndFactory(t *testing.T) {
+	registry := provider.NewDNSHandlerRegistry(clock.RealClock{})
+
+	RegisterTo(registry)
+
+	// Assert provider type support
+	if !registry.Supports(ProviderType) {
+		t.Fatalf("expected registry to support provider type %q", ProviderType)
+	}
+
+	// Assert adapter capabilities
+	adapter, err := registry.GetDNSHandlerAdapter(ProviderType)
+	if err != nil {
+		t.Fatalf("unexpected error getting adapter: %v", err)
+	}
+
+	if diff := cmp.Diff(ProviderType, adapter.ProviderType()); diff != "" {
+		t.Errorf("adapter ProviderType mismatch (-want +got):\n%s", diff)
+	}
+
+	// Should fail with nil / empty properties
+	if err := adapter.ValidateCredentialsAndProviderConfig(nil, nil); err == nil {
+		t.Errorf("expected error validating empty credentials, got nil")
+	}
+
+	validServiceAccountJSON := `{"type":"gdch_service_account","project":"fake-project","name":"dns-sa","private_key_id":"key-1"}`
+	validGDCHConfigJSON := `{"orgClusterURL":"https://global-api.test"}`
+
+	validProps := utils.Properties{
+		constants.ServiceAccountJSONField: validServiceAccountJSON,
+		constants.GDCHConfigJSONField:     validGDCHConfigJSON,
+	}
+
+	if err := adapter.ValidateCredentialsAndProviderConfig(validProps, nil); err != nil {
+		t.Errorf("expected valid properties to succeed, got: %v", err)
+	}
+
+	// Should reject provider config if provided
+	if err := adapter.ValidateCredentialsAndProviderConfig(validProps, &runtime.RawExtension{Raw: []byte(`{"foo":"bar"}`)}); err == nil {
+		t.Errorf("expected error when provider config is provided, got nil")
+	}
+
+	// Test handler instantiation and Release
+	config := &provider.DNSHandlerConfig{
+		Properties: map[string]string{
+			constants.GDCHConfigJSONField:     validGDCHConfigJSON,
+			constants.ServiceAccountJSONField: validServiceAccountJSON,
+		},
+	}
+	h, err := NewHandler(config)
+	if err != nil {
+		t.Fatalf("failed to create new handler: %v", err)
+	}
+
+	if diff := cmp.Diff(ProviderType, h.ProviderType()); diff != "" {
+		t.Errorf("handler ProviderType mismatch (-want +got):\n%s", diff)
+	}
+
+	h.Release()
+}

--- a/pkg/dnsman2/dns/provider/handler/gdc/handler.go
+++ b/pkg/dnsman2/dns/provider/handler/gdc/handler.go
@@ -1,0 +1,255 @@
+// SPDX-FileCopyrightText: Contributors to the Gardener project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gdc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	globalnetworkingv1 "github.com/googlecloudplatform/google-distributed-cloud-apis/pkg/apis/public/global/networking/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	gdcclient "github.com/gardener/external-dns-management/pkg/controller/provider/gdc/client"
+	"github.com/gardener/external-dns-management/pkg/controller/provider/gdc/client/auth"
+	"github.com/gardener/external-dns-management/pkg/controller/provider/gdc/client/constants"
+	dnsconst "github.com/gardener/external-dns-management/pkg/controller/provider/gdc/client/dns"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/utils"
+)
+
+var sharedScheme = runtime.NewScheme()
+
+func init() {
+	_ = globalnetworkingv1.AddToScheme(sharedScheme)
+	_ = corev1.AddToScheme(sharedScheme)
+}
+
+// handler implements the provider.DNSHandler interface for GDC (gdch-dns).
+// It orchestrates direct synchronization between Gardener external-dns-management
+// and GDC ManagedDNSZones and ResourceRecordSets custom resources.
+type handler struct {
+	project string
+	client  client.Client
+	config  provider.DNSHandlerConfig
+}
+
+var _ provider.DNSHandler = &handler{}
+
+// ProviderType returns the unique type identifier of this DNS provider.
+func (h *handler) ProviderType() string {
+	return ProviderType
+}
+
+// Release performs any necessary cleanup or connection teardowns when the handler is closed.
+func (h *handler) Release() {}
+
+// GetZones discovers and lists all ManagedDNSZone Custom Resources in the GDC project namespace.
+// It maps them to Gardener's internal provider.DNSHostedZone structure for mapping and ownership checks.
+func (h *handler) GetZones(ctx context.Context) ([]provider.DNSHostedZone, error) {
+	// Apply rate limiting and report metrics to prevent API throttling and enable operational visibility.
+	h.config.RateLimiter.Accept()
+	h.config.Metrics.AddGenericRequests(provider.MetricsRequestTypeListZones, 1)
+
+	managedZoneList := &globalnetworkingv1.ManagedDNSZoneList{}
+	listOptions := client.InNamespace(h.project)
+	if err := h.client.List(ctx, managedZoneList, listOptions); err != nil {
+		return nil, fmt.Errorf("failed to list ManagedDNSZones in project %q: %w", h.project, err)
+	}
+
+	var zones []provider.DNSHostedZone
+	for _, zone := range managedZoneList.Items {
+		hostedZone := provider.NewDNSHostedZone(
+			h.ProviderType(),
+			h.makeZoneID(zone.Name),
+			dns.NormalizeDomainName(zone.Spec.DNSName),
+			zone.Name,
+			false,
+		)
+		zones = append(zones, hostedZone)
+	}
+
+	h.config.Log.Info("Discovered GDC DNS zones", "count", len(zones), "provider", h.ProviderType(), "project", h.project)
+	return zones, nil
+}
+
+// GetCustomQueryDNSFunc registers and returns the custom authoritative resolver query function
+// for a given DNS zone. This redirects Gardener's record lookups to GDC API servers directly.
+func (h *handler) GetCustomQueryDNSFunc(_ dns.ZoneInfo, _ utils.QueryDNSFactoryFunc) (provider.CustomQueryDNSFunc, error) {
+	return func(ctx context.Context, localZoneInfo dns.ZoneInfo, setName dns.DNSSetName, recordType dns.RecordType) (*dns.RecordSet, error) {
+		return h.queryDNS(ctx, localZoneInfo, setName, recordType)
+	}, nil
+}
+
+// queryDNS queries ResourceRecordSets custom resources directly from GDC APIs.
+func (h *handler) queryDNS(ctx context.Context, _ dns.ZoneInfo, setName dns.DNSSetName, recordType dns.RecordType) (*dns.RecordSet, error) {
+	// Apply rate limiting and report metrics to prevent API throttling and enable operational visibility.
+	h.config.RateLimiter.Accept()
+	h.config.Metrics.AddGenericRequests(provider.MetricsRequestTypeListRecords, 1)
+
+	// Calculate unique ResourceRecordSet name according to GDC controller schemes.
+	recordSetName := dnsconst.GetDNSRecordSetName(string(recordType), setName.DNSName)
+	gdcRecordSet := &globalnetworkingv1.ResourceRecordSet{}
+
+	err := h.client.Get(ctx, client.ObjectKey{
+		Name:      recordSetName,
+		Namespace: h.project,
+	}, gdcRecordSet)
+
+	if err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get ResourceRecordSet %q: %w", recordSetName, err)
+	}
+
+	ttl := int64(0)
+	if gdcRecordSet.Spec.TTLSeconds != nil {
+		ttl = int64(*gdcRecordSet.Spec.TTLSeconds)
+	}
+
+	records := make([]*dns.Record, 0, len(gdcRecordSet.Spec.RRData))
+	for _, rrdata := range gdcRecordSet.Spec.RRData {
+		val := rrdata
+		if recordType == dns.TypeTXT {
+			if u, err := strconv.Unquote(rrdata); err == nil {
+				val = u
+			}
+		}
+		records = append(records, &dns.Record{Value: val})
+	}
+
+	h.config.Log.Info("Resolved DNS record from GDC API", "name", setName.DNSName, "type", recordType, "records", len(records), "provider", h.ProviderType(), "project", h.project)
+	return dns.NewRecordSet(recordType, ttl, records), nil
+}
+
+// ExecuteRequests executes DNS record changes by creating, updating, or deleting ResourceRecordSet
+// Custom Resources in the GDC project namespace.
+// It processes a batch of updates mapped by record type:
+//   - If the update's New set is nil, the record is scheduled for deletion, and we delete the GDC ResourceRecordSet.
+//   - Otherwise, the record is scheduled for creation or update. We resolve the records values, construct the spec,
+//     and perform a CreateOrUpdate operation to reconcile the desired state inside the GDC API server.
+func (h *handler) ExecuteRequests(ctx context.Context, zone provider.DNSHostedZone, requests provider.ChangeRequests) error {
+	var succeeded, failed int
+	for recordType, update := range requests.Updates {
+		h.config.RateLimiter.Accept()
+		h.config.Metrics.AddZoneRequests(zone.ZoneID().ID, provider.MetricsRequestTypeUpdateRecords, 1)
+
+		recordSetName := dnsconst.GetDNSRecordSetName(string(recordType), requests.Name.DNSName)
+		gdcRecordSet := &globalnetworkingv1.ResourceRecordSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      recordSetName,
+				Namespace: h.project,
+			},
+		}
+
+		if update.New == nil {
+			if err := h.client.Delete(ctx, gdcRecordSet); client.IgnoreNotFound(err) != nil {
+				failed++
+				h.config.Log.Error(err, "Failed to delete ResourceRecordSet", "name", recordSetName)
+				continue
+			}
+			succeeded++
+			h.config.Log.Info("Deleted GDC ResourceRecordSet successfully", "name", recordSetName, "provider", h.ProviderType(), "project", h.project)
+		} else {
+			ttl := uint32(update.New.TTL) // #nosec G115 -- TTL is safe bounded integer
+			rrdata := make([]string, 0, len(update.New.Records))
+			for _, r := range update.New.Records {
+				val := r.Value
+				if recordType == dns.TypeTXT {
+					val = ensureQuotedText(val)
+				}
+				rrdata = append(rrdata, val)
+			}
+
+			_, err := controllerutil.CreateOrUpdate(ctx, h.client, gdcRecordSet, func() error {
+				gdcRecordSet.Spec = globalnetworkingv1.ResourceRecordSetSpec{
+					Name:       trimTrailingDot(requests.Name.DNSName),
+					Type:       string(recordType),
+					TTLSeconds: &ttl,
+					RRData:     rrdata,
+					DNSZone:    zone.Key(),
+				}
+				return nil
+			})
+			if err != nil {
+				failed++
+				h.config.Log.Error(err, "Failed to apply ResourceRecordSet", "name", recordSetName)
+				continue
+			}
+			succeeded++
+			h.config.Log.Info("Applied GDC ResourceRecordSet successfully", "name", recordSetName, "provider", h.ProviderType(), "project", h.project)
+		}
+	}
+
+	if failed > 0 {
+		return fmt.Errorf("failed to execute %d of %d record change updates", failed, succeeded+failed)
+	}
+	return nil
+}
+
+// makeZoneID formats a GDC zone ID utilizing the project and resource name.
+func (h *handler) makeZoneID(zoneName string) string {
+	return fmt.Sprintf("%s/%s", h.project, zoneName)
+}
+
+// NewHandler instantiates a new GDC DNSHandler using the provided configuration.
+func NewHandler(config *provider.DNSHandlerConfig) (provider.DNSHandler, error) {
+	if config == nil {
+		return nil, fmt.Errorf("config cannot be nil")
+	}
+	h := &handler{
+		config: *config,
+	}
+
+	gdchConfigStr := h.config.Properties[constants.GDCHConfigJSONField]
+	if gdchConfigStr == "" {
+		return nil, fmt.Errorf("%s required in secret", constants.GDCHConfigJSONField)
+	}
+
+	serviceAccountStr := h.config.Properties[constants.ServiceAccountJSONField]
+	if serviceAccountStr == "" {
+		return nil, fmt.Errorf("%s required in secret", constants.ServiceAccountJSONField)
+	}
+
+	gdcConfig := &gdcclient.OrgClusterConfig{}
+	if err := json.Unmarshal([]byte(gdchConfigStr), gdcConfig); err != nil {
+		return nil, fmt.Errorf("failed to parse GDC Config %w", err)
+	}
+
+	serviceAccount := &auth.ServiceAccount{}
+	if err := json.Unmarshal([]byte(serviceAccountStr), serviceAccount); err != nil {
+		return nil, fmt.Errorf("failed to parse service account %w", err)
+	}
+
+	var err error
+	h.client, err = gdcclient.Get(gdcConfig, serviceAccount, sharedScheme)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Global kubeClient %w", err)
+	}
+
+	h.project = serviceAccount.Project
+	return h, nil
+}
+
+func ensureQuotedText(v string) string {
+	if _, err := strconv.Unquote(v); err != nil {
+		v = strconv.Quote(v)
+	}
+	return v
+}
+
+func trimTrailingDot(s string) string {
+	if s != "" && s[len(s)-1] == '.' {
+		return s[:len(s)-1]
+	}
+	return s
+}

--- a/pkg/dnsman2/dns/provider/handler/gdc/handler_test.go
+++ b/pkg/dnsman2/dns/provider/handler/gdc/handler_test.go
@@ -1,0 +1,408 @@
+// SPDX-FileCopyrightText: Contributors to the Gardener project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gdc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	globalnetworkingv1 "github.com/googlecloudplatform/google-distributed-cloud-apis/pkg/apis/public/global/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/flowcontrol"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	dnsconst "github.com/gardener/external-dns-management/pkg/controller/provider/gdc/client/dns"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider"
+)
+
+type noopMetrics struct{}
+
+func (m *noopMetrics) AddGenericRequests(_ provider.MetricsRequestType, _ int) {}
+func (m *noopMetrics) AddZoneRequests(_ string, _ provider.MetricsRequestType, _ int) {
+}
+
+func TestGetZones(t *testing.T) {
+	type zoneResult struct {
+		ID     string
+		Domain string
+	}
+
+	tests := []struct {
+		name          string
+		existingZones []runtime.Object
+		expected      []zoneResult
+		expectErr     bool
+	}{
+		{
+			name: "discover existing zones",
+			existingZones: []runtime.Object{
+				&globalnetworkingv1.ManagedDNSZone{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-zone-1", Namespace: "my-project"},
+					Spec:       globalnetworkingv1.ManagedDNSZoneSpec{DNSName: "zone1.gdc.sap.corp."},
+				},
+				&globalnetworkingv1.ManagedDNSZone{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-zone-2", Namespace: "my-project"},
+					Spec:       globalnetworkingv1.ManagedDNSZoneSpec{DNSName: "zone2.gdc.sap.corp."},
+				},
+			},
+			expected: []zoneResult{
+				{ID: "my-project/my-zone-1", Domain: "zone1.gdc.sap.corp"},
+				{ID: "my-project/my-zone-2", Domain: "zone2.gdc.sap.corp"},
+			},
+			expectErr: false,
+		},
+		{
+			name:          "no zones found",
+			existingZones: []runtime.Object{},
+			expected:      nil,
+			expectErr:     false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			scheme := runtime.NewScheme()
+			_ = globalnetworkingv1.AddToScheme(scheme)
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(tc.existingZones...).Build()
+			h := &handler{
+				project: "my-project",
+				client:  fakeClient,
+				config: provider.DNSHandlerConfig{
+					Log:         log.Log,
+					Metrics:     &noopMetrics{},
+					RateLimiter: flowcontrol.NewFakeAlwaysRateLimiter(),
+				},
+			}
+			ctx := context.Background()
+
+			// Action
+			zones, err := h.GetZones(ctx)
+
+			// Assert
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("expected an error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error listing zones: %v", err)
+			}
+
+			var actual []zoneResult
+			for _, z := range zones {
+				actual = append(actual, zoneResult{
+					ID:     z.ZoneID().ID,
+					Domain: z.Domain(),
+				})
+			}
+
+			if diff := cmp.Diff(tc.expected, actual); diff != "" {
+				t.Errorf("GetZones mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestQueryDNS(t *testing.T) {
+	ttlVal := uint32(300)
+	tests := []struct {
+		name            string
+		existingRecords []runtime.Object
+		queryName       string
+		queryType       dns.RecordType
+		expectedRS      *dns.RecordSet
+	}{
+		{
+			name: "resolve existing record",
+			existingRecords: []runtime.Object{
+				&globalnetworkingv1.ResourceRecordSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      dnsconst.GetDNSRecordSetName("A", "host.zone1.gdc.sap.corp"),
+						Namespace: "my-project",
+					},
+					Spec: globalnetworkingv1.ResourceRecordSetSpec{
+						Name:       "host.zone1.gdc.sap.corp.",
+						Type:       "A",
+						TTLSeconds: &ttlVal,
+						RRData:     []string{"1.2.3.4", "5.6.7.8"},
+					},
+				},
+			},
+			queryName:  "host.zone1.gdc.sap.corp",
+			queryType:  dns.TypeA,
+			expectedRS: dns.NewRecordSet(dns.TypeA, 300, []*dns.Record{{Value: "1.2.3.4"}, {Value: "5.6.7.8"}}),
+		},
+		{
+			name: "resolve TXT record with surrounding quotes",
+			existingRecords: []runtime.Object{
+				&globalnetworkingv1.ResourceRecordSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      dnsconst.GetDNSRecordSetName("TXT", "txt.zone1.gdc.sap.corp"),
+						Namespace: "my-project",
+					},
+					Spec: globalnetworkingv1.ResourceRecordSetSpec{
+						Name:       "txt.zone1.gdc.sap.corp.",
+						Type:       "TXT",
+						TTLSeconds: &ttlVal,
+						RRData:     []string{`"sample-text"`},
+					},
+				},
+			},
+			queryName:  "txt.zone1.gdc.sap.corp",
+			queryType:  dns.TypeTXT,
+			expectedRS: dns.NewRecordSet(dns.TypeTXT, 300, []*dns.Record{{Value: "sample-text"}}),
+		},
+		{
+			name:            "record not found",
+			existingRecords: []runtime.Object{},
+			queryName:       "missing.zone1.gdc.sap.corp",
+			queryType:       dns.TypeA,
+			expectedRS:      nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			scheme := runtime.NewScheme()
+			_ = globalnetworkingv1.AddToScheme(scheme)
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(tc.existingRecords...).Build()
+			h := &handler{
+				project: "my-project",
+				client:  fakeClient,
+				config: provider.DNSHandlerConfig{
+					Log:         log.Log,
+					Metrics:     &noopMetrics{},
+					RateLimiter: flowcontrol.NewFakeAlwaysRateLimiter(),
+				},
+			}
+			ctx := context.Background()
+			zoneInfo := dns.NewZoneInfo(dns.NewZoneID("gdch-dns", "my-project/my-zone-1"), "zone1.gdc.sap.corp.", false, "my-zone-1")
+			setName := dns.DNSSetName{DNSName: tc.queryName}
+
+			// Action
+			rs, err := h.queryDNS(ctx, zoneInfo, setName, tc.queryType)
+
+			// Assert
+			if err != nil {
+				t.Fatalf("unexpected error querying dns: %v", err)
+			}
+			if diff := cmp.Diff(tc.expectedRS, rs, cmp.AllowUnexported(dns.RecordSet{})); diff != "" {
+				t.Errorf("queryDNS mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestExecuteRequests(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = globalnetworkingv1.AddToScheme(scheme)
+
+	tests := []struct {
+		name            string
+		existingRecords []runtime.Object
+		requests        provider.ChangeRequests
+		expectedSpec    *globalnetworkingv1.ResourceRecordSetSpec
+		expectDeleted   bool
+		expectErr       bool
+	}{
+		{
+			name:            "create new record set",
+			existingRecords: []runtime.Object{},
+			requests: provider.ChangeRequests{
+				Name: dns.DNSSetName{DNSName: "new-host.zone1.gdc.sap.corp"},
+				Updates: map[dns.RecordType]*provider.ChangeRequestUpdate{
+					dns.TypeA: {
+						Old: nil,
+						New: dns.NewRecordSet(dns.TypeA, 300, []*dns.Record{{Value: "10.0.0.1"}}),
+					},
+				},
+			},
+			expectedSpec: &globalnetworkingv1.ResourceRecordSetSpec{
+				Name:       "new-host.zone1.gdc.sap.corp",
+				Type:       "A",
+				TTLSeconds: func() *uint32 { v := uint32(300); return &v }(),
+				RRData:     []string{"10.0.0.1"},
+				DNSZone:    "my-zone-1",
+			},
+			expectDeleted: false,
+			expectErr:     false,
+		},
+		{
+			name: "update existing record set",
+			existingRecords: []runtime.Object{
+				&globalnetworkingv1.ResourceRecordSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      dnsconst.GetDNSRecordSetName("A", "host.zone1.gdc.sap.corp"),
+						Namespace: "my-project",
+					},
+					Spec: globalnetworkingv1.ResourceRecordSetSpec{
+						Name:       "host.zone1.gdc.sap.corp.",
+						Type:       "A",
+						TTLSeconds: func() *uint32 { v := uint32(300); return &v }(),
+						RRData:     []string{"1.2.3.4"},
+						DNSZone:    "my-zone-1",
+					},
+				},
+			},
+			requests: provider.ChangeRequests{
+				Name: dns.DNSSetName{DNSName: "host.zone1.gdc.sap.corp"},
+				Updates: map[dns.RecordType]*provider.ChangeRequestUpdate{
+					dns.TypeA: {
+						Old: dns.NewRecordSet(dns.TypeA, 300, []*dns.Record{{Value: "1.2.3.4"}}),
+						New: dns.NewRecordSet(dns.TypeA, 600, []*dns.Record{{Value: "5.6.7.8"}, {Value: "9.10.11.12"}}),
+					},
+				},
+			},
+			expectedSpec: &globalnetworkingv1.ResourceRecordSetSpec{
+				Name:       "host.zone1.gdc.sap.corp",
+				Type:       "A",
+				TTLSeconds: func() *uint32 { v := uint32(600); return &v }(),
+				RRData:     []string{"5.6.7.8", "9.10.11.12"},
+				DNSZone:    "my-zone-1",
+			},
+			expectDeleted: false,
+			expectErr:     false,
+		},
+		{
+			name: "delete existing record set",
+			existingRecords: []runtime.Object{
+				&globalnetworkingv1.ResourceRecordSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      dnsconst.GetDNSRecordSetName("A", "host.zone1.gdc.sap.corp"),
+						Namespace: "my-project",
+					},
+					Spec: globalnetworkingv1.ResourceRecordSetSpec{
+						Name:       "host.zone1.gdc.sap.corp.",
+						Type:       "A",
+						TTLSeconds: func() *uint32 { v := uint32(300); return &v }(),
+						RRData:     []string{"1.2.3.4"},
+						DNSZone:    "my-zone-1",
+					},
+				},
+			},
+			requests: provider.ChangeRequests{
+				Name: dns.DNSSetName{DNSName: "host.zone1.gdc.sap.corp"},
+				Updates: map[dns.RecordType]*provider.ChangeRequestUpdate{
+					dns.TypeA: {
+						Old: dns.NewRecordSet(dns.TypeA, 300, []*dns.Record{{Value: "1.2.3.4"}}),
+						New: nil,
+					},
+				},
+			},
+			expectedSpec:  nil,
+			expectDeleted: true,
+			expectErr:     false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(tc.existingRecords...).Build()
+			h := &handler{
+				project: "my-project",
+				client:  fakeClient,
+				config: provider.DNSHandlerConfig{
+					Log:         log.Log,
+					Metrics:     &noopMetrics{},
+					RateLimiter: flowcontrol.NewFakeAlwaysRateLimiter(),
+				},
+			}
+			ctx := context.Background()
+			hostedZone := provider.NewDNSHostedZone("gdch-dns", "my-project/my-zone-1", "zone1.gdc.sap.corp.", "my-zone-1", false)
+
+			// Action
+			err := h.ExecuteRequests(ctx, hostedZone, tc.requests)
+
+			// Assert
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("expected an error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			recordList := &globalnetworkingv1.ResourceRecordSetList{}
+			if err := fakeClient.List(ctx, recordList, client.InNamespace("my-project")); err != nil {
+				t.Fatalf("failed to list ResourceRecordSets: %v", err)
+			}
+
+			var actualSpecs []globalnetworkingv1.ResourceRecordSetSpec
+			for _, item := range recordList.Items {
+				actualSpecs = append(actualSpecs, item.Spec)
+			}
+
+			var expectedSpecs []globalnetworkingv1.ResourceRecordSetSpec
+			if tc.expectedSpec != nil {
+				expectedSpecs = append(expectedSpecs, *tc.expectedSpec)
+			}
+
+			if diff := cmp.Diff(expectedSpecs, actualSpecs); diff != "" {
+				t.Errorf("ResourceRecordSets state mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetCustomQueryDNSFunc(t *testing.T) {
+	// Arrange
+	scheme := runtime.NewScheme()
+	_ = globalnetworkingv1.AddToScheme(scheme)
+	ttlVal := uint32(300)
+	recordSet := &globalnetworkingv1.ResourceRecordSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dnsconst.GetDNSRecordSetName("A", "host.zone1.gdc.sap.corp"),
+			Namespace: "my-project",
+		},
+		Spec: globalnetworkingv1.ResourceRecordSetSpec{
+			Name:       "host.zone1.gdc.sap.corp.",
+			Type:       "A",
+			TTLSeconds: &ttlVal,
+			RRData:     []string{"1.2.3.4"},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(recordSet).Build()
+	h := &handler{
+		project: "my-project",
+		client:  fakeClient,
+		config: provider.DNSHandlerConfig{
+			Log:         log.Log,
+			Metrics:     &noopMetrics{},
+			RateLimiter: flowcontrol.NewFakeAlwaysRateLimiter(),
+		},
+	}
+	zoneInfo := dns.NewZoneInfo(dns.NewZoneID("gdch-dns", "my-project/my-zone-1"), "zone1.gdc.sap.corp.", false, "my-zone-1")
+
+	// Action
+	queryFn, err := h.GetCustomQueryDNSFunc(zoneInfo, nil)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("unexpected error getting query function: %v", err)
+	}
+
+	ctx := context.Background()
+	setName := dns.DNSSetName{DNSName: "host.zone1.gdc.sap.corp"}
+	rs, err := queryFn(ctx, zoneInfo, setName, dns.TypeA)
+	if err != nil {
+		t.Fatalf("unexpected error running query function: %v", err)
+	}
+
+	expected := dns.NewRecordSet(dns.TypeA, 300, []*dns.Record{{Value: "1.2.3.4"}})
+	if diff := cmp.Diff(expected, rs, cmp.AllowUnexported(dns.RecordSet{})); diff != "" {
+		t.Errorf("custom resolver result mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/pkg/dnsman2/dns/provider/handler/providertypes.go
+++ b/pkg/dnsman2/dns/provider/handler/providertypes.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/handler/azure"
 	azureprivate "github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/handler/azure-private"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/handler/cloudflare"
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/handler/gdc"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/handler/google"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/handler/local"
 	"github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/handler/netlify"
@@ -30,6 +31,7 @@ var allProviderTypes = map[string]provider.AddToRegistryFunc{
 	azure.ProviderType:        azure.RegisterTo,
 	azureprivate.ProviderType: azureprivate.RegisterTo,
 	cloudflare.ProviderType:   cloudflare.RegisterTo,
+	gdc.ProviderType:          gdc.RegisterTo,
 	google.ProviderType:       google.RegisterTo,
 	local.ProviderType:        local.RegisterTo,
 	netlify.ProviderType:      netlify.RegisterTo,


### PR DESCRIPTION
- Add pkg/controller/provider/gdc/client with authentication (JWT signing, STS token exchange) and org cluster client
- Add pkg/controller/provider/gdc for legacy compound controller
- Add pkg/dnsman2/dns/provider/handler/gdc for dnsman2 controller
- Register GDC provider in compound and dnsman2 controller registries
- Add example manifests and documentation in docs/gdc-dns/README.md

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/kind enhancement

**What this PR does / why we need it**:
This PR introduces support for **Google Distributed Cloud (GDC) air-gapped** as a DNS provider (`gdch-dns`) in `external-dns-management`.

Key changes:
- **Authentication & Client (`pkg/controller/provider/gdc/client`)**: Implements JWT signing and STS token exchange to authenticate against GDC organization clusters and manage `ManagedDNSZone` / `ResourceRecordSet` custom resources.
- **Legacy Compound Controller (`pkg/controller/provider/gdc`)**: Implements handler and execution logic for compound controller deployments.
- **DNSMan2 Controller (`pkg/dnsman2/dns/provider/handler/gdc`)**: Implements handler and factory for the dnsman2 controller architecture.
- **Provider Registrations**: Registers the `gdch-dns` provider type in both controller registries.
- **Documentation & Examples**: Adds sample manifests and usage guide in `docs/gdc-dns/README.md` and `examples/`.
- **Tests**: Comprehensive unit tests for JWT signing, STS exchange, DNS name mapping, and provider handlers.

**Which issue(s) this PR fixes**:
Fixes # N/A

**Special notes for your reviewer**:
- Provider type identifier is `gdch-dns`.
- Credentials require a Kubernetes secret containing `serviceaccount.json` (GDC service account credential) and `gdch-config` (cluster URL and CA data).

**Release note**:
```feature operator
Add Google Distributed Cloud (GDC) air-gapped DNS provider (`gdch-dns`) support.
