### PR TITLE
Keep track of fqdn and setIdentifier on GDCA

### DIFF
--- a/pkg/controller/provider/gdc/client/dns/const.go
+++ b/pkg/controller/provider/gdc/client/dns/const.go
@@ -7,4 +7,10 @@ package dns
 const (
 	// DNSDefaultTTL is the default TTL for DNS records in seconds.
 	DNSDefaultTTL = 300 // 300 seconds
+
+	// DNSAnnotationKey used to preserve the original FQDN without prefix and replacements.
+	OriginalFQDNAnnotationKey = "OriginalFQDN"
+
+	// SetIdentifierKey used to preserve the identifier when handling records.
+	SetIdentifierKey = "SetIdentifier"
 )

--- a/pkg/controller/provider/gdc/execution.go
+++ b/pkg/controller/provider/gdc/execution.go
@@ -20,10 +20,13 @@ import (
 )
 
 type Change struct {
-	RecordSet      *resourceRecordSet
-	RecordType     string // supported record type: A, TXT
-	ChangeType     string // supported change type: create, update, delete
-	ObjectMetaName string // ResourceRecordSet Name
+	RecordSet           *resourceRecordSet
+	RecordType          string // supported record type: A, TXT
+	DnsZone             string // Name of the DNS zone the record will be in
+	ChangeType          string // supported change type: create, update, delete
+	ObjectMetaName      string // ResourceRecordSet Name
+	ObjectMetaNamespace string // ResourceRecordSet Namespace
+	SetIdentifier       string // (Optional) Identifier for the RecordSet
 }
 
 type Execution struct {
@@ -61,11 +64,48 @@ func (exec *Execution) prepareChange(req *provider.ChangeRequest) (*Change, erro
 
 	rrSet := mapRecordSet(dnsset.Name.DNSName, newSet)
 	return &Change{
-		RecordSet:      rrSet,
-		RecordType:     newSet.Type,
-		ChangeType:     req.Action,
-		ObjectMetaName: objectMetaName,
+		RecordSet:           rrSet,
+		RecordType:          newSet.Type,
+		DnsZone:             exec.zone.Key(),
+		ChangeType:          req.Action,
+		ObjectMetaName:      objectMetaName,
+		ObjectMetaNamespace: exec.handler.project,
+		SetIdentifier:       dnsset.Name.SetIdentifier,
 	}, nil
+}
+
+func resourceRecordSetForChange(change *Change) *globalnetworkingv1.ResourceRecordSet {
+	recordSet := &globalnetworkingv1.ResourceRecordSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      change.ObjectMetaName,
+			Namespace: change.ObjectMetaNamespace,
+			Annotations: map[string]string{
+				// We need to make sure to preserve the original FQDN (before changes due to
+				// k8s-object-name limitations) since this will be used at a later point to match
+				// records retrieved from a hosted zone with records known to a running instance
+				// of the controller in the seed
+				dnsutil.OriginalFQDNAnnotationKey: change.RecordSet.fqdn,
+			},
+		},
+	}
+	if change.SetIdentifier != "" {
+		// Similar to above, the set identifier (if it exists) is used when matching records
+		// retrieved from the infra to those known to the controller in the case of
+		// routing policies.
+		recordSet.Annotations[dnsutil.SetIdentifierKey] = change.SetIdentifier
+	}
+	if change.ChangeType == provider.R_CREATE || change.ChangeType == provider.R_UPDATE {
+		ttl := uint32(change.RecordSet.ttl) // #nosec G115 -- TTL is safe bounded integer
+		recordSet.Spec = globalnetworkingv1.ResourceRecordSetSpec{
+			Name:       change.RecordSet.fqdn,
+			TTLSeconds: &ttl,
+			Type:       change.RecordType,
+			RRData:     change.RecordSet.data,
+			DNSZone:    change.DnsZone,
+		}
+	}
+
+	return recordSet
 }
 
 func (exec *Execution) applyChange(change *Change) error {
@@ -77,23 +117,10 @@ func (exec *Execution) applyChange(change *Change) error {
 	exec.handler.config.Metrics.AddZoneRequests(exec.zone.Id().ID, provider.M_UPDATERECORDS, 1)
 	exec.handler.config.RateLimiter.Accept()
 
-	ttl := uint32(change.RecordSet.ttl) // #nosec G115 -- TTL is safe bounded integer
-	recordSet := &globalnetworkingv1.ResourceRecordSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      change.ObjectMetaName,
-			Namespace: exec.handler.project,
-		},
-	}
+	recordSet := resourceRecordSetForChange(change)
 
 	if change.ChangeType == provider.R_CREATE || change.ChangeType == provider.R_UPDATE {
 		_, err := controllerutil.CreateOrUpdate(context.Background(), exec.handler.client, recordSet, func() error {
-			recordSet.Spec = globalnetworkingv1.ResourceRecordSetSpec{
-				Name:       change.RecordSet.fqdn,
-				TTLSeconds: &ttl,
-				Type:       change.RecordType,
-				RRData:     change.RecordSet.data,
-				DNSZone:    exec.zone.Key(),
-			}
 			return nil
 		})
 		if err != nil {

--- a/pkg/controller/provider/gdc/execution.go
+++ b/pkg/controller/provider/gdc/execution.go
@@ -118,9 +118,16 @@ func (exec *Execution) applyChange(change *Change) error {
 	exec.handler.config.RateLimiter.Accept()
 
 	recordSet := resourceRecordSetForChange(change)
-
+	ttl := uint32(change.RecordSet.ttl) // #nosec G115 -- TTL is safe bounded integer
 	if change.ChangeType == provider.R_CREATE || change.ChangeType == provider.R_UPDATE {
 		_, err := controllerutil.CreateOrUpdate(context.Background(), exec.handler.client, recordSet, func() error {
+			recordSet.Spec = globalnetworkingv1.ResourceRecordSetSpec{
+				Name:       change.RecordSet.fqdn,
+				TTLSeconds: &ttl,
+				Type:       change.RecordType,
+				RRData:     change.RecordSet.data,
+				DNSZone:    change.DnsZone,
+			}
 			return nil
 		})
 		if err != nil {

--- a/pkg/controller/provider/gdc/execution_test.go
+++ b/pkg/controller/provider/gdc/execution_test.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	dnsutil "github.com/gardener/external-dns-management/pkg/controller/provider/gdc/client/dns"
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
 )
 
@@ -39,10 +40,11 @@ func TestApplyChange(t *testing.T) {
 		},
 	}
 
+	hostedZone := provider.NewDNSHostedZone("GDC", "test-zone-id", "test.com", "test-zone-key", true)
 	exec := &Execution{
 		LogContext: logger.NewContext("test", "applyChange"),
 		handler:    handler,
-		zone:       provider.NewDNSHostedZone("GDC", "test-zone-id", "test.com", "test-zone-key", true),
+		zone:       hostedZone,
 	}
 
 	tests := []struct {
@@ -58,12 +60,19 @@ func TestApplyChange(t *testing.T) {
 					ttl:  300,
 					data: []string{"1.2.3.4"},
 				},
-				RecordType:     "A",
-				ChangeType:     provider.R_CREATE,
-				ObjectMetaName: "a-test.example.com",
+				DnsZone:             hostedZone.Key(),
+				RecordType:          "A",
+				ChangeType:          provider.R_CREATE,
+				ObjectMetaName:      "a-test.example.com",
+				ObjectMetaNamespace: "test-project",
 			},
 			wantRRS: &globalnetworkingv1.ResourceRecordSet{
-				ObjectMeta: metav1.ObjectMeta{Name: "a-test.example.com", Namespace: "test-project", ResourceVersion: "1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a-test.example.com", Namespace: "test-project", ResourceVersion: "1",
+					Annotations: map[string]string{
+						dnsutil.OriginalFQDNAnnotationKey: "test.example.com",
+					},
+				},
 				Spec: globalnetworkingv1.ResourceRecordSetSpec{
 					Name:       "test.example.com",
 					TTLSeconds: &ttl,
@@ -81,12 +90,19 @@ func TestApplyChange(t *testing.T) {
 					ttl:  300,
 					data: []string{"5.6.7.8"},
 				},
-				RecordType:     "A",
-				ChangeType:     provider.R_UPDATE,
-				ObjectMetaName: "a-test.example.com",
+				DnsZone:             hostedZone.Key(),
+				RecordType:          "A",
+				ChangeType:          provider.R_UPDATE,
+				ObjectMetaName:      "a-test.example.com",
+				ObjectMetaNamespace: "test-project",
 			},
 			wantRRS: &globalnetworkingv1.ResourceRecordSet{
-				ObjectMeta: metav1.ObjectMeta{Name: "a-test.example.com", Namespace: "test-project", ResourceVersion: "2"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a-test.example.com", Namespace: "test-project", ResourceVersion: "2",
+					Annotations: map[string]string{
+						dnsutil.OriginalFQDNAnnotationKey: "test.example.com",
+					},
+				},
 				Spec: globalnetworkingv1.ResourceRecordSetSpec{
 					Name:       "test.example.com",
 					TTLSeconds: &ttl,

--- a/pkg/controller/provider/gdc/handler.go
+++ b/pkg/controller/provider/gdc/handler.go
@@ -155,8 +155,23 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, _ provider.ZoneCache
 					Value: value,
 				})
 			}
-			logger.Infof("DNS Name: %v, Records of type %s: %s", rrSet.Spec.Name, recordType, spec.RRData)
-			dnssets.AddRecordSetFromProvider(rrSet.Spec.Name, dns.NewRecordSet(recordType, int64(ttl), records))
+
+			dnsSetName := dns.DNSSetName{}
+			// when creating the rrSet from the retrieved hosted zone, we need to make sure that the generated
+			// record sets can match with those created from the existing k8s resources. The required information
+			// is added to the ResourceRecordSet via annotations
+			if unmodifiedFqdn, ok := rrSet.Annotations[dnsconst.OriginalFQDNAnnotationKey]; ok {
+				dnsSetName.DNSName = unmodifiedFqdn
+				if setIdentifier, ok := rrSet.Annotations[dnsconst.SetIdentifierKey]; ok {
+					dnsSetName.SetIdentifier = setIdentifier
+				}
+			} else {
+				// legacy behaviour
+				dnsSetName.DNSName = rrSet.Spec.Name
+			}
+
+			logger.Infof("DNS Name: %v, Records of type %s: %s", dnsSetName, recordType, spec.RRData)
+			dnssets.AddRecordSetFromProviderEx(dnsSetName, nil, dns.NewRecordSet(recordType, int64(ttl), records))
 		}
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
During execution, the controller periodically loops over hosted zones on GDC-ag and reconciles the entries it finds with the ones that are supposed to exist. Due to the way the records are created, there are two kinds of dns-records where the controller is unable to match the existing records to the ones it's supposed to manage:

- wildcard-records: Records on GDC-ag are managed as kubernetes objects (ResourceRecordSets). As such, their names are required to follow the naming restrictions for kubernetes objects. To get around this the record name is translated by a function, however matching records found on GDC-ag with ones managed internally later on fails as it is assumed the k8s-object's name matches the record's name. As the translation function is not bijective, this can not be resolved by simply doing the inverse of the changes.
- records with setIdentifier: The set identifier of records is not preserved when creating ResourceRecordSets. As the identifier is used for matching internally, these records cannot be matched again later.

This results in a repeating pattern for the affected records that repeats every 15 minutes, e.g.:

```
level=info msg="controllers: compound: dns: 0: cmd:hostedzone:foo:bar/baz: gdch-dns: no existing entry found for <some-url>#test"
level=info msg="controllers: compound: dns: 0: cmd:hostedzone:foo:bar/baz: gdch-dns: create A record set <some-url>[gdch-dns/bar/baz]: [1.2.3.4](600)"
[...] # 15 minutes later
level=info msg="controllers: compound: dns: 0: cmd:hostedzone:foo:bar/baz: gdch-dns: no existing entry found for <some-url>#test"
level=info msg="controllers: compound: dns: 0: cmd:hostedzone:foo:bar/baz: gdch-dns: create A record set <some-url>[gdch-dns/bar/baz]: [1.2.3.4](600)"
```

In addition, affected records will not be cleaned up when the owning shoot is deleted and will be left in the infrastructure for a human to clean up.

This PR fixes these issues by adding the required information to the created k8s RRSet objects as annotations and then later using that information (if present) to reconstruct the original FQDN and set identifier.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
As routing policies seem to be not supported on GDC-ag, and they seem to be very closely related to set identifiers, I'm not sure if there isn't a better way to do that part (e.g. disable set identifiers/routing policies as a whole when running on GDC-ag).

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
fix a bug that results in leftover DNS records on GDCA if wildcard-records or records with set identifiers are created
```
