### PR TITLE
[dnsman-ng] Improve robustness for CNAME chain filtering; add regression test

### DIFF
--- a/pkg/dnsman2/dns/utils/dnsquery.go
+++ b/pkg/dnsman2/dns/utils/dnsquery.go
@@ -144,7 +144,7 @@ func (q *standardQueryDNS) Query(ctx context.Context, setName dns.DNSSetName, rs
 				return QueryDNSResult{Err: fmt.Errorf("unexpected record type %T (CNAME)", rr)}
 			}
 			// Recursive resolvers return the full CNAME chain; only keep the record for the queried name.
-			if rr.Header().Name == ToFQDN(setName.DNSName) {
+			if dns.NormalizeDomainName(rr.Header().Name) == dns.NormalizeDomainName(setName.DNSName) {
 				addRecord(dns.NormalizeDomainName(r.Target), r.Hdr.Ttl)
 			}
 		default:

--- a/pkg/dnsman2/dns/utils/dnsquery_test.go
+++ b/pkg/dnsman2/dns/utils/dnsquery_test.go
@@ -244,5 +244,16 @@ var _ = Describe("QueryDNS with mocked DNS responses", func() {
 			Not(HaveOccurred()),
 			ConsistOf(&dns.Record{Value: "1.2.3.4"}, &dns.Record{Value: "5.6.7.8"}),
 		),
+		Entry("CNAME query with full chain keeps only the record for the queried name",
+			dns.TypeCNAME,
+			[]miekgdns.RR{
+				cnameRR("example.com.", "alias1.example.net.", 60),
+				cnameRR("alias1.example.net.", "alias2.example.net.", 60),
+				cnameRR("alias2.example.net.", "target.example.org.", 60),
+			},
+			miekgdns.RcodeSuccess,
+			Not(HaveOccurred()),
+			ConsistOf(&dns.Record{Value: "alias1.example.net"}),
+		),
 	)
 })


### PR DESCRIPTION


<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind task

**What this PR does / why we need it**:
Recursive resolvers return the full CNAME chain; the code keeps only the record for the queried name. To improve robustness, compare header name and queried name via NormalizeDomainName so the match is case- and trailing-dot-insensitive, matching how DNS names are compared elsewhere.

Add a regression test covering a full CNAME chain response.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Follow-up of #1055 

Addresses https://github.com/gardener/external-dns-management/pull/1055#pullrequestreview-5079429111

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
