### PR TITLE
Isolate failing changes in AWS Route53 batches via bisection

### DIFF
--- a/pkg/controller/provider/aws/aws_suite_test.go
+++ b/pkg/controller/provider/aws/aws_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Contributors to the Gardener project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestAWS(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AWS Provider Suite")
+}

--- a/pkg/controller/provider/aws/execution.go
+++ b/pkg/controller/provider/aws/execution.go
@@ -38,6 +38,7 @@ type changeRecordsAPI interface {
 
 type Execution struct {
 	logger.LogContext
+	metrics       provider.Metrics
 	r53           changeRecordsAPI
 	policyContext *routingPolicyContext
 	rateLimiter   flowcontrol.RateLimiter
@@ -50,6 +51,7 @@ type Execution struct {
 func NewExecution(logger logger.LogContext, h *Handler, zone provider.DNSHostedZone) *Execution {
 	return &Execution{
 		LogContext:    logger,
+		metrics:       h.config.Metrics,
 		r53:           &h.r53,
 		policyContext: h.policyContext,
 		rateLimiter:   h.config.RateLimiter,
@@ -109,7 +111,7 @@ func (this *Execution) addRawChange(name dns.DNSSetName, updateGroup string, cha
 	this.changes[name] = append(this.changes[name], &Change{Change: change, Done: done, UpdateGroup: updateGroup})
 }
 
-func (this *Execution) submitChanges(ctx context.Context, metrics provider.Metrics) error {
+func (this *Execution) submitChanges(ctx context.Context) error {
 	if len(this.changes) == 0 {
 		return nil
 	}
@@ -136,7 +138,7 @@ func (this *Execution) submitChanges(ctx context.Context, metrics provider.Metri
 			},
 		}
 
-		metrics.AddZoneRequests(this.zone.Id().ID, provider.M_UPDATERECORDS, 1)
+		this.metrics.AddZoneRequests(this.zone.Id().ID, provider.M_UPDATERECORDS, 1)
 		this.rateLimiter.Accept()
 		var succeededChanges, failedChanges []*Change
 		_, err := this.r53.ChangeResourceRecordSets(ctx, params)
@@ -176,7 +178,7 @@ func (this *Execution) submitChanges(ctx context.Context, metrics provider.Metri
 					c.Done.Failed(stableError(err))
 				}
 			}
-			this.Errorf("%d records in zone %s fail: %s", len(changes), this.zone.Id(), err)
+			this.Errorf("%d records in zone %s fail: %s", len(failedChanges), this.zone.Id(), err)
 		}
 		if len(succeededChanges) > 0 {
 			successCount += len(succeededChanges)
@@ -264,6 +266,7 @@ func (this *Execution) submitBisected(ctx context.Context, changes []*Change) (s
 			Changes: mapChanges(changes),
 		},
 	}
+	this.metrics.AddZoneRequests(this.zone.Id().ID, provider.M_UPDATERECORDS, 1)
 	this.rateLimiter.Accept()
 	if _, callErr := this.r53.ChangeResourceRecordSets(ctx, params); callErr == nil {
 		return changes, nil, nil

--- a/pkg/controller/provider/aws/execution.go
+++ b/pkg/controller/provider/aws/execution.go
@@ -145,18 +145,12 @@ func (this *Execution) submitChanges(ctx context.Context) error {
 		if err != nil {
 			failedChanges = changes
 			handled := false
-			throttling := false
+			throttling := isThrottlingError(err)
 			var apiError smithy.APIError
-			if errors.As(err, &apiError) {
-				switch v := apiError.(type) {
-				case *route53types.InvalidChangeBatch:
+			if !throttling && errors.As(err, &apiError) {
+				if v, ok := apiError.(*route53types.InvalidChangeBatch); ok {
 					succeededChanges, failedChanges, err = this.tryFixChanges(ctx, v.ErrorMessage(), changes)
 					handled = true // tryFixChanges already bisects its unclear remainder
-				default:
-					if v.ErrorCode() == "Throttling" {
-						throttling = true
-						throttlingErrCount++
-					}
 				}
 			}
 			// For non-throttling errors that were not already handled as an InvalidChangeBatch,
@@ -167,6 +161,12 @@ func (this *Execution) submitChanges(ctx context.Context) error {
 				var additionalSucceededChanges []*Change
 				additionalSucceededChanges, failedChanges, err = this.submitBisected(ctx, failedChanges)
 				succeededChanges = append(succeededChanges, additionalSucceededChanges...)
+			}
+			// Count the batch as throttled if the initial call throttled or if
+			// throttling surfaced later while bisecting (submitBisected/tryFixChanges
+			// propagate the throttling error instead of splitting further).
+			if len(failedChanges) > 0 && isThrottlingError(err) {
+				throttlingErrCount++
 			}
 		} else {
 			succeededChanges = changes
@@ -270,8 +270,14 @@ func (this *Execution) submitBisected(ctx context.Context, changes []*Change) (s
 	this.rateLimiter.Accept()
 	if _, callErr := this.r53.ChangeResourceRecordSets(ctx, params); callErr == nil {
 		return changes, nil, nil
+	} else if isThrottlingError(callErr) {
+		// Throttling is not evidence that any change is bad. Stop bisecting:
+		// splitting further would only amplify load on an already-throttling
+		// API, and blaming a leaf would wrongly mark a valid change as failed.
+		// Fail the whole sub-batch so it is retried later as a unit.
+		return nil, changes, callErr
 	} else if len(changes) == 1 {
-		// A single change still fails: it is the bad one.
+		// A single change still fails with a non-throttling error: it is the bad one.
 		return nil, changes, callErr
 	}
 
@@ -314,6 +320,15 @@ func (this *Execution) isFetchedRecordSetEqual(ctx context.Context, change *Chan
 		}
 	}
 	return true
+}
+
+// isThrottlingError reports whether err is a Route53 throttling error.
+func isThrottlingError(err error) bool {
+	var apiError smithy.APIError
+	if errors.As(err, &apiError) {
+		return apiError.ErrorCode() == "Throttling"
+	}
+	return false
 }
 
 func safeCompareInt64(a, b *int64) bool {

--- a/pkg/controller/provider/aws/execution.go
+++ b/pkg/controller/provider/aws/execution.go
@@ -275,8 +275,12 @@ func (this *Execution) submitBisected(ctx context.Context, changes []*Change) (s
 	mid := len(changes) / 2
 	s1, f1, err1 := this.submitBisected(ctx, changes[:mid])
 	s2, f2, err2 := this.submitBisected(ctx, changes[mid:])
-	succeeded = append(s1, s2...)
-	failed = append(f1, f2...)
+	// Build fresh slices: s1/f1 may alias the backing array of changes[:mid],
+	// so append(s1, s2...) could overwrite changes[mid] (and thus corrupt f2).
+	succeeded = append(succeeded, s1...)
+	succeeded = append(succeeded, s2...)
+	failed = append(failed, f1...)
+	failed = append(failed, f2...)
 	// Prefer a leaf (single-change) error so the message names a real cause.
 	err = err1
 	if err == nil {

--- a/pkg/controller/provider/aws/execution.go
+++ b/pkg/controller/provider/aws/execution.go
@@ -28,9 +28,17 @@ type Change struct {
 	UpdateGroup string
 }
 
+// changeRecordsAPI is the narrow subset of the Route53 client used by Execution.
+// It exists so the batching logic (submitChanges/tryFixChanges/submitBisected)
+// can be exercised with a fake in tests. *route53.Client satisfies it.
+type changeRecordsAPI interface {
+	ChangeResourceRecordSets(ctx context.Context, params *route53.ChangeResourceRecordSetsInput, optFns ...func(*route53.Options)) (*route53.ChangeResourceRecordSetsOutput, error)
+	ListResourceRecordSets(ctx context.Context, params *route53.ListResourceRecordSetsInput, optFns ...func(*route53.Options)) (*route53.ListResourceRecordSetsOutput, error)
+}
+
 type Execution struct {
 	logger.LogContext
-	r53           route53.Client
+	r53           changeRecordsAPI
 	policyContext *routingPolicyContext
 	rateLimiter   flowcontrol.RateLimiter
 	zone          provider.DNSHostedZone
@@ -42,7 +50,7 @@ type Execution struct {
 func NewExecution(logger logger.LogContext, h *Handler, zone provider.DNSHostedZone) *Execution {
 	return &Execution{
 		LogContext:    logger,
-		r53:           h.r53,
+		r53:           &h.r53,
 		policyContext: h.policyContext,
 		rateLimiter:   h.config.RateLimiter,
 		zone:          zone,
@@ -134,16 +142,29 @@ func (this *Execution) submitChanges(ctx context.Context, metrics provider.Metri
 		_, err := this.r53.ChangeResourceRecordSets(ctx, params)
 		if err != nil {
 			failedChanges = changes
+			handled := false
+			throttling := false
 			var apiError smithy.APIError
 			if errors.As(err, &apiError) {
 				switch v := apiError.(type) {
 				case *route53types.InvalidChangeBatch:
 					succeededChanges, failedChanges, err = this.tryFixChanges(ctx, v.ErrorMessage(), changes)
+					handled = true // tryFixChanges already bisects its unclear remainder
 				default:
 					if v.ErrorCode() == "Throttling" {
+						throttling = true
 						throttlingErrCount++
 					}
 				}
+			}
+			// For non-throttling errors that were not already handled as an InvalidChangeBatch,
+			// bisect the batch so a single bad change does not fail its valid batch-mates.
+			// Throttling errors are left as a whole-batch failure to be retried later;
+			// bisecting them would not help and would only multiply the load.
+			if !handled && !throttling && len(failedChanges) > 1 {
+				var additionalSucceededChanges []*Change
+				additionalSucceededChanges, failedChanges, err = this.submitBisected(ctx, failedChanges)
+				succeededChanges = append(succeededChanges, additionalSucceededChanges...)
 			}
 		} else {
 			succeededChanges = changes
@@ -217,18 +238,49 @@ outer:
 	}
 
 	if len(unclear) > 0 {
-		params := &route53.ChangeResourceRecordSetsInput{
-			HostedZoneId: aws.String(this.zone.Id().ID),
-			ChangeBatch: &route53types.ChangeBatch{
-				Changes: mapChanges(unclear),
-			},
+		s, f, ferr := this.submitBisected(ctx, unclear)
+		succeeded = append(succeeded, s...)
+		failed = append(failed, f...)
+		if ferr != nil {
+			err = ferr
 		}
-		_, err = this.r53.ChangeResourceRecordSets(ctx, params)
-		if err != nil {
-			failed = append(failed, unclear...)
-		} else {
-			succeeded = append(succeeded, unclear...)
-		}
+	}
+	return
+}
+
+// submitBisected submits the given changes as one batch. On rejection it splits
+// the batch in half and retries each half recursively, so a single bad change
+// only fails itself instead of its valid batch-mates. It returns the changes
+// that were successfully applied, the ones that could not be applied, and the
+// error from the smallest failing batch (nil if all changes succeeded).
+func (this *Execution) submitBisected(ctx context.Context, changes []*Change) (succeeded, failed []*Change, err error) {
+	if len(changes) == 0 {
+		return nil, nil, nil
+	}
+
+	params := &route53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String(this.zone.Id().ID),
+		ChangeBatch: &route53types.ChangeBatch{
+			Changes: mapChanges(changes),
+		},
+	}
+	this.rateLimiter.Accept()
+	if _, callErr := this.r53.ChangeResourceRecordSets(ctx, params); callErr == nil {
+		return changes, nil, nil
+	} else if len(changes) == 1 {
+		// A single change still fails: it is the bad one.
+		return nil, changes, callErr
+	}
+
+	mid := len(changes) / 2
+	s1, f1, err1 := this.submitBisected(ctx, changes[:mid])
+	s2, f2, err2 := this.submitBisected(ctx, changes[mid:])
+	succeeded = append(s1, s2...)
+	failed = append(f1, f2...)
+	// Prefer a leaf (single-change) error so the message names a real cause.
+	err = err1
+	if err == nil {
+		err = err2
 	}
 	return
 }

--- a/pkg/controller/provider/aws/execution_test.go
+++ b/pkg/controller/provider/aws/execution_test.go
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: Contributors to the Gardener project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"context"
+	"errors"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	route53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+	"github.com/aws/smithy-go"
+	"github.com/gardener/controller-manager-library/pkg/logger"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/util/flowcontrol"
+
+	"github.com/gardener/external-dns-management/pkg/dns"
+	"github.com/gardener/external-dns-management/pkg/dns/provider"
+	dnserrors "github.com/gardener/external-dns-management/pkg/dns/provider/errors"
+)
+
+// fakeChangeRecordsAPI is a controllable fake of changeRecordsAPI.
+type fakeChangeRecordsAPI struct {
+	changeFn    func(*route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error)
+	changeCalls []*route53.ChangeResourceRecordSetsInput
+}
+
+func (f *fakeChangeRecordsAPI) ChangeResourceRecordSets(_ context.Context, params *route53.ChangeResourceRecordSetsInput, _ ...func(*route53.Options)) (*route53.ChangeResourceRecordSetsOutput, error) {
+	f.changeCalls = append(f.changeCalls, params)
+	if f.changeFn == nil {
+		return &route53.ChangeResourceRecordSetsOutput{}, nil
+	}
+	return f.changeFn(params)
+}
+
+func (f *fakeChangeRecordsAPI) ListResourceRecordSets(_ context.Context, _ *route53.ListResourceRecordSetsInput, _ ...func(*route53.Options)) (*route53.ListResourceRecordSetsOutput, error) {
+	return &route53.ListResourceRecordSetsOutput{}, nil
+}
+
+// recordingDoneHandler records the terminal outcome reported for a change.
+type recordingDoneHandler struct {
+	succeeded bool
+	failed    bool
+	err       error
+}
+
+func (h *recordingDoneHandler) SetInvalid(_ error) {}
+func (h *recordingDoneHandler) Throttled()         {}
+func (h *recordingDoneHandler) Failed(err error)   { h.failed = true; h.err = err }
+func (h *recordingDoneHandler) Succeeded()         { h.succeeded = true }
+
+// upsertChange builds an A-record upsert change with the given name/value and done handler.
+func upsertChange(name, value string, done provider.DoneHandler) *Change {
+	rrs := &route53types.ResourceRecordSet{
+		Name:            aws.String(name),
+		Type:            route53types.RRTypeA,
+		TTL:             aws.Int64(60),
+		ResourceRecords: []route53types.ResourceRecord{{Value: aws.String(value)}},
+	}
+	return &Change{
+		Change: &route53types.Change{Action: route53types.ChangeActionUpsert, ResourceRecordSet: rrs},
+		Done:   done,
+	}
+}
+
+func newTestExecution(api changeRecordsAPI) *Execution {
+	zone := provider.NewDNSHostedZone(TYPE_CODE, "Z1", "example.org", "/hostedzone/Z1", false)
+	return &Execution{
+		LogContext:  logger.New(),
+		r53:         api,
+		rateLimiter: flowcontrol.NewFakeAlwaysRateLimiter(),
+		zone:        zone,
+		changes:     map[dns.DNSSetName][]*Change{},
+		batchSize:   16,
+	}
+}
+
+var _ = Describe("Execution submitChanges", func() {
+	var (
+		ctx     context.Context
+		metrics = &provider.NullMetrics{}
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	It("bisects a rejected batch so only the bad change fails", func() {
+		fake := &fakeChangeRecordsAPI{
+			changeFn: func(params *route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error) {
+				for _, c := range params.ChangeBatch.Changes {
+					for _, rr := range c.ResourceRecordSet.ResourceRecords {
+						if aws.ToString(rr.Value) == "bad" {
+							return nil, errors.New("server error")
+						}
+					}
+				}
+				return &route53.ChangeResourceRecordSetsOutput{}, nil
+			},
+		}
+		goodDone := &recordingDoneHandler{}
+		good2Done := &recordingDoneHandler{}
+		badDone := &recordingDoneHandler{}
+		exec := newTestExecution(fake)
+		exec.changes[dns.DNSSetName{DNSName: "good.example.org"}] = []*Change{upsertChange("good.example.org", "1.2.3.4", goodDone)}
+		exec.changes[dns.DNSSetName{DNSName: "good2.example.org"}] = []*Change{upsertChange("good2.example.org", "1.2.3.4", good2Done)}
+		exec.changes[dns.DNSSetName{DNSName: "bad.example.org"}] = []*Change{upsertChange("bad.example.org", "bad", badDone)}
+
+		err := exec.submitChanges(ctx, metrics)
+		Expect(err).To(MatchError(ContainSubstring("1 changes failed")))
+
+		// The valid change was applied and reported success; only the bad one failed.
+		Expect(goodDone.succeeded).To(BeTrue())
+		Expect(goodDone.failed).To(BeFalse())
+		Expect(good2Done.succeeded).To(BeTrue())
+		Expect(good2Done.failed).To(BeFalse())
+		Expect(badDone.failed).To(BeTrue())
+		Expect(badDone.succeeded).To(BeFalse())
+	})
+
+	It("does not bisect a fully valid multi-change batch", func() {
+		fake := &fakeChangeRecordsAPI{}
+		d1 := &recordingDoneHandler{}
+		d2 := &recordingDoneHandler{}
+		exec := newTestExecution(fake)
+		exec.changes[dns.DNSSetName{DNSName: "a.example.org"}] = []*Change{upsertChange("a.example.org", "1.2.3.4", d1)}
+		exec.changes[dns.DNSSetName{DNSName: "b.example.org"}] = []*Change{upsertChange("b.example.org", "1.2.3.5", d2)}
+
+		Expect(exec.submitChanges(ctx, metrics)).To(Succeed())
+		// One batch call, no splitting on the happy path.
+		Expect(fake.changeCalls).To(HaveLen(1))
+		Expect(fake.changeCalls[0].ChangeBatch.Changes).To(HaveLen(2))
+		Expect(d1.succeeded).To(BeTrue())
+		Expect(d2.succeeded).To(BeTrue())
+	})
+
+	It("does not bisect a throttled batch", func() {
+		fake := &fakeChangeRecordsAPI{
+			changeFn: func(_ *route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error) {
+				return nil, &smithy.GenericAPIError{Code: "Throttling", Message: "Rate exceeded"}
+			},
+		}
+		d1 := &recordingDoneHandler{}
+		d2 := &recordingDoneHandler{}
+		exec := newTestExecution(fake)
+		exec.changes[dns.DNSSetName{DNSName: "a.example.org"}] = []*Change{upsertChange("a.example.org", "1.2.3.4", d1)}
+		exec.changes[dns.DNSSetName{DNSName: "b.example.org"}] = []*Change{upsertChange("b.example.org", "1.2.3.5", d2)}
+
+		err := exec.submitChanges(ctx, metrics)
+		Expect(err).To(HaveOccurred())
+		// Both changes were throttled, so this surfaces as an "all changes failed"
+		// error wrapping the throttling error; neither is bisected.
+		Expect(dnserrors.IsAllChangesFailedError(err)).To(BeTrue())
+		Expect(err).To(MatchError(ContainSubstring("Throttling")))
+		// The batch is retried as a whole, not bisected: exactly one attempt.
+		Expect(fake.changeCalls).To(HaveLen(1))
+	})
+})

--- a/pkg/controller/provider/aws/execution_test.go
+++ b/pkg/controller/provider/aws/execution_test.go
@@ -70,6 +70,7 @@ func newTestExecution(api changeRecordsAPI) *Execution {
 	zone := provider.NewDNSHostedZone(TYPE_CODE, "Z1", "example.org", "/hostedzone/Z1", false)
 	return &Execution{
 		LogContext:  logger.New(),
+		metrics:     &provider.NullMetrics{},
 		r53:         api,
 		rateLimiter: flowcontrol.NewFakeAlwaysRateLimiter(),
 		zone:        zone,
@@ -79,10 +80,7 @@ func newTestExecution(api changeRecordsAPI) *Execution {
 }
 
 var _ = Describe("Execution submitChanges", func() {
-	var (
-		ctx     context.Context
-		metrics = &provider.NullMetrics{}
-	)
+	var ctx context.Context
 
 	BeforeEach(func() {
 		ctx = context.Background()
@@ -109,7 +107,7 @@ var _ = Describe("Execution submitChanges", func() {
 		exec.changes[dns.DNSSetName{DNSName: "good2.example.org"}] = []*Change{upsertChange("good2.example.org", "1.2.3.4", good2Done)}
 		exec.changes[dns.DNSSetName{DNSName: "bad.example.org"}] = []*Change{upsertChange("bad.example.org", "bad", badDone)}
 
-		err := exec.submitChanges(ctx, metrics)
+		err := exec.submitChanges(ctx)
 		Expect(err).To(MatchError(ContainSubstring("1 changes failed")))
 
 		// The valid change was applied and reported success; only the bad one failed.
@@ -129,7 +127,7 @@ var _ = Describe("Execution submitChanges", func() {
 		exec.changes[dns.DNSSetName{DNSName: "a.example.org"}] = []*Change{upsertChange("a.example.org", "1.2.3.4", d1)}
 		exec.changes[dns.DNSSetName{DNSName: "b.example.org"}] = []*Change{upsertChange("b.example.org", "1.2.3.5", d2)}
 
-		Expect(exec.submitChanges(ctx, metrics)).To(Succeed())
+		Expect(exec.submitChanges(ctx)).To(Succeed())
 		// One batch call, no splitting on the happy path.
 		Expect(fake.changeCalls).To(HaveLen(1))
 		Expect(fake.changeCalls[0].ChangeBatch.Changes).To(HaveLen(2))
@@ -149,7 +147,7 @@ var _ = Describe("Execution submitChanges", func() {
 		exec.changes[dns.DNSSetName{DNSName: "a.example.org"}] = []*Change{upsertChange("a.example.org", "1.2.3.4", d1)}
 		exec.changes[dns.DNSSetName{DNSName: "b.example.org"}] = []*Change{upsertChange("b.example.org", "1.2.3.5", d2)}
 
-		err := exec.submitChanges(ctx, metrics)
+		err := exec.submitChanges(ctx)
 		Expect(err).To(HaveOccurred())
 		// Both changes were throttled, so this surfaces as an "all changes failed"
 		// error wrapping the throttling error; neither is bisected.

--- a/pkg/controller/provider/aws/execution_test.go
+++ b/pkg/controller/provider/aws/execution_test.go
@@ -156,4 +156,42 @@ var _ = Describe("Execution submitChanges", func() {
 		// The batch is retried as a whole, not bisected: exactly one attempt.
 		Expect(fake.changeCalls).To(HaveLen(1))
 	})
+
+	It("stops bisecting and does not blame a leaf when throttling surfaces mid-bisection", func() {
+		// The first (whole-batch) call fails with a non-throttling error, which
+		// forces bisection. As soon as bisection issues its first sub-batch call,
+		// the API starts throttling. The bisection must then stop splitting and
+		// fail the whole sub-batch rather than isolating a valid change as "bad".
+		call := 0
+		fake := &fakeChangeRecordsAPI{
+			changeFn: func(_ *route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error) {
+				call++
+				if call == 1 {
+					return nil, errors.New("server error")
+				}
+				return nil, &smithy.GenericAPIError{Code: "Throttling", Message: "Rate exceeded"}
+			},
+		}
+		d1 := &recordingDoneHandler{}
+		d2 := &recordingDoneHandler{}
+		exec := newTestExecution(fake)
+		exec.changes[dns.DNSSetName{DNSName: "a.example.org"}] = []*Change{upsertChange("a.example.org", "1.2.3.4", d1)}
+		exec.changes[dns.DNSSetName{DNSName: "b.example.org"}] = []*Change{upsertChange("b.example.org", "1.2.3.5", d2)}
+
+		err := exec.submitChanges(ctx)
+		Expect(err).To(HaveOccurred())
+		// The batch's final error is a throttle, so it is classified as throttling
+		// (all changes failed) rather than a partial bisection result.
+		Expect(dnserrors.IsAllChangesFailedError(err)).To(BeTrue())
+		Expect(err).To(MatchError(ContainSubstring("Throttling")))
+		// No change is falsely reported as succeeded, and none is isolated as the
+		// bad leaf: both are failed together for a later retry.
+		Expect(d1.succeeded).To(BeFalse())
+		Expect(d2.succeeded).To(BeFalse())
+		Expect(d1.failed).To(BeTrue())
+		Expect(d2.failed).To(BeTrue())
+		// The sub-batch is not split down to single changes once throttling hits:
+		// one whole-batch call plus one throttled sub-batch call, no leaf calls.
+		Expect(fake.changeCalls).To(HaveLen(2))
+	})
 })

--- a/pkg/controller/provider/aws/handler.go
+++ b/pkg/controller/provider/aws/handler.go
@@ -259,7 +259,7 @@ func (h *Handler) executeRequests(ctx context.Context, logger logger.LogContext,
 		logger.Infof("no changes in dryrun mode for AWS")
 		return nil
 	}
-	return exec.submitChanges(ctx, h.config.Metrics)
+	return exec.submitChanges(ctx)
 }
 
 func (h *Handler) MapTargets(_ string, targets []provider.Target) []provider.Target {
@@ -401,7 +401,7 @@ func (h *Handler) executeRecordSetChange(ctx context.Context, action route53type
 	if err := exec.addChange(ctx, action, &provider.ChangeRequest{Type: rs.Type}, dnsset); err != nil {
 		return err
 	}
-	return exec.submitChanges(ctx, h.config.Metrics)
+	return exec.submitChanges(ctx)
 }
 
 // ensure staticTokenRetriever implements github.com/aws/aws-sdk-go-v2/credentials/stscreds.IdentityTokenRetriever

--- a/pkg/dnsman2/dns/provider/handler/aws/execution.go
+++ b/pkg/dnsman2/dns/provider/handler/aws/execution.go
@@ -243,8 +243,12 @@ func (ex *execution) submitBisected(ctx context.Context, changes []*wrappedChang
 	mid := len(changes) / 2
 	s1, f1, err1 := ex.submitBisected(ctx, changes[:mid])
 	s2, f2, err2 := ex.submitBisected(ctx, changes[mid:])
-	succeeded = append(s1, s2...)
-	failed = append(f1, f2...)
+	// Build fresh slices: s1/f1 may alias the backing array of changes[:mid],
+	// so append(s1, s2...) could overwrite changes[mid] (and thus corrupt f2).
+	succeeded = append(succeeded, s1...)
+	succeeded = append(succeeded, s2...)
+	failed = append(failed, f1...)
+	failed = append(failed, f2...)
 	// Prefer a leaf (single-change) error so the message names a real cause.
 	err = err1
 	if err == nil {

--- a/pkg/dnsman2/dns/provider/handler/aws/execution.go
+++ b/pkg/dnsman2/dns/provider/handler/aws/execution.go
@@ -123,16 +123,29 @@ func (ex *execution) submitChanges(ctx context.Context, metrics provider.Metrics
 		_, err := ex.r53.ChangeResourceRecordSets(ctx, params)
 		if err != nil {
 			failedChanges = changes
+			handled := false
+			throttling := false
 			var apiError smithy.APIError
 			if errors.As(err, &apiError) {
 				switch v := apiError.(type) {
 				case *route53types.InvalidChangeBatch:
 					succeededChanges, failedChanges, err = ex.tryFixChanges(ctx, v.ErrorMessage(), changes)
+					handled = true // tryFixChanges already bisects its unclear remainder
 				default:
 					if v.ErrorCode() == "Throttling" {
+						throttling = true
 						throttlingErrCount++
 					}
 				}
+			}
+			// For non-throttling errors that were not already handled as an InvalidChangeBatch,
+			// bisect the batch so a single bad change does not fail its valid batch-mates.
+			// Throttling errors are left as a whole-batch failure to be retried later;
+			// bisecting them would not help and would only multiply the load.
+			if !handled && !throttling && len(failedChanges) > 1 {
+				var additionalSucceededChanges []*wrappedChange
+				additionalSucceededChanges, failedChanges, err = ex.submitBisected(ctx, failedChanges)
+				succeededChanges = append(succeededChanges, additionalSucceededChanges...)
 			}
 		} else {
 			succeededChanges = changes
@@ -193,18 +206,49 @@ outer:
 	}
 
 	if len(unclear) > 0 {
-		params := &route53.ChangeResourceRecordSetsInput{
-			HostedZoneId: aws.String(ex.zoneID.ID),
-			ChangeBatch: &route53types.ChangeBatch{
-				Changes: mapChanges(unclear),
-			},
+		s, f, ferr := ex.submitBisected(ctx, unclear)
+		succeeded = append(succeeded, s...)
+		failed = append(failed, f...)
+		if ferr != nil {
+			err = ferr
 		}
-		_, err = ex.r53.ChangeResourceRecordSets(ctx, params)
-		if err != nil {
-			failed = append(failed, unclear...)
-		} else {
-			succeeded = append(succeeded, unclear...)
-		}
+	}
+	return
+}
+
+// submitBisected submits the given changes as one batch. On rejection it splits
+// the batch in half and retries each half recursively, so a single bad change
+// only fails itself instead of its valid batch-mates. It returns the changes
+// that were successfully applied, the ones that could not be applied, and the
+// error from the smallest failing batch (nil if all changes succeeded).
+func (ex *execution) submitBisected(ctx context.Context, changes []*wrappedChange) (succeeded, failed []*wrappedChange, err error) {
+	if len(changes) == 0 {
+		return nil, nil, nil
+	}
+
+	params := &route53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String(ex.zoneID.ID),
+		ChangeBatch: &route53types.ChangeBatch{
+			Changes: mapChanges(changes),
+		},
+	}
+	ex.rateLimiter.Accept()
+	if _, callErr := ex.r53.ChangeResourceRecordSets(ctx, params); callErr == nil {
+		return changes, nil, nil
+	} else if len(changes) == 1 {
+		// A single change still fails: it is the bad one.
+		return nil, changes, callErr
+	}
+
+	mid := len(changes) / 2
+	s1, f1, err1 := ex.submitBisected(ctx, changes[:mid])
+	s2, f2, err2 := ex.submitBisected(ctx, changes[mid:])
+	succeeded = append(s1, s2...)
+	failed = append(f1, f2...)
+	// Prefer a leaf (single-change) error so the message names a real cause.
+	err = err1
+	if err == nil {
+		err = err2
 	}
 	return
 }

--- a/pkg/dnsman2/dns/provider/handler/aws/execution.go
+++ b/pkg/dnsman2/dns/provider/handler/aws/execution.go
@@ -124,18 +124,12 @@ func (ex *execution) submitChanges(ctx context.Context, metrics provider.Metrics
 		if err != nil {
 			failedChanges = changes
 			handled := false
-			throttling := false
+			throttling := isThrottlingError(err)
 			var apiError smithy.APIError
-			if errors.As(err, &apiError) {
-				switch v := apiError.(type) {
-				case *route53types.InvalidChangeBatch:
+			if !throttling && errors.As(err, &apiError) {
+				if v, ok := apiError.(*route53types.InvalidChangeBatch); ok {
 					succeededChanges, failedChanges, err = ex.tryFixChanges(ctx, v.ErrorMessage(), changes)
 					handled = true // tryFixChanges already bisects its unclear remainder
-				default:
-					if v.ErrorCode() == "Throttling" {
-						throttling = true
-						throttlingErrCount++
-					}
 				}
 			}
 			// For non-throttling errors that were not already handled as an InvalidChangeBatch,
@@ -146,6 +140,12 @@ func (ex *execution) submitChanges(ctx context.Context, metrics provider.Metrics
 				var additionalSucceededChanges []*wrappedChange
 				additionalSucceededChanges, failedChanges, err = ex.submitBisected(ctx, failedChanges)
 				succeededChanges = append(succeededChanges, additionalSucceededChanges...)
+			}
+			// Count the batch as throttled if the initial call throttled or if
+			// throttling surfaced later while bisecting (submitBisected/tryFixChanges
+			// propagate the throttling error instead of splitting further).
+			if len(failedChanges) > 0 && isThrottlingError(err) {
+				throttlingErrCount++
 			}
 		} else {
 			succeededChanges = changes
@@ -235,8 +235,14 @@ func (ex *execution) submitBisected(ctx context.Context, changes []*wrappedChang
 	ex.rateLimiter.Accept()
 	if _, callErr := ex.r53.ChangeResourceRecordSets(ctx, params); callErr == nil {
 		return changes, nil, nil
+	} else if isThrottlingError(callErr) {
+		// Throttling is not evidence that any change is bad. Stop bisecting:
+		// splitting further would only amplify load on an already-throttling
+		// API, and blaming a leaf would wrongly mark a valid change as failed.
+		// Fail the whole sub-batch so it is retried later as a unit.
+		return nil, changes, callErr
 	} else if len(changes) == 1 {
-		// A single change still fails: it is the bad one.
+		// A single change still fails with a non-throttling error: it is the bad one.
 		return nil, changes, callErr
 	}
 
@@ -279,6 +285,15 @@ func (ex *execution) isFetchedRecordSetEqual(ctx context.Context, change *wrappe
 		}
 	}
 	return true
+}
+
+// isThrottlingError reports whether err is a Route53 throttling error.
+func isThrottlingError(err error) bool {
+	var apiError smithy.APIError
+	if errors.As(err, &apiError) {
+		return apiError.ErrorCode() == "Throttling"
+	}
+	return false
 }
 
 func safeCompareInt64(a, b *int64) bool {

--- a/pkg/dnsman2/dns/provider/handler/aws/execution_test.go
+++ b/pkg/dnsman2/dns/provider/handler/aws/execution_test.go
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: Contributors to the Gardener project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package aws
+
+import (
+	"context"
+	"errors"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	route53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+	"github.com/aws/smithy-go"
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/util/flowcontrol"
+
+	"github.com/gardener/external-dns-management/pkg/dnsman2/dns"
+	dnserrors "github.com/gardener/external-dns-management/pkg/dnsman2/dns/provider/errors"
+)
+
+// upsertWrappedChange builds an A-record upsert change with the given name/value.
+func upsertWrappedChange(name, value string) *wrappedChange {
+	rrs := &route53types.ResourceRecordSet{
+		Name:            aws.String(name),
+		Type:            route53types.RRTypeA,
+		TTL:             aws.Int64(60),
+		ResourceRecords: []route53types.ResourceRecord{{Value: aws.String(value)}},
+	}
+	return &wrappedChange{
+		Change: &route53types.Change{Action: route53types.ChangeActionUpsert, ResourceRecordSet: rrs},
+	}
+}
+
+func newTestExecution(r53 route53API) *execution {
+	return &execution{
+		log:         logr.Discard(),
+		r53:         r53,
+		rateLimiter: flowcontrol.NewFakeAlwaysRateLimiter(),
+		zoneID:      dns.NewZoneID(ProviderType, "Z1"),
+		batchSize:   16,
+	}
+}
+
+var _ = Describe("execution submitChanges", func() {
+	var (
+		ctx     context.Context
+		metrics = noopMetrics{}
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	It("bisects a rejected batch so only the bad change fails", func() {
+		fake := &fakeRoute53{
+			changeResourceRecordsFn: func(_ context.Context, params *route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error) {
+				for _, c := range params.ChangeBatch.Changes {
+					for _, rr := range c.ResourceRecordSet.ResourceRecords {
+						if aws.ToString(rr.Value) == "bad" {
+							return nil, errors.New("server error")
+						}
+					}
+				}
+				return &route53.ChangeResourceRecordSetsOutput{}, nil
+			},
+		}
+		exec := newTestExecution(fake)
+		exec.changes = []*wrappedChange{
+			upsertWrappedChange("good.example.org.", "1.2.3.4"),
+			upsertWrappedChange("good2.example.org.", "1.2.3.4"),
+			upsertWrappedChange("bad.example.org.", "bad"),
+		}
+
+		err := exec.submitChanges(ctx, metrics)
+		Expect(err).To(MatchError(ContainSubstring("1 changes failed")))
+	})
+
+	It("does not bisect a fully valid multi-change batch", func() {
+		fake := &fakeRoute53{}
+		exec := newTestExecution(fake)
+		exec.changes = []*wrappedChange{
+			upsertWrappedChange("a.example.org.", "1.2.3.4"),
+			upsertWrappedChange("b.example.org.", "1.2.3.5"),
+		}
+
+		Expect(exec.submitChanges(ctx, metrics)).To(Succeed())
+		// One batch call, no splitting on the happy path.
+		Expect(fake.changeCalls).To(HaveLen(1))
+		Expect(fake.changeCalls[0].ChangeBatch.Changes).To(HaveLen(2))
+	})
+
+	It("does not bisect a throttled batch", func() {
+		fake := &fakeRoute53{
+			changeResourceRecordsFn: func(_ context.Context, _ *route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error) {
+				return nil, &smithy.GenericAPIError{Code: "Throttling", Message: "Rate exceeded"}
+			},
+		}
+		exec := newTestExecution(fake)
+		exec.changes = []*wrappedChange{
+			upsertWrappedChange("a.example.org.", "1.2.3.4"),
+			upsertWrappedChange("b.example.org.", "1.2.3.5"),
+		}
+
+		err := exec.submitChanges(ctx, metrics)
+		Expect(err).To(HaveOccurred())
+		// Every batch throttled, so the error is wrapped as a throttling error.
+		Expect(dnserrors.IsThrottlingError(err)).To(BeTrue())
+		// The batch is retried as a whole, not bisected: exactly one attempt.
+		Expect(fake.changeCalls).To(HaveLen(1))
+	})
+
+	It("stops bisecting and does not blame a leaf when throttling surfaces mid-bisection", func() {
+		// The first (whole-batch) call fails with a non-throttling error, which
+		// forces bisection. As soon as bisection issues its first sub-batch call,
+		// the API starts throttling. The bisection must then stop splitting and
+		// fail the whole sub-batch rather than isolating a valid change as "bad".
+		call := 0
+		fake := &fakeRoute53{
+			changeResourceRecordsFn: func(_ context.Context, _ *route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error) {
+				call++
+				if call == 1 {
+					return nil, errors.New("server error")
+				}
+				return nil, &smithy.GenericAPIError{Code: "Throttling", Message: "Rate exceeded"}
+			},
+		}
+		exec := newTestExecution(fake)
+		exec.changes = []*wrappedChange{
+			upsertWrappedChange("a.example.org.", "1.2.3.4"),
+			upsertWrappedChange("b.example.org.", "1.2.3.5"),
+		}
+
+		err := exec.submitChanges(ctx, metrics)
+		Expect(err).To(HaveOccurred())
+		// The batch's final error is a throttle, so it is classified as throttling.
+		Expect(dnserrors.IsThrottlingError(err)).To(BeTrue())
+		// The sub-batch is not split down to single changes once throttling hits:
+		// one whole-batch call plus one throttled sub-batch call, no leaf calls.
+		Expect(fake.changeCalls).To(HaveLen(2))
+	})
+})

--- a/pkg/dnsman2/dns/provider/handler/aws/handler_test.go
+++ b/pkg/dnsman2/dns/provider/handler/aws/handler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
 	route53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+	"github.com/aws/smithy-go"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -369,6 +370,80 @@ var _ = Describe("DNSHandler", func() {
 
 			err := h.ExecuteRequests(ctx, zone, reqs)
 			Expect(err).To(MatchError(ContainSubstring("changes failed")))
+		})
+
+		It("bisects a rejected batch so only the bad change fails", func() {
+			h = newTestHandler(fake)
+			// The batch contains two upserts (TypeA + TypeAAAA). The provider rejects any
+			// batch that still contains the bad IPv6 record; valid batches succeed. Bisection
+			// must isolate the bad change so the good one is applied.
+			fake.changeResourceRecordsFn = func(_ context.Context, params *route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error) {
+				for _, c := range params.ChangeBatch.Changes {
+					for _, rr := range c.ResourceRecordSet.ResourceRecords {
+						if aws.ToString(rr.Value) == "bad::1" {
+							return nil, errors.New("server error")
+						}
+					}
+				}
+				return &route53.ChangeResourceRecordSetsOutput{}, nil
+			}
+			reqs := provider.ChangeRequests{
+				Name: dns.DNSSetName{DNSName: "x.example.org"},
+				Updates: map[dns.RecordType]*provider.ChangeRequestUpdate{
+					dns.TypeA:    {New: dns.NewRecordSet(dns.TypeA, 60, []*dns.Record{{Value: "1.2.3.4"}})},
+					dns.TypeAAAA: {New: dns.NewRecordSet(dns.TypeAAAA, 60, []*dns.Record{{Value: "bad::1"}})},
+				},
+			}
+
+			err := h.ExecuteRequests(ctx, zone, reqs)
+			// Exactly one change (the bad AAAA) could not be applied.
+			Expect(err).To(MatchError(ContainSubstring("1 changes failed")))
+
+			// The good A record must have been applied in an isolated (size-1) batch.
+			appliedGoodA := false
+			for _, call := range fake.changeCalls {
+				changes := call.ChangeBatch.Changes
+				if len(changes) == 1 && changes[0].ResourceRecordSet.Type == route53types.RRTypeA {
+					appliedGoodA = true
+				}
+			}
+			Expect(appliedGoodA).To(BeTrue(), "expected the valid A record to be applied in its own batch")
+		})
+
+		It("does not bisect a fully valid multi-change batch", func() {
+			h = newTestHandler(fake)
+			reqs := provider.ChangeRequests{
+				Name: dns.DNSSetName{DNSName: "x.example.org"},
+				Updates: map[dns.RecordType]*provider.ChangeRequestUpdate{
+					dns.TypeA:    {New: dns.NewRecordSet(dns.TypeA, 60, []*dns.Record{{Value: "1.2.3.4"}})},
+					dns.TypeAAAA: {New: dns.NewRecordSet(dns.TypeAAAA, 60, []*dns.Record{{Value: "2001:db8::1"}})},
+				},
+			}
+
+			Expect(h.ExecuteRequests(ctx, zone, reqs)).To(Succeed())
+			// A single batch call, no splitting on the happy path.
+			Expect(fake.changeCalls).To(HaveLen(1))
+			Expect(fake.changeCalls[0].ChangeBatch.Changes).To(HaveLen(2))
+		})
+
+		It("does not bisect a throttled batch", func() {
+			h = newTestHandler(fake)
+			fake.changeResourceRecordsFn = func(_ context.Context, _ *route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error) {
+				return nil, &smithy.GenericAPIError{Code: "Throttling", Message: "Rate exceeded"}
+			}
+			reqs := provider.ChangeRequests{
+				Name: dns.DNSSetName{DNSName: "x.example.org"},
+				Updates: map[dns.RecordType]*provider.ChangeRequestUpdate{
+					dns.TypeA:    {New: dns.NewRecordSet(dns.TypeA, 60, []*dns.Record{{Value: "1.2.3.4"}})},
+					dns.TypeAAAA: {New: dns.NewRecordSet(dns.TypeAAAA, 60, []*dns.Record{{Value: "2001:db8::1"}})},
+				},
+			}
+
+			err := h.ExecuteRequests(ctx, zone, reqs)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring("Throttling")))
+			// The batch is retried as a whole, not bisected: exactly one attempt.
+			Expect(fake.changeCalls).To(HaveLen(1))
 		})
 	})
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Route53 ChangeBatch is atomic, so one bad change rejected the whole
batch and blocked all valid changes. On a non-throttling rejection,
recursively bisect the batch to apply valid changes and isolate only
the bad ones. tryFixChanges bisects its unclear remainder too.

Changes are applied to both legacy and next-generation controller.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Isolate failing changes in AWS Route53 batches via bisection
```
