### PR TITLE
Prevent deletion of stale/foreign DNS entry backend records

### DIFF
--- a/pkg/dns/provider/state_entry.go
+++ b/pkg/dns/provider/state_entry.go
@@ -101,7 +101,13 @@ func (this *state) addEntryVersion(logger logger.LogContext, v *EntryVersion, st
 	if v.IsDeleting() {
 		var err error
 		if old != nil {
-			this.cleanupEntry(logger, old, oldDNSSet)
+			// Only allow the backend record to be deleted via the zone transaction
+			// when a valid provider currently resolves the entry's zone. For a
+			// stale/foreign entry (no valid provider) the record must be preserved;
+			// scheduling a delete here would orphan it and get it removed on the
+			// next zone reconcile ("found unapplied managed set" -> DELETE).
+			zoneResolvable := new.valid && !new.activezone.IsEmpty() && this.zones[new.activezone] != nil
+			this.cleanupEntry(logger, old, oldDNSSet, zoneResolvable)
 		}
 		if new.valid {
 			if !new.activezone.IsEmpty() && this.zones[new.activezone] != nil {
@@ -146,7 +152,7 @@ func (this *state) addEntryVersion(logger logger.LogContext, v *EntryVersion, st
 	if old != nil && old != new {
 		// DNS name changed -> clean up old dns name
 		logger.Infof("dns name changed to %q", new.ZonedDNSName())
-		this.cleanupEntry(logger, old, oldDNSSet)
+		this.cleanupEntry(logger, old, oldDNSSet, true)
 		if !old.activezone.IsEmpty() && old.activezone != new.ZoneId() {
 			if this.zones[old.activezone] != nil {
 				logger.Infof("dns zone changed -> trigger old zone '%s'", old.ZoneId())
@@ -388,7 +394,7 @@ func (this *state) EntryDeleted(logger logger.LogContext, key resources.ClusterO
 		} else {
 			this.smartInfof(logger, "removing foreign entry %q (%s)", key.ObjectName(), old.ZonedDNSName())
 		}
-		this.cleanupEntry(logger, old, this.dnsSetFromEntry(old))
+		this.cleanupEntry(logger, old, this.dnsSetFromEntry(old), zone != nil)
 	} else {
 		logger.Debugf("removing unknown entry %q", key.ObjectName())
 	}
@@ -406,7 +412,21 @@ func (this *state) countEntriesForProvider(provider resources.ObjectName) int32 
 	return count
 }
 
-func (this *state) cleanupEntry(logger logger.LogContext, e *Entry, oldDNSSet *dns.DNSSet) {
+// cleanupInBackend reports whether the backend DNS record of an entry being
+// cleaned up may be deleted via the zone transaction.
+//
+// It must return false when:
+//   - the entry is obsolete, i.e. only handled by a fallback provider, or
+//   - no valid provider currently resolves a managed zone for the entry
+//     (zoneResolvable == false). This is the stale/foreign case: the record is
+//     preserved elsewhere (see the stale handling in addEntriesForZone and
+//     ChangeGroup.cleanup), so scheduling a delete here would orphan and
+//     eventually remove a record that must be kept.
+func cleanupInBackend(obsolete, zoneResolvable bool) bool {
+	return !obsolete && zoneResolvable
+}
+
+func (this *state) cleanupEntry(logger logger.LogContext, e *Entry, oldDNSSet *dns.DNSSet, zoneResolvable bool) {
 	this.smartInfof(logger, "cleanup old entry (duplicate=%t)", e.duplicate)
 	this.entries.Delete(e)
 	this.DeleteLookupJob(e.ObjectName())
@@ -432,7 +452,7 @@ func (this *state) cleanupEntry(logger logger.LogContext, e *Entry, oldDNSSet *d
 			}
 		}
 		if txn := this.getActiveZoneTransaction(e.activezone); txn != nil {
-			if !e.obsolete {
+			if cleanupInBackend(e.obsolete, zoneResolvable) {
 				txn.AddEntryChange(e.ObjectKey(), e.object.GetGeneration(), oldDNSSet, nil)
 			} else {
 				logger.Warnf("cannot cleanup stale entry %s(%s)", e.ObjectName(), e.DNSSetName())

--- a/pkg/dns/provider/state_entry_test.go
+++ b/pkg/dns/provider/state_entry_test.go
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: Contributors to the Gardener project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package provider
+
+import (
+	g "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/external-dns-management/pkg/dns"
+	"github.com/gardener/external-dns-management/pkg/dns/provider/zonetxn"
+)
+
+var _ = g.Describe("cleanupEntry backend deletion guard", func() {
+	// Regression test for foreign/stale DNS entries being deleted ~15 minutes
+	// after the DNSEntry object is removed:
+	//
+	// When EntryDeleted runs while no valid provider currently resolves a zone
+	// for the entry ("removing foreign entry"), cleanupEntry must NOT schedule a
+	// backend delete into the zone transaction. Otherwise the record - which is
+	// otherwise preserved as stale - gets orphaned and deleted on the next zone
+	// reconcile ("found unapplied managed set" -> DELETE).
+
+	g.Describe("cleanupInBackend", func() {
+		g.It("deletes only when the entry is managed and a zone is currently resolvable", func() {
+			Expect(cleanupInBackend(false, true)).To(BeTrue(), "managed entry with resolvable zone -> delete")
+
+			// the regression: provider temporarily invalid, no zone resolvable
+			Expect(cleanupInBackend(false, false)).To(BeFalse(), "no resolvable zone -> preserve (foreign/stale)")
+
+			// obsolete = handled only by a fallback provider
+			Expect(cleanupInBackend(true, true)).To(BeFalse(), "obsolete entry -> preserve")
+			Expect(cleanupInBackend(true, false)).To(BeFalse(), "obsolete entry -> preserve")
+		})
+	})
+
+	g.Describe("effect on the pending zone transaction", func() {
+		var (
+			zoneID  dns.ZoneID
+			setName dns.DNSSetName
+			key     client.ObjectKey
+			oldSet  *dns.DNSSet
+		)
+
+		g.BeforeEach(func() {
+			zoneID = dns.NewZoneID("aws-route53", "Z02026782CY0WR1NYZD7R")
+			setName = dns.DNSSetName{DNSName: "test-dns.example.com"}
+			key = client.ObjectKey{Namespace: "ns", Name: "smoke-test-dns-entry"}
+			oldSet = dns.NewDNSSet(setName, nil)
+			oldSet.SetRecordSet(dns.RS_CNAME, 300, "2026-09-01-13-09-28UTC.build23878441")
+		})
+
+		// applyCleanup mirrors the decision cleanupEntry makes for the active
+		// zone transaction (see state_entry.go): only when cleanupInBackend
+		// allows it, the old record set is queued for deletion (old -> nil).
+		applyCleanup := func(obsolete, zoneResolvable bool) *zonetxn.PendingTransaction {
+			txn := zonetxn.NewZoneTransaction(zoneID)
+			if cleanupInBackend(obsolete, zoneResolvable) {
+				txn.AddEntryChange(key, 1, oldSet, nil)
+			}
+			return txn
+		}
+
+		g.It("queues the record for deletion when a zone is resolvable", func() {
+			txn := applyCleanup(false, true)
+			Expect(txn.OldDNSSets()).To(HaveKey(setName))
+		})
+
+		g.It("does NOT queue the record for deletion for a foreign/stale entry (no resolvable zone)", func() {
+			txn := applyCleanup(false, false)
+			Expect(txn.OldDNSSets()).To(BeEmpty())
+		})
+
+		g.It("does NOT queue the record for deletion for an obsolete entry", func() {
+			txn := applyCleanup(true, true)
+			Expect(txn.OldDNSSets()).To(BeEmpty())
+		})
+	})
+})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
When a DNSEntry is deleted while no valid provider currently resolves its zone (stale/foreign case, e.g. the provider is temporarily invalid), cleanupEntry previously scheduled a backend DELETE into the pending zone transaction. The record - otherwise preserved as stale - was then orphaned and removed on the next zone reconcile ("found unapplied managed set" -> DELETE), ~15 min after the object disappeared.

Gate the backend DELETE in cleanupEntry on a new zoneResolvable flag via cleanupInBackend(obsolete, zoneResolvable): only delete when the entry is not obsolete and a valid provider currently resolves a managed zone for it. The deleting and dns-name-changed branches in addEntryVersion pass the computed / true value; EntryDeleted passes zone != nil.

Add a unit test covering the cleanupInBackend decision matrix and its effect on the pending zone transaction.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Could reproduce the bug manually, but an integration test case is complicated/masked by the different behaviour of the local in-memory provider on reenabling the provider.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Prevent deletion of stale/foreign DNS entry backend records
```
