### PR TITLE
Document Google Distributed Cloud air-gapped DNS provider in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ It contains provisioning controllers for creating DNS records in one of the DNS 
   - [_remote_](docs/remote/README.md),
   - [_DNS servers supporting RFC 2136 (DNS Update)_](docs/rfc2136/README.md) *(alpha - not recommended for productive usage)*,
   - [_powerdns_](docs/powerdns/README.md),
+  - [_Google Distributed Cloud air-gapped DNS_](docs/gdc-dns/README.md),
 
 and source controllers for services and ingresses to create DNS entries by annotations.
 
@@ -550,6 +551,7 @@ The following provider types can be selected (comma separated):
 - `netlify-dns`: Netlify DNS provider
 - `remote`: Remote DNS provider (a dns-controller-manager with enabled remote access service)
 - `powerdns`: PowerDNS provider
+- `gdch-dns`: Google Distributed Cloud air-gapped DNS provider
 
 Here is the complete list of options provided:
 
@@ -642,6 +644,12 @@ Flags:
       --compound.entry-failure-backoff-base duration                  base delay for the exponential backoff applied to persistently failing entries before they trigger a hosted zone reconciliation again of controller compound
       --compound.entry-failure-backoff-factor int                     multiplier applied per consecutive failure for the entry failure backoff of controller compound
       --compound.entry-failure-backoff-max duration                   maximum delay for the entry failure backoff of controller compound
+      --compound.gdch-dns.advanced.batch-size int                     batch size for change requests (currently only used for aws-route53) of controller compound
+      --compound.gdch-dns.advanced.max-retries int                    maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53) of controller compound
+      --compound.gdch-dns.blocked-zone zone-id                        Blocks a zone given in the format zone-id from a provider as if the zone is not existing. of controller compound
+      --compound.gdch-dns.ratelimiter.burst int                       number of burst requests for rate limiter of controller compound
+      --compound.gdch-dns.ratelimiter.enabled                         enables rate limiter for DNS provider requests of controller compound
+      --compound.gdch-dns.ratelimiter.qps int                         maximum requests/queries per second of controller compound
       --compound.google-clouddns.advanced.batch-size int              batch size for change requests (currently only used for aws-route53) of controller compound
       --compound.google-clouddns.advanced.max-retries int             maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53) of controller compound
       --compound.google-clouddns.blocked-zone zone-id                 Blocks a zone given in the format zone-id from a provider as if the zone is not existing. of controller compound
@@ -754,6 +762,12 @@ Flags:
       --entry-failure-backoff-max duration                            maximum delay for the entry failure backoff
       --exclude-domains stringArray                                   excluded domains
       --force-crd-update                                              enforce update of crds even they are unmanaged
+      --gdch-dns.advanced.batch-size int                              batch size for change requests (currently only used for aws-route53)
+      --gdch-dns.advanced.max-retries int                             maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53)
+      --gdch-dns.blocked-zone zone-id                                 Blocks a zone given in the format zone-id from a provider as if the zone is not existing.
+      --gdch-dns.ratelimiter.burst int                                number of burst requests for rate limiter
+      --gdch-dns.ratelimiter.enabled                                  enables rate limiter for DNS provider requests
+      --gdch-dns.ratelimiter.qps int                                  maximum requests/queries per second
       --google-clouddns.advanced.batch-size int                       batch size for change requests (currently only used for aws-route53)
       --google-clouddns.advanced.max-retries int                      maximum number of retries to avoid paging stops on throttling (currently only used for aws-route53)
       --google-clouddns.blocked-zone zone-id                          Blocks a zone given in the format zone-id from a provider as if the zone is not existing.

--- a/docs/gdc-dns/README.md
+++ b/docs/gdc-dns/README.md
@@ -1,6 +1,6 @@
-# Google Distributed Cloud (GDC) air-gapped DNS Provider
+# Google Distributed Cloud air-gapped DNS Provider
 
-This DNS provider allows you to create and manage DNS entries in Google Distributed Cloud (GDC) air-gapped Managed DNS zones.
+This DNS provider allows you to create and manage DNS entries in Google Distributed Cloud air-gapped Managed DNS zones.
 
 ## Overview
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
This PR updates `README.md` to document the recently added Google Distributed Cloud air-gapped DNS provider (`gdch-dns`, introduced in #1043):
- Added `Google Distributed Cloud air-gapped DNS` to the list of provisioning controllers linking to `docs/gdc-dns/README.md`.
- Added `gdch-dns: Google Distributed Cloud air-gapped DNS provider` to the list of selectable `--provider-types`.
- Added the generated `--compound.gdch-dns.*` and `--gdch-dns.*` CLI flags in alphabetical order to the options list.
- Standardized product naming in `docs/gdc-dns/README.md` to `Google Distributed Cloud air-gapped`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Follow-up to #1043.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc operator
Document Google Distributed Cloud air-gapped DNS provider (`gdch-dns`) in README.md.
