### PR TITLE
[dnsman-ng] Fix duplicate `CNAME` records by filtering answer section to queried name

### DIFF
--- a/pkg/dnsman2/dns/utils/dnsquery.go
+++ b/pkg/dnsman2/dns/utils/dnsquery.go
@@ -143,7 +143,10 @@ func (q *standardQueryDNS) Query(ctx context.Context, setName dns.DNSSetName, rs
 			if !ok {
 				return QueryDNSResult{Err: fmt.Errorf("unexpected record type %T (CNAME)", rr)}
 			}
-			addRecord(dns.NormalizeDomainName(r.Target), r.Hdr.Ttl)
+			// Recursive resolvers return the full CNAME chain; only keep the record for the queried name.
+			if rr.Header().Name == ToFQDN(setName.DNSName) {
+				addRecord(dns.NormalizeDomainName(r.Target), r.Hdr.Ttl)
+			}
 		default:
 			return QueryDNSResult{Err: fmt.Errorf("unsupported record type %s in DNS response", rstype)}
 		}


### PR DESCRIPTION

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Fix duplicate `CNAME` records by filtering answer section to queried name.

When a recursive resolver follows a CNAME chain, `msg.Answer` of the DNS query contains
all CNAMEs in the chain. Only add the record whose name matches the
queried FQDN to avoid returning the full chain as duplicates.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
[dnsman-ng] Fix duplicate `CNAME` records by filtering answer section to queried name if recursive resolver is queried.
```
