### PR TITLE
Preserve setIdentifiers on gdc-ag

### DIFF
--- a/pkg/controller/provider/gdc/client/constants/constants.go
+++ b/pkg/controller/provider/gdc/client/constants/constants.go
@@ -10,4 +10,6 @@ const (
 
 	// GDCHConfigJSONField is the field in a secret where the GDCH configuration is stored at.
 	GDCHConfigJSONField = "gdch-config"
+
+	SetIdentifierAnnotationKey = "setIdentifier"
 )

--- a/pkg/controller/provider/gdc/execution.go
+++ b/pkg/controller/provider/gdc/execution.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/gardener/external-dns-management/pkg/controller/provider/gdc/client/constants"
 	dnsutil "github.com/gardener/external-dns-management/pkg/controller/provider/gdc/client/dns"
 	"github.com/gardener/external-dns-management/pkg/dns"
 	"github.com/gardener/external-dns-management/pkg/dns/provider"
@@ -24,6 +25,7 @@ type Change struct {
 	RecordType     string // supported record type: A, TXT
 	ChangeType     string // supported change type: create, update, delete
 	ObjectMetaName string // ResourceRecordSet Name
+	SetIdentifier  string // Set identifier of the record
 }
 
 type Execution struct {
@@ -65,6 +67,7 @@ func (exec *Execution) prepareChange(req *provider.ChangeRequest) (*Change, erro
 		RecordType:     newSet.Type,
 		ChangeType:     req.Action,
 		ObjectMetaName: objectMetaName,
+		SetIdentifier:  dnsset.Name.SetIdentifier,
 	}, nil
 }
 
@@ -83,6 +86,12 @@ func (exec *Execution) applyChange(change *Change) error {
 			Name:      change.ObjectMetaName,
 			Namespace: exec.handler.project,
 		},
+	}
+
+	if change.SetIdentifier != "" {
+		recordSet.Annotations = map[string]string{
+			constants.SetIdentifierAnnotationKey: change.SetIdentifier,
+		}
 	}
 
 	if change.ChangeType == provider.R_CREATE || change.ChangeType == provider.R_UPDATE {

--- a/pkg/controller/provider/gdc/handler.go
+++ b/pkg/controller/provider/gdc/handler.go
@@ -155,8 +155,14 @@ func (h *Handler) getZoneState(zone provider.DNSHostedZone, _ provider.ZoneCache
 					Value: value,
 				})
 			}
-			logger.Infof("DNS Name: %v, Records of type %s: %s", rrSet.Spec.Name, recordType, spec.RRData)
-			dnssets.AddRecordSetFromProvider(rrSet.Spec.Name, dns.NewRecordSet(recordType, int64(ttl), records))
+
+			dnsSetName := dns.DNSSetName{DNSName: rrSet.Spec.Name}
+			if setIdentifier, ok := rrSet.Annotations[constants.SetIdentifierAnnotationKey]; ok {
+				dnsSetName.SetIdentifier = setIdentifier
+			}
+
+			logger.Infof("DNS Name: %v, Records of type %s: %s", dnsSetName, recordType, spec.RRData)
+			dnssets.AddRecordSetFromProviderEx(dnsSetName, nil, dns.NewRecordSet(recordType, int64(ttl), records))
 		}
 	}
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select a kind for this pull request. This helps the community categorizing it.
Replace the below TODO or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the command multiple times, e.g.
  /kind api-change
  /kind cleanup
  ...

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
With this change, set Identifiers (most often used with routing policies) are preserved by putting them as annotations to the k8s-objects in the infrastructure. This allows matching the existing records to managed internal ones.

Without this, we've seen records being senselessly recreated periodically, and orphaned records once shoots are deleted.

**Special notes for your reviewer**:
Since routing policies don't seem to be supported on GDC-ag, we might think about disabling them (similar to Azure).
This would affect all current users, however. Also, I think set identifiers themselves are strictly speaking separate from routing policies, but I'm not entirely sure I understand everything around that topic yet.

For the time being, this should avoid unnecessary creation calls and prevent orphaned records.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
[provider GDC-ag] Keep track of setIdentifiers for records on GDC-ag to avoid periodically recreating them or orphaning records
```
